### PR TITLE
Tidy get-cluster-status action output on failure

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -508,7 +508,21 @@ class MySQLOperatorCharm(CharmBase):
 
     def _get_cluster_status(self, event: ActionEvent) -> None:
         """Get the cluster status without topology."""
-        event.set_results(self._mysql.get_cluster_status())
+        status = self._mysql.get_cluster_status()
+        if status:
+            event.set_results(
+                {
+                    "success": True,
+                    "status": status,
+                }
+            )
+        else:
+            event.set_results(
+                {
+                    "success": False,
+                    "message": "Failed to read cluster status.  See logs for more information.",
+                }
+            )
 
     def _restart(self, _) -> None:
         """Restart server rolling ops callback function.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -62,7 +62,7 @@ async def get_cluster_status(ops_test: OpsTest, unit: Unit) -> Dict:
     """
     get_cluster_status_action = await unit.run_action("get-cluster-status")
     cluster_status_results = await get_cluster_status_action.wait()
-    return cluster_status_results.results
+    return cluster_status_results.results.get("status", {})
 
 
 async def get_primary_unit(


### PR DESCRIPTION
`get_cluster_status()` returns None on failure,
so that must be accounted for when setting the get-cluster-status
action results dictionary.

Also ensure that this `None` return value is documented
and accounted for elsewhere in the code where it wasn't previously.
