### PR TITLE
Enable nodes with IPV6 addresses in the group replication 

### DIFF
--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -216,6 +216,7 @@ class MySQL(MySQLBase):
         commands = (
             "INSTALL PLUGIN group_replication SONAME 'group_replication.so'",
             f"SET PERSIST group_replication_local_address='{self.instance_address}:33061'",
+            "SET PERSIST group_replication_ip_allowlist='AUTOMATIC'",
         )
 
         self._run_mysqlcli_script(

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -154,7 +154,7 @@ class MySQL(MySQLBase):
             self.wait_until_mysql_connection()
 
             # set global variables to enable group replication in k8s
-            self._install_group_replication_plugin()
+            self._set_group_replication_initial_variables()
         except (
             MySQLClientError,
             MySQLServiceNotRunningError,
@@ -207,16 +207,19 @@ class MySQL(MySQLBase):
             logger.exception("Error configuring MySQL users", exc_info=e)
             raise MySQLConfigureMySQLUsersError(e.message)
 
-    def _install_group_replication_plugin(self) -> None:
-        """Install the group replication plugin.
+    def _set_group_replication_initial_variables(self) -> None:
+        """Install the group replication plugin and set initial variables.
 
         Necessary for k8s deployments.
         Raises MySQLClientError if the script gets a non-zero return code.
         """
-        commands = ("INSTALL PLUGIN group_replication SONAME 'group_replication.so';",)
+        commands = (
+            "INSTALL PLUGIN group_replication SONAME 'group_replication.so'",
+            f"SET PERSIST group_replication_local_address='{self.instance_address}:33061'",
+        )
 
         self._run_mysqlcli_script(
-            " ".join(commands), self.cluster_admin_password, self.cluster_admin_user
+            "; ".join(commands), self.cluster_admin_password, self.cluster_admin_user
         )
 
     def create_custom_config_file(self, report_host: str) -> None:

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -216,7 +216,7 @@ class MySQL(MySQLBase):
         commands = (
             "INSTALL PLUGIN group_replication SONAME 'group_replication.so'",
             f"SET PERSIST group_replication_local_address='{self.instance_address}:33061'",
-            "SET PERSIST group_replication_ip_allowlist='AUTOMATIC'",
+            "SET PERSIST group_replication_ip_allowlist='0.0.0.0/0,::/0'",
         )
 
         self._run_mysqlcli_script(

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -213,9 +213,7 @@ class MySQL(MySQLBase):
         Necessary for k8s deployments.
         Raises MySQLClientError if the script gets a non-zero return code.
         """
-        commands = (
-            "INSTALL PLUGIN group_replication SONAME 'group_replication.so';",
-        )
+        commands = ("INSTALL PLUGIN group_replication SONAME 'group_replication.so';",)
 
         self._run_mysqlcli_script(
             " ".join(commands), self.cluster_admin_password, self.cluster_admin_user

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -154,7 +154,7 @@ class MySQL(MySQLBase):
             self.wait_until_mysql_connection()
 
             # set global variables to enable group replication in k8s
-            self._set_group_replication_initial_variables()
+            self._install_group_replication_plugin()
         except (
             MySQLClientError,
             MySQLServiceNotRunningError,
@@ -207,16 +207,14 @@ class MySQL(MySQLBase):
             logger.exception("Error configuring MySQL users", exc_info=e)
             raise MySQLConfigureMySQLUsersError(e.message)
 
-    def _set_group_replication_initial_variables(self) -> None:
-        """Set group replication initial variables.
+    def _install_group_replication_plugin(self) -> None:
+        """Install the group replication plugin.
 
         Necessary for k8s deployments.
-        Raises ExecError if the script gets a non-zero return code.
+        Raises MySQLClientError if the script gets a non-zero return code.
         """
         commands = (
             "INSTALL PLUGIN group_replication SONAME 'group_replication.so';",
-            f"SET PERSIST group_replication_local_address='{self.instance_address}:33061';",
-            "SET PERSIST group_replication_ip_allowlist='0.0.0.0/0';",
         )
 
         self._run_mysqlcli_script(


### PR DESCRIPTION
# Issue
We are running into this [issue/error trace](https://github.com/canonical/mysql-k8s-operator/runs/7434800404?check_suite_focus=true#step:4:6640) when running integration tests on github actions.

[Further research](https://dev.mysql.com/doc/refman/8.0/en/group-replication-options.html#sysvar_group_replication_ip_allowlist) shows that connections in the group may be refused if the protocol is different that the one in the `group_replication_ip_allowlist`. Since we are setting an ipv4 cidr (`0.0.0.0/0`), connections from ipv6 addresses are being refused.

# Solution
Set the `group_replication_ip_allowlist` as `0.0.0.0/0,::/0` to allow any ipv4 or ipv6 address.

# Release Notes
Enable nodes with IPV6 addresses in the group replication 
