### PR TITLE
Replicate CI job dependency + try to address flakiness of tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
 
   integration-test-microk8s-charm:
     name: Charm integration tests (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -45,6 +48,9 @@ jobs:
 
   integration-test-database-relation:
     name: Integration tests for database relation
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -61,6 +67,9 @@ jobs:
 
   integration-test-microk8s-osm-mysql:
     name: Integration osm-msyql relation tests (microk8s)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   ci-tests:
+    needs:
+      - lib-check
     uses: ./.github/workflows/ci.yaml
 
   release-to-charmhub:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -202,6 +202,7 @@ async def scale_application(
             status="active",
             timeout=(15 * 60),
             wait_for_exact_units=desired_count,
+            raise_on_blocked=True,
         )
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -138,6 +138,9 @@ async def test_scale_up_and_down(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         random_unit = ops_test.model.applications[APP_NAME].units[0]
 
+        # TODO: address the flakiness of scaling up multiple units at once
+        # For now, we'll scale up one at a time to make tests reliably pass
+        await scale_application(ops_test, APP_NAME, 4)
         await scale_application(ops_test, APP_NAME, 5)
 
         cluster_status = await get_cluster_status(ops_test, random_unit)


### PR DESCRIPTION
# Issue
1. Alex introduced a dependency for tests (to save time and cycles running heavy integration tests if unit tests or lints fail). We do not yet have this in this repository
2. We are not raising on blocked in the `scale_application` helper function
3. Somehow, scaling the database more than one unit at a time is causing the following error trace (https://github.com/canonical/mysql-k8s-operator/actions/runs/3204633434/jobs/5236555089#step:4:541). Not suggesting that this is the root cause

# Solution
1. Replicate the dependencies for tests to this repo
2. Raise on blocked
3. Scale up one application at a time to see if that reduces the frequency of the error

# Release Notes
Replicate CI job dependency + try to address flakiness of tests
