### PR TITLE
Pin flake8 version for linting to temporarily resolve lint errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1 # Pin version until https://github.com/csachs/pyproject-flake8/pull/14 is merged
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
# Issue
<!-- What issue is this PR trying to solve? -->
There is a known [issue](https://github.com/PyCQA/flake8/issues/1635) where pflake8 monkey patches flake8 which is now allowed. Due to this, linting check error out.

# Solution
<!-- A summary of the solution addressing the above issue -->
Pin flake8 to version `4.0.1` until the [following PR](https://github.com/csachs/pyproject-flake8/pull/14) resolving the issue is merged.
