### PR TITLE
Fetch updated mysql lib to resolve unescaped database identifiers

### DIFF
--- a/tests/integration/relations/application-charm/src/charm.py
+++ b/tests/integration/relations/application-charm/src/charm.py
@@ -39,7 +39,7 @@ class ApplicationCharm(CharmBase):
 
         # Events related to the requested database
         # (these events are defined in the database requires charm library).
-        self.database_name = f'{self.app.name}-test-database'
+        self.database_name = f"{self.app.name}-test-database"
         self.database = DatabaseRequires(self, REMOTE, self.database_name)
         self.framework.observe(self.database.on.database_created, self._on_database_created)
         self.framework.observe(

--- a/tests/integration/relations/application-charm/src/charm.py
+++ b/tests/integration/relations/application-charm/src/charm.py
@@ -39,7 +39,7 @@ class ApplicationCharm(CharmBase):
 
         # Events related to the requested database
         # (these events are defined in the database requires charm library).
-        self.database_name = f'{self.app.name.replace("-", "_")}_test_database'
+        self.database_name = f'{self.app.name}-test-database'
         self.database = DatabaseRequires(self, REMOTE, self.database_name)
         self.framework.observe(self.database.on.database_created, self._on_database_created)
         self.framework.observe(


### PR DESCRIPTION
# Issue
- We introduced a [fix](https://github.com/canonical/mysql-operator/pull/50) for not properly escaping `database-name`, `username` and `hostname` while forming application relation. However, we have not yet imported this fix into this repository.

# Solution
Import the fix by fetching the latest version of the `mysql` library. Update the `relations` application-charm to use `-`s in database name when trying to form a relation with the database.

# Release Notes
Fetch updated mysql lib to resolve unescaped database identifiers
