### PR TITLE
Feature/auto charmhub publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,33 +25,7 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
-  # This job is needed until the OCI image is published to ROCKS.
-  build-oci-image:
-    name: Build OCI image for integration tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          repository: "canonical/mysql-container"
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Build Image and Export
-        uses: docker/build-push-action@v2
-        with:
-          context: ./
-          file: ./Dockerfile
-          builder: ${{ steps.buildx.outputs.name }}
-          # Do not publish the image.
-          push: false
-          # Set the tag to retrieve the image in Deploy tests.
-          tags: mysql-dp:8.0
-          outputs: type=docker,dest=/tmp/image.tar
-      - name: Upload image to be used in integration tests
-        uses: actions/upload-artifact@v2
-        with:
-          name: image
-          path: /tmp/image.tar
+
   integration-test-microk8s:
     name: Integration tests (microk8s)
     needs: build-oci-image
@@ -63,16 +37,5 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          # workaround for https://github.com/charmed-kubernetes/actions-operator/issues/37
-          channel: 1.23/stable
-      # These two steps (download and load image) are needed until the OCI image is published to ROCKS.
-      - name: Download image built in build oci image step
-        uses: actions/download-artifact@v2
-        with:
-          name: image
-          path: /tmp
-      - name: Load Image into microk8s
-        run: |
-          /usr/bin/sg microk8s -c "microk8s ctr image import /tmp/image.tar"
       - name: Run integration tests
         run: tox -e integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,6 @@ jobs:
 
   integration-test-microk8s:
     name: Integration tests (microk8s)
-    needs: build-oci-image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,79 @@
+name: Release to latest/edge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@1.0.3
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Run tests
+        run: tox -e unit
+
+  integration-test:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+      - name: Run integration tests
+        run: tox -e integration
+
+  release-to-charmhub:
+    name: Release to CharmHub
+    needs:
+      - lib-check
+      - lint
+      - unit-test
+      - integration-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Select charmhub channel
+        uses: canonical/charming-actions/channel@1.0.3
+        id: channel
+      - name: Upload charm to charmhub
+        uses: canonical/charming-actions/upload-charm@1.0.3
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: "${{ steps.channel.outputs.name }}"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: mysql-dp:8.0
+    upstream-source: dataplatformoci/mysql-and-shell:latest
 peers:
   database-peers:
     interface: mysql-peers
@@ -34,3 +34,6 @@ storage:
   database:
     type: filesystem
     description: Persistent storage for MySQL data
+assumes:
+  - k8s-api
+

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: mysql-k8s


### PR DESCRIPTION
# Issue

Auto publish to charmhub. Temporarily using image from [this dockerhub registry](https://hub.docker.com/r/dataplatformoci/mysql-and-shell)

# Release Notes

- `.github/workflows/ci.yaml` - remove OCI build step
- `.github/workflows/release.yaml` - Add release to edge
- `metadata.yaml` - changes image source
