### PR TITLE
Add mysqlrouter extra user roles for the database relation interface

### DIFF
--- a/src/relations/database.py
+++ b/src/relations/database.py
@@ -16,6 +16,8 @@ from charms.mysql.v0.mysql import (
     MySQLDeleteUserForRelationError,
     MySQLGetClusterMembersAddressesError,
     MySQLGetMySQLVersionError,
+    MySQLGrantPrivilegesToUserError,
+    MySQLUpgradeUserForMySQLRouterError,
 )
 from ops.charm import RelationDepartedEvent
 from ops.framework import Object
@@ -70,6 +72,9 @@ class DatabaseRelation(Object):
         # get base relation data
         relation_id = event.relation.id
         db_name = event.database
+        extra_user_roles = []
+        if event.extra_user_roles:
+            extra_user_roles = event.extra_user_roles.split(",")
         # user name is derived from the relation id
         db_user = f"relation-{relation_id}"
         db_pass = self._get_or_set_password(event.relation)
@@ -98,19 +103,23 @@ class DatabaseRelation(Object):
                 db_name, db_user, db_pass, "%", remote_app
             )
 
+            if "mysqlrouter" in extra_user_roles:
+                self.charm._mysql.upgrade_user_for_mysqlrouter(db_user, "%")
+                self.charm._mysql.grant_privileges_to_user(
+                    db_user, "%", ["CREATE USER"], with_grant_option=True
+                )
+
             logger.info(f"Created user for app {remote_app}")
-        except MySQLCreateApplicationDatabaseAndScopedUserError:
-            logger.error(f"Failed to create scoped user for app {remote_app}")
+        except (
+            MySQLCreateApplicationDatabaseAndScopedUserError,
+            MySQLGetMySQLVersionError,
+            MySQLGetClusterMembersAddressesError,
+            MySQLClientError,
+            MySQLUpgradeUserForMySQLRouterError,
+            MySQLGrantPrivilegesToUserError,
+        ) as e:
+            logger.exception("Failed to set up database relation", exc_info=e)
             self.charm.unit.status = BlockedStatus("Failed to create scoped user")
-        except MySQLGetMySQLVersionError as e:
-            logger.exception("Failed to get MySQL version", exc_info=e)
-            self.charm.unit.status = BlockedStatus("Failed to get MySQL version")
-        except MySQLGetClusterMembersAddressesError as e:
-            logger.exception("Failed to get cluster members", exc_info=e)
-            self.charm.unit.status = BlockedStatus("Failed to get cluster members")
-        except MySQLClientError as e:
-            logger.exception("Failed to get primary", exc_info=e)
-            self.charm.unit.status = BlockedStatus("Failed to get primary")
 
     def _on_database_broken(self, event: RelationDepartedEvent) -> None:
         """Handle the removal of database relation.

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -119,6 +119,7 @@ async def test_password_rotation(ops_test: OpsTest):
     assert updated_credentials["password"] == new_password
 
     # verify that the new password actually works
+    # since get_primary_unit (and this get_cluster_status) use the cluster admin credentials
     primary_unit = await get_primary_unit(ops_test, random_unit, DATABASE_APP_NAME)
     primary_unit_address = await primary_unit.get_public_address()
     logger.debug(
@@ -148,6 +149,7 @@ async def test_password_rotation_silent(ops_test: OpsTest):
     assert updated_credentials["password"] != old_credentials["password"]
 
     # verify that the new password actually works
+    # since get_primary_unit (and this get_cluster_status) use the cluster admin credentials
     primary_unit = await get_primary_unit(ops_test, random_unit, DATABASE_APP_NAME)
     primary_unit_address = await primary_unit.get_public_address()
     logger.debug(


### PR DESCRIPTION
# Issue
We have not yet ported over the `mysqlrouter` extra user roles in the database relation interface. This role is used to create a user used by mysqlrouter to bootstrap and additionally needs to be granted `CREATE USER` privileges.

# Solution
Port over the `mysqlrouter` extra user roles. Use `mysqlsh.cluster.setup_router_account({update: 1})` to set up the bootstrap user. Create helper method to grant `CREATE USER` privileges to this user.

# Release Notes
Add mysqlrouter extra user roles for the database relation interface
