### PR TITLE
Pin integration test microk8s environment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,9 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
+          # workaround for https://github.com/charmed-kubernetes/actions-operator/issues/37
+          channel: 1.23/stable
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration tests
         run: tox -e integration
 


### PR DESCRIPTION
# Issue
Integration tests in release to charmhub CI are [failing](https://github.com/canonical/mysql-k8s-operator/runs/7454554979?check_suite_focus=true). The same integration tests are passing in the normal CI job. The only difference I can find is the microk8s and juju versions.

# Solution
Pin the microk8s version to 1.23 and juju version to 2.9.29 (the same as the other CI job)

# Release Notes
Pin integration test microk8s environment
