### PR TITLE
Feature TLS support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,3 +83,22 @@ jobs:
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run osm-mysql relation integration tests
         run: tox -e integration-osm-mysql
+
+  integration-test-tls:
+    name: Integration tls relation tests
+    needs:
+      - lint
+      - unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+          # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
+          channel: 1.23/stable
+          bootstrap-options: "--agent-version 2.9.29"
+      - name: Run osm-mysql relation integration tests
+        run: tox -e integration-tls

--- a/actions.yaml
+++ b/actions.yaml
@@ -23,3 +23,14 @@ set-password:
     password:
       type: string
       description: The password will be auto-generated if this option is not specified.
+
+set-tls-private-key:
+  description:
+    Set the privates key, which will be used for certificate signing requests (CSR). Run
+      for each unit separately.
+  params:
+    internal-key:
+      type: string
+      description: The content of private key for internal communications with
+        clients. Content will be auto-generated if this option is not specified.
+

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,3 +9,11 @@ bases:
     run-on:
       - name: "ubuntu"
         channel: "20.04"
+parts:
+  charm:
+    build-packages:
+      - libffi-dev
+      - libssl-dev
+      - rustc
+      - cargo
+

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -1,0 +1,390 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This library enables "rolling" operations across units of a charmed Application.
+
+For example, a charm author might use this library to implement a "rolling restart", in
+which all units in an application restart their workload, but no two units execute the
+restart at the same time.
+
+To implement the rolling restart, a charm author would do the following:
+
+1. Add a peer relation called 'restart' to a charm's `metadata.yaml`:
+```yaml
+peers:
+    restart:
+        interface: rolling_op
+```
+
+Import this library into src/charm.py, and initialize a RollingOpsManager in the Charm's
+`__init__`. The Charm should also define a callback routine, which will be executed when
+a unit holds the distributed lock:
+
+src/charm.py
+```python
+# ...
+from charms.rolling_ops.v0.rollingops import RollingOpsManager
+# ...
+class SomeCharm(...):
+    def __init__(...)
+        # ...
+        self.restart_manager = RollingOpsManager(
+            charm=self, relation="restart", callback=self._restart
+        )
+        # ...
+    def _restart(self, event):
+        systemd.service_restart('foo')
+```
+
+To kick off the rolling restart, emit this library's AcquireLock event. The simplest way
+to do so would be with an action, though it might make sense to acquire the lock in
+response to another event. 
+
+```python
+    def _on_trigger_restart(self, event):
+        self.charm.on[self.restart_manager.name].acquire_lock.emit()
+```
+
+In order to trigger the restart, a human operator would execute the following command on
+the CLI:
+
+```
+juju run-action some-charm/0 some-charm/1 <... some-charm/n> restart
+```
+
+Note that all units that plan to restart must receive the action and emit the aquire
+event. Any units that do not run their acquire handler will be left out of the rolling
+restart. (An operator might take advantage of this fact to recover from a failed rolling
+operation without restarting workloads that were able to successfully restart -- simply
+omit the successful units from a subsequent run-action call.)
+
+"""
+import logging
+from enum import Enum
+from typing import AnyStr, Callable
+
+from ops.charm import ActionEvent, CharmBase, RelationChangedEvent
+from ops.framework import EventBase, Object
+from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "20b7777f58fe421e9a223aefc2b4d3a4"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+
+class LockNoRelationError(Exception):
+    """Raised if we are trying to process a lock, but do not appear to have a relation yet."""
+
+    pass
+
+
+class LockState(Enum):
+    """Possible states for our Distributed lock.
+
+    Note that there are two states set on the unit, and two on the application.
+
+    """
+
+    ACQUIRE = "acquire"
+    RELEASE = "release"
+    GRANTED = "granted"
+    IDLE = "idle"
+
+
+class Lock:
+    """A class that keeps track of a single asynchronous lock.
+
+    Warning: a Lock has permission to update relation data, which means that there are
+    side effects to invoking the .acquire, .release and .grant methods. Running any one of
+    them will trigger a RelationChanged event, once per transition from one internal
+    status to another.
+
+    This class tracks state across the cloud by implementing a peer relation
+    interface. There are two parts to the interface:
+
+    1) The data on a unit's peer relation (defined in metadata.yaml.) Each unit can update
+       this data. The only meaningful values are "acquire", and "release", which represent
+       a request to acquire the lock, and a request to release the lock, respectively.
+
+    2) The application data in the relation. This tracks whether the lock has been
+       "granted", Or has been released (and reverted to idle). There are two valid states:
+       "granted" or None.  If a lock is in the "granted" state, a unit should emit a
+       RunWithLocks event and then release the lock.
+
+       If a lock is in "None", this means that a unit has not yet requested the lock, or
+       that the request has been completed.
+
+    In more detail, here is the relation structure:
+
+    relation.data:
+        <unit n>:
+            status: 'acquire|release'
+        <application>:
+           <unit n>: 'granted|None'
+
+    Note that this class makes no attempts to timestamp the locks and thus handle multiple
+    requests in a row. If a unit re-requests a lock before being granted the lock, the
+    lock will simply stay in the "acquire" state. If a unit wishes to clear its lock, it
+    simply needs to call lock.release().
+
+    """
+
+    def __init__(self, manager, unit=None):
+
+        self.relation = manager.model.relations[manager.name][0]
+        if not self.relation:
+            # TODO: defer caller in this case (probably just fired too soon).
+            raise LockNoRelationError()
+
+        self.unit = unit or manager.model.unit
+        self.app = manager.model.app
+
+    @property
+    def _state(self) -> LockState:
+        """Return an appropriate state.
+
+        Note that the state exists in the unit's relation data, and the application
+        relation data, so we have to be careful about what our states mean.
+
+        Unit state can only be in "acquire", "release", "None" (None means unset)
+        Application state can only be in "granted" or "None" (None means unset or released)
+
+        """
+        unit_state = LockState(self.relation.data[self.unit].get("state", LockState.IDLE.value))
+        app_state = LockState(
+            self.relation.data[self.app].get(str(self.unit), LockState.IDLE.value)
+        )
+
+        if app_state == LockState.GRANTED and unit_state == LockState.RELEASE:
+            # Active release request.
+            return LockState.RELEASE
+
+        if app_state == LockState.IDLE and unit_state == LockState.ACQUIRE:
+            # Active acquire request.
+            return LockState.ACQUIRE
+
+        return app_state  # Granted or unset/released
+
+    @_state.setter
+    def _state(self, state: LockState):
+        """Set the given state.
+
+        Since we update the relation data, this may fire off a RelationChanged event.
+        """
+        if state == LockState.ACQUIRE:
+            self.relation.data[self.unit].update({"state": state.value})
+
+        if state == LockState.RELEASE:
+            self.relation.data[self.unit].update({"state": state.value})
+
+        if state == LockState.GRANTED:
+            self.relation.data[self.app].update({str(self.unit): state.value})
+
+        if state is LockState.IDLE:
+            self.relation.data[self.app].update({str(self.unit): state.value})
+
+    def acquire(self):
+        """Request that a lock be acquired."""
+        self._state = LockState.ACQUIRE
+
+    def release(self):
+        """Request that a lock be released."""
+        self._state = LockState.RELEASE
+
+    def clear(self):
+        """Unset a lock."""
+        self._state = LockState.IDLE
+
+    def grant(self):
+        """Grant a lock to a unit."""
+        self._state = LockState.GRANTED
+
+    def is_held(self):
+        """This unit holds the lock."""
+        return self._state == LockState.GRANTED
+
+    def release_requested(self):
+        """A unit has reported that they are finished with the lock."""
+        return self._state == LockState.RELEASE
+
+    def is_pending(self):
+        """Is this unit waiting for a lock?"""
+        return self._state == LockState.ACQUIRE
+
+
+class Locks:
+    """Generator that returns a list of locks."""
+
+    def __init__(self, manager):
+        self.manager = manager
+
+        # Gather all the units.
+        relation = manager.model.relations[manager.name][0]
+        units = [unit for unit in relation.units]
+
+        # Plus our unit ...
+        units.append(manager.model.unit)
+
+        self.units = units
+
+    def __iter__(self):
+        """Yields a lock for each unit we can find on the relation."""
+        for unit in self.units:
+            yield Lock(self.manager, unit=unit)
+
+
+class RunWithLock(EventBase):
+    """Event to signal that this unit should run the callback."""
+
+    pass
+
+
+class AcquireLock(EventBase):
+    """Signals that this unit wants to acquire a lock."""
+
+    pass
+
+
+class ProcessLocks(EventBase):
+    """Used to tell the leader to process all locks."""
+
+    pass
+
+
+class RollingOpsManager(Object):
+    """Emitters and handlers for rolling ops."""
+
+    def __init__(self, charm: CharmBase, relation: AnyStr, callback: Callable):
+        """Register our custom events.
+
+        params:
+            charm: the charm we are attaching this to.
+            relation: an identifier, by convention based on the name of the relation in the
+                metadata.yaml, which identifies this instance of RollingOperatorsFactory,
+                distinct from other instances that may be hanlding other events.
+            callback: a closure to run when we have a lock. (It must take a CharmBase object and
+                EventBase object as args.)
+        """
+        # "Inherit" from the charm's class. This gives us access to the framework as
+        # self.framework, as well as the self.model shortcut.
+        super().__init__(charm, None)
+
+        self.name = relation
+        self._callback = callback
+        self.charm = charm  # Maintain a reference to charm, so we can emit events.
+
+        charm.on.define_event("{}_run_with_lock".format(self.name), RunWithLock)
+        charm.on.define_event("{}_acquire_lock".format(self.name), AcquireLock)
+        charm.on.define_event("{}_process_locks".format(self.name), ProcessLocks)
+
+        # Watch those events (plus the built in relation event).
+        self.framework.observe(charm.on[self.name].relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on[self.name].acquire_lock, self._on_acquire_lock)
+        self.framework.observe(charm.on[self.name].run_with_lock, self._on_run_with_lock)
+        self.framework.observe(charm.on[self.name].process_locks, self._on_process_locks)
+
+    def _callback(self: CharmBase, event: EventBase) -> None:
+        """Placeholder for the function that actually runs our event.
+
+        Usually overridden in the init.
+        """
+        raise NotImplementedError
+
+    def _on_relation_changed(self: CharmBase, event: RelationChangedEvent):
+        """Process relation changed.
+
+        First, determine whether this unit has been granted a lock. If so, emit a RunWithLock
+        event.
+
+        Then, if we are the leader, fire off a process locks event.
+
+        """
+        lock = Lock(self)
+
+        if lock.is_pending():
+            self.model.unit.status = WaitingStatus("Awaiting {} operation".format(self.name))
+
+        if lock.is_held():
+            self.charm.on[self.name].run_with_lock.emit()
+
+        if self.model.unit.is_leader():
+            self.charm.on[self.name].process_locks.emit()
+
+    def _on_process_locks(self: CharmBase, event: ProcessLocks):
+        """Process locks.
+
+        Runs only on the leader. Updates the status of all locks.
+
+        """
+        if not self.model.unit.is_leader():
+            return
+
+        pending = []
+
+        for lock in Locks(self):
+            if lock.is_held():
+                # One of our units has the lock -- return without further processing.
+                return
+
+            if lock.release_requested():
+                lock.clear()  # Updates relation data
+
+            if lock.is_pending():
+                if lock.unit == self.model.unit:
+                    # Always run on the leader last.
+                    pending.insert(0, lock)
+                else:
+                    pending.append(lock)
+
+        # If we reach this point, and we have pending units, we want to grant a lock to
+        # one of them.
+        if pending:
+            self.model.app.status = MaintenanceStatus("Beginning rolling {}".format(self.name))
+            lock = pending[-1]
+            lock.grant()
+            if lock.unit == self.model.unit:
+                # It's time for the leader to run with lock.
+                self.charm.on[self.name].run_with_lock.emit()
+            return
+
+        self.model.app.status = ActiveStatus()
+
+    def _on_acquire_lock(self: CharmBase, event: ActionEvent):
+        """Request a lock."""
+        try:
+            Lock(self).acquire()  # Updates relation data
+            # emit relation changed event in the edge case where aquire does not
+            relation = self.model.get_relation(self.name)
+            self.charm.on[self.name].relation_changed.emit(relation)
+        except LockNoRelationError:
+            logger.debug("No {} peer relation yet. Delaying rolling op.".format(self.name))
+            event.defer()
+
+    def _on_run_with_lock(self: CharmBase, event: RunWithLock):
+        lock = Lock(self)
+        self.model.unit.status = MaintenanceStatus("Executing {} operation".format(self.name))
+        self._callback(event)
+        lock.release()  # Updates relation data
+        if lock.unit == self.model.unit:
+            self.charm.on[self.name].process_locks.emit()
+
+        self.model.unit.status = ActiveStatus()

--- a/lib/charms/tls_certificates_interface/v1/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v1/tls_certificates.py
@@ -1,0 +1,1209 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the tls-certificates relation.
+
+This library contains the Requires and Provides classes for handling the tls-certificates
+interface.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.tls_certificates_interface.v1.tls_certificates
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- jsonschema
+- cryptography
+
+Add the following section to the charm's `charmcraft.yaml` file:
+```yaml
+parts:
+  charm:
+    build-packages:
+      - libffi-dev
+      - libssl-dev
+      - rustc
+      - cargo
+```
+
+### Provider charm
+The provider charm is the charm providing certificates to another charm that requires them. In
+this example, the provider charm is storing its private key using a peer relation interface called
+`replicas`.
+
+Example:
+```python
+from charms.tls_certificates_interface.v1.tls_certificates import (
+    CertificateCreationRequestEvent,
+    CertificateRevocationRequestEvent,
+    TLSCertificatesProvidesV1,
+    generate_private_key,
+)
+from ops.charm import CharmBase, InstallEvent
+from ops.main import main
+from ops.model import ActiveStatus, WaitingStatus
+
+
+def generate_ca(private_key: bytes, subject: str) -> str:
+    return "whatever ca content"
+
+
+def generate_certificate(ca: str, private_key: str, csr: str) -> str:
+    return "Whatever certificate"
+
+
+class ExampleProviderCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.certificates = TLSCertificatesProvidesV1(self, "certificates")
+        self.framework.observe(
+            self.certificates.on.certificate_request, self._on_certificate_request
+        )
+        self.framework.observe(
+            self.certificates.on.certificate_revoked, self._on_certificate_revocation_request
+        )
+        self.framework.observe(self.on.install, self._on_install)
+
+    def _on_install(self, event: InstallEvent) -> None:
+        private_key_password = b"banana"
+        private_key = generate_private_key(password=private_key_password)
+        ca_certificate = generate_ca(private_key=private_key, subject="whatever")
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        replicas_relation.data[self.app].update(
+            {
+                "private_key_password": "banana",
+                "private_key": private_key,
+                "ca_certificate": ca_certificate,
+            }
+        )
+        self.unit.status = ActiveStatus()
+
+    def _on_certificate_request(self, event: CertificateCreationRequestEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        ca_certificate = replicas_relation.data[self.app].get("ca_certificate")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        certificate = generate_certificate(
+            ca=ca_certificate,
+            private_key=private_key,
+            csr=event.certificate_signing_request,
+        )
+
+        self.certificates.set_relation_certificate(
+            certificate=certificate,
+            certificate_signing_request=event.certificate_signing_request,
+            ca=ca_certificate,
+            chain=[ca_certificate, certificate],
+            relation_id=event.relation_id,
+        )
+
+    def _on_certificate_revocation_request(self, event: CertificateRevocationRequestEvent) -> None:
+        # Do what you want to do with this information
+        pass
+
+
+if __name__ == "__main__":
+    main(ExampleProviderCharm)
+```
+
+### Requirer charm
+The requirer charm is the charm requiring certificates from another charm that provides them. In
+this example, the requirer charm is storing its certificates using a peer relation interface called
+`replicas`.
+
+Example:
+```python
+from charms.tls_certificates_interface.v1.tls_certificates import (
+    CertificateAvailableEvent,
+    CertificateExpiringEvent,
+    TLSCertificatesRequiresV1,
+    generate_csr,
+    generate_private_key,
+)
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+from ops.model import ActiveStatus, WaitingStatus
+
+
+class ExampleRequirerCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.cert_subject = "whatever"
+        self.certificates = TLSCertificatesRequiresV1(self, "certificates")
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(
+            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+        )
+        self.framework.observe(
+            self.certificates.on.certificate_available, self._on_certificate_available
+        )
+        self.framework.observe(
+            self.certificates.on.certificate_expiring, self._on_certificate_expiring
+        )
+
+    def _on_install(self, event) -> None:
+        private_key_password = b"banana"
+        private_key = generate_private_key(password=private_key_password)
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        replicas_relation.data[self.app].update(
+            {"private_key_password": "banana", "private_key": private_key.decode()}
+        )
+
+    def _on_certificates_relation_joined(self, event: RelationJoinedEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        private_key_password = replicas_relation.data[self.app].get("private_key_password")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        csr = generate_csr(
+            private_key=private_key.encode(),
+            private_key_password=private_key_password.encode(),
+            subject=self.cert_subject,
+        )
+        replicas_relation.data[self.app].update({"csr": csr.decode()})
+        self.certificates.request_certificate_creation(certificate_signing_request=csr)
+
+    def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        replicas_relation.data[self.app].update({"certificate": event.certificate})
+        replicas_relation.data[self.app].update({"ca": event.ca})
+        replicas_relation.data[self.app].update({"chain": event.chain})
+        self.unit.status = ActiveStatus()
+
+    def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
+        replicas_relation = self.model.get_relation("replicas")
+        if not replicas_relation:
+            self.unit.status = WaitingStatus("Waiting for peer relation to be created")
+            event.defer()
+            return
+        old_csr = replicas_relation.data[self.app].get("csr")
+        private_key_password = replicas_relation.data[self.app].get("private_key_password")
+        private_key = replicas_relation.data[self.app].get("private_key")
+        new_csr = generate_csr(
+            private_key=private_key.encode(),
+            private_key_password=private_key_password.encode(),
+            subject=self.cert_subject,
+        )
+        self.certificates.request_certificate_renewal(
+            old_certificate_signing_request=old_csr,
+            new_certificate_signing_request=new_csr,
+        )
+        replicas_relation.data[self.app].update({"csr": new_csr.decode()})
+
+
+if __name__ == "__main__":
+    main(ExampleRequirerCharm)
+```
+"""  # noqa: D405, D410, D411, D214, D416
+
+import copy
+import json
+import logging
+import uuid
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import pkcs12
+from jsonschema import exceptions, validate  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent, UpdateStatusEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+
+# The unique Charmhub library identifier, never change it
+LIBID = "afd8c2bccf834997afce12c2706d2ede"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 8
+
+REQUIRER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v1/schemas/requirer.json",  # noqa: E501
+    "type": "object",
+    "title": "`tls_certificates` requirer root schema",
+    "description": "The `tls_certificates` root schema comprises the entire requirer databag for this interface.",  # noqa: E501
+    "examples": [
+        {
+            "certificate_signing_requests": [
+                {
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\\nAQEBBQADggEPADCCAQoCggEBANWlx9wE6cW7Jkb4DZZDOZoEjk1eDBMJ+8R4pyKp\\nFBeHMl1SQSDt6rAWsrfL3KOGiIHqrRY0B5H6c51L8LDuVrJG0bPmyQ6rsBo3gVke\\nDSivfSLtGvHtp8lwYnIunF8r858uYmblAR0tdXQNmnQvm+6GERvURQ6sxpgZ7iLC\\npPKDoPt+4GKWL10FWf0i82FgxWC2KqRZUtNbgKETQuARLig7etBmCnh20zmynorA\\ncY7vrpTPAaeQpGLNqqYvKV9W6yWVY08V+nqARrFrjk3vSioZSu8ZJUdZ4d9++SGl\\nbH7A6e77YDkX9i/dQ3Pa/iDtWO3tXS2MvgoxX1iSWlGNOHcCAwEAAaAAMA0GCSqG\\nSIb3DQEBCwUAA4IBAQCW1fKcHessy/ZhnIwAtSLznZeZNH8LTVOzkhVd4HA7EJW+\\nKVLBx8DnN7L3V2/uPJfHiOg4Rx7fi7LkJPegl3SCqJZ0N5bQS/KvDTCyLG+9E8Y+\\n7wqCmWiXaH1devimXZvazilu4IC2dSks2D8DPWHgsOdVks9bme8J3KjdNMQudegc\\newWZZ1Dtbd+Rn7cpKU3jURMwm4fRwGxbJ7iT5fkLlPBlyM/yFEik4SmQxFYrZCQg\\n0f3v4kBefTh5yclPy5tEH+8G0LMsbbo3dJ5mPKpAShi0QEKDLd7eR1R/712lYTK4\\ndi4XaEfqERgy68O4rvb4PGlJeRGS7AmL7Ss8wfAq\\n-----END CERTIFICATE REQUEST-----\\n"  # noqa: E501
+                },
+                {
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\\nAQEBBQADggEPADCCAQoCggEBAMk3raaX803cHvzlBF9LC7KORT46z4VjyU5PIaMb\\nQLIDgYKFYI0n5hf2Ra4FAHvOvEmW7bjNlHORFEmvnpcU5kPMNUyKFMTaC8LGmN8z\\nUBH3aK+0+FRvY4afn9tgj5435WqOG9QdoDJ0TJkjJbJI9M70UOgL711oU7ql6HxU\\n4d2ydFK9xAHrBwziNHgNZ72L95s4gLTXf0fAHYf15mDA9U5yc+YDubCKgTXzVySQ\\nUx73VCJLfC/XkZIh559IrnRv5G9fu6BMLEuBwAz6QAO4+/XidbKWN4r2XSq5qX4n\\n6EPQQWP8/nd4myq1kbg6Q8w68L/0YdfjCmbyf2TuoWeImdUCAwEAAaAAMA0GCSqG\\nSIb3DQEBCwUAA4IBAQBIdwraBvpYo/rl5MH1+1Um6HRg4gOdQPY5WcJy9B9tgzJz\\nittRSlRGTnhyIo6fHgq9KHrmUthNe8mMTDailKFeaqkVNVvk7l0d1/B90Kz6OfmD\\nxN0qjW53oP7y3QB5FFBM8DjqjmUnz5UePKoX4AKkDyrKWxMwGX5RoET8c/y0y9jp\\nvSq3Wh5UpaZdWbe1oVY8CqMVUEVQL2DPjtopxXFz2qACwsXkQZxWmjvZnRiP8nP8\\nbdFaEuh9Q6rZ2QdZDEtrU4AodPU3NaukFr5KlTUQt3w/cl+5//zils6G5zUWJ2pN\\ng7+t9PTvXHRkH+LnwaVnmsBFU2e05qADQbfIn7JA\\n-----END CERTIFICATE REQUEST-----\\n"  # noqa: E501
+                },
+            ]
+        }
+    ],
+    "properties": {
+        "certificate_signing_requests": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"certificate_signing_request": {"type": "string"}},
+                "required": ["certificate_signing_request"],
+            },
+        }
+    },
+    "required": ["certificate_signing_requests"],
+    "additionalProperties": True,
+}
+
+PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v1/schemas/provider.json",  # noqa: E501
+    "type": "object",
+    "title": "`tls_certificates` provider root schema",
+    "description": "The `tls_certificates` root schema comprises the entire provider databag for this interface.",  # noqa: E501
+    "example": [
+        {
+            "certificates": [
+                {
+                    "ca": "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n",  # noqa: E501
+                    "chain": [
+                        "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIUMsSK+4FGCjW6sL/EXMSxColmKw8wDQYJKoZIhvcNAQEL\\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIyMDcyOTIx\\nMTgyN1oXDTIzMDcyOTIxMTgyN1owIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdo\\nYXRldmVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA55N9DkgFWbJ/\\naqcdQhso7n1kFvt6j/fL1tJBvRubkiFMQJnZFtekfalN6FfRtA3jq+nx8o49e+7t\\nLCKT0xQ+wufXfOnxv6/if6HMhHTiCNPOCeztUgQ2+dfNwRhYYgB1P93wkUVjwudK\\n13qHTTZ6NtEF6EzOqhOCe6zxq6wrr422+ZqCvcggeQ5tW9xSd/8O1vNID/0MTKpy\\nET3drDtBfHmiUEIBR3T3tcy6QsIe4Rz/2sDinAcM3j7sG8uY6drh8jY3PWar9til\\nv2l4qDYSU8Qm5856AB1FVZRLRJkLxZYZNgreShAIYgEd0mcyI2EO/UvKxsIcxsXc\\nd45GhGpKkwIDAQABo1cwVTAfBgNVHQ4EGAQWBBRXBrXKh3p/aFdQjUcT/UcvICBL\\nODAhBgNVHSMEGjAYgBYEFFcGtcqHen9oV1CNRxP9Ry8gIEs4MA8GA1UdEwEB/wQF\\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGmCEvcoFUrT9e133SHkgF/ZAgzeIziO\\nBjfAdU4fvAVTVfzaPm0yBnGqzcHyacCzbZjKQpaKVgc5e6IaqAQtf6cZJSCiJGhS\\nJYeosWrj3dahLOUAMrXRr8G/Ybcacoqc+osKaRa2p71cC3V6u2VvcHRV7HDFGJU7\\noijbdB+WhqET6Txe67rxZCJG9Ez3EOejBJBl2PJPpy7m1Ml4RR+E8YHNzB0lcBzc\\nEoiJKlDfKSO14E2CPDonnUoWBJWjEvJys3tbvKzsRj2fnLilytPFU0gH3cEjCopi\\nzFoWRdaRuNHYCqlBmso1JFDl8h4fMmglxGNKnKRar0WeGyxb4xXBGpI=\\n-----END CERTIFICATE-----\\n"  # noqa: E501, W505
+                    ],
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----\nMIICWjCCAUICAQAwFTETMBEGA1UEAwwKYmFuYW5hLmNvbTCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANWlx9wE6cW7Jkb4DZZDOZoEjk1eDBMJ+8R4pyKp\nFBeHMl1SQSDt6rAWsrfL3KOGiIHqrRY0B5H6c51L8LDuVrJG0bPmyQ6rsBo3gVke\nDSivfSLtGvHtp8lwYnIunF8r858uYmblAR0tdXQNmnQvm+6GERvURQ6sxpgZ7iLC\npPKDoPt+4GKWL10FWf0i82FgxWC2KqRZUtNbgKETQuARLig7etBmCnh20zmynorA\ncY7vrpTPAaeQpGLNqqYvKV9W6yWVY08V+nqARrFrjk3vSioZSu8ZJUdZ4d9++SGl\nbH7A6e77YDkX9i/dQ3Pa/iDtWO3tXS2MvgoxX1iSWlGNOHcCAwEAAaAAMA0GCSqG\nSIb3DQEBCwUAA4IBAQCW1fKcHessy/ZhnIwAtSLznZeZNH8LTVOzkhVd4HA7EJW+\nKVLBx8DnN7L3V2/uPJfHiOg4Rx7fi7LkJPegl3SCqJZ0N5bQS/KvDTCyLG+9E8Y+\n7wqCmWiXaH1devimXZvazilu4IC2dSks2D8DPWHgsOdVks9bme8J3KjdNMQudegc\newWZZ1Dtbd+Rn7cpKU3jURMwm4fRwGxbJ7iT5fkLlPBlyM/yFEik4SmQxFYrZCQg\n0f3v4kBefTh5yclPy5tEH+8G0LMsbbo3dJ5mPKpAShi0QEKDLd7eR1R/712lYTK4\ndi4XaEfqERgy68O4rvb4PGlJeRGS7AmL7Ss8wfAq\n-----END CERTIFICATE REQUEST-----\n",  # noqa: E501
+                    "certificate": "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCFFPAOD7utDTsgFrm0vS4We18OcnKMA0GCSqGSIb3DQEBCwUAMCAx\nCzAJBgNVBAYTAlVTMREwDwYDVQQDDAh3aGF0ZXZlcjAeFw0yMjA3MjkyMTE5Mzha\nFw0yMzA3MjkyMTE5MzhaMBUxEzARBgNVBAMMCmJhbmFuYS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDVpcfcBOnFuyZG+A2WQzmaBI5NXgwTCfvE\neKciqRQXhzJdUkEg7eqwFrK3y9yjhoiB6q0WNAeR+nOdS/Cw7layRtGz5skOq7Aa\nN4FZHg0or30i7Rrx7afJcGJyLpxfK/OfLmJm5QEdLXV0DZp0L5vuhhEb1EUOrMaY\nGe4iwqTyg6D7fuBili9dBVn9IvNhYMVgtiqkWVLTW4ChE0LgES4oO3rQZgp4dtM5\nsp6KwHGO766UzwGnkKRizaqmLylfVusllWNPFfp6gEaxa45N70oqGUrvGSVHWeHf\nfvkhpWx+wOnu+2A5F/Yv3UNz2v4g7Vjt7V0tjL4KMV9YklpRjTh3AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAChjRzuba8zjQ7NYBVas89Oy7u++MlS8xWxh++yiUsV6\nWMk3ZemsPtXc1YmXorIQohtxLxzUPm2JhyzFzU/sOLmJQ1E/l+gtZHyRCwsb20fX\nmphuJsMVd7qv/GwEk9PBsk2uDqg4/Wix0Rx5lf95juJP7CPXQJl5FQauf3+LSz0y\nwF/j+4GqvrwsWr9hKOLmPdkyKkR6bHKtzzsxL9PM8GnElk2OpaPMMnzbL/vt2IAt\nxK01ZzPxCQCzVwHo5IJO5NR/fIyFbEPhxzG17QsRDOBR9fl9cOIvDeSO04vyZ+nz\n+kA2c3fNrZFAtpIlOOmFh8Q12rVL4sAjI5mVWnNEgvI=\n-----END CERTIFICATE-----\n",  # noqa: E501
+                }
+            ]
+        }
+    ],
+    "properties": {
+        "certificates": {
+            "$id": "#/properties/certificates",
+            "type": "array",
+            "items": {
+                "$id": "#/properties/certificates/items",
+                "type": "object",
+                "required": ["certificate_signing_request", "certificate", "ca", "chain"],
+                "properties": {
+                    "certificate_signing_request": {
+                        "$id": "#/properties/certificates/items/certificate_signing_request",
+                        "type": "string",
+                    },
+                    "certificate": {
+                        "$id": "#/properties/certificates/items/certificate",
+                        "type": "string",
+                    },
+                    "ca": {"$id": "#/properties/certificates/items/ca", "type": "string"},
+                    "chain": {
+                        "$id": "#/properties/certificates/items/chain",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "$id": "#/properties/certificates/items/chain/items",
+                        },
+                    },
+                },
+                "additionalProperties": True,
+            },
+        }
+    },
+    "required": ["certificates"],
+    "additionalProperties": True,
+}
+
+
+logger = logging.getLogger(__name__)
+
+
+class CertificateAvailableEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is available."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: List[str],
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.certificate_signing_request = certificate_signing_request
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate": self.certificate,
+            "certificate_signing_request": self.certificate_signing_request,
+            "ca": self.ca,
+            "chain": self.chain,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+
+
+class CertificateExpiringEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is almost expired."""
+
+    def __init__(self, handle, certificate: str, expiry: str):
+        """CertificateExpiringEvent.
+
+        Args:
+            handle (Handle): Juju framework handle
+            certificate (str): TLS Certificate
+            expiry (str): Datetime string reprensenting the time at which the certificate
+                won't be valid anymore.
+        """
+        super().__init__(handle)
+        self.certificate = certificate
+        self.expiry = expiry
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {"certificate": self.certificate, "expiry": self.expiry}
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.expiry = snapshot["expiry"]
+
+
+class CertificateExpiredEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is expired."""
+
+    def __init__(self, handle: Handle, certificate: str):
+        super().__init__(handle)
+        self.certificate = certificate
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {"certificate": self.certificate}
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+
+
+class CertificateCreationRequestEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is required."""
+
+    def __init__(self, handle: Handle, certificate_signing_request: str, relation_id: int):
+        super().__init__(handle)
+        self.certificate_signing_request = certificate_signing_request
+        self.relation_id = relation_id
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate_signing_request": self.certificate_signing_request,
+            "relation_id": self.relation_id,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.relation_id = snapshot["relation_id"]
+
+
+class CertificateRevocationRequestEvent(EventBase):
+    """Charm Event triggered when a TLS certificate needs to be revoked."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: str,
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.certificate_signing_request = certificate_signing_request
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Returns snapshot."""
+        return {
+            "certificate": self.certificate,
+            "certificate_signing_request": self.certificate_signing_request,
+            "ca": self.ca,
+            "chain": self.chain,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.certificate_signing_request = snapshot["certificate_signing_request"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+
+
+def _load_relation_data(raw_relation_data: dict) -> dict:
+    """Loads relation data from the relation data bag.
+
+    Json loads all data.
+
+    Args:
+        raw_relation_data: Relation data from the databag
+
+    Returns:
+        dict: Relation data in dict format.
+    """
+    certificate_data = dict()
+    for key in raw_relation_data:
+        try:
+            certificate_data[key] = json.loads(raw_relation_data[key])
+        except (json.decoder.JSONDecodeError, TypeError):
+            certificate_data[key] = raw_relation_data[key]
+    return certificate_data
+
+
+def generate_ca(
+    private_key: bytes,
+    subject: str,
+    private_key_password: Optional[bytes] = None,
+    validity: int = 365,
+    country: str = "US",
+) -> bytes:
+    """Generates a CA Certificate.
+
+    Args:
+        private_key (bytes): Private key
+        subject (str): Certificate subject
+        private_key_password (bytes): Private key password
+        validity (int): Certificate validity time (in days)
+        country (str): Certificate Issuing country
+
+    Returns:
+        bytes: CA Certificate.
+    """
+    private_key_object = serialization.load_pem_private_key(
+        private_key, password=private_key_password
+    )
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
+            x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
+        ]
+    )
+    subject_identifier_object = x509.SubjectKeyIdentifier.from_public_key(
+        private_key_object.public_key()  # type: ignore[arg-type]
+    )
+    subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key_object.public_key())  # type: ignore[arg-type]
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+        .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier(
+                key_identifier=key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        )
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None),
+            critical=True,
+        )
+        .sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def generate_certificate(
+    csr: bytes,
+    ca: bytes,
+    ca_key: bytes,
+    ca_key_password: Optional[bytes] = None,
+    validity: int = 365,
+    alt_names: list = None,
+) -> bytes:
+    """Generates a TLS certificate based on a CSR.
+
+    Args:
+        csr (bytes): CSR
+        ca (bytes): CA Certificate
+        ca_key (bytes): CA private key
+        ca_key_password: CA private key password
+        validity (int): Certificate validity (in days)
+        alt_names: Certificate Subject alternative names
+
+    Returns:
+        bytes: Certificate
+    """
+    csr_object = x509.load_pem_x509_csr(csr)
+    subject = csr_object.subject
+    issuer = x509.load_pem_x509_certificate(ca).issuer
+    private_key = serialization.load_pem_private_key(ca_key, password=ca_key_password)
+
+    certificate_builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(csr_object.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.utcnow())
+        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+    )
+    if alt_names:
+        names = [x509.DNSName(n) for n in alt_names]
+        certificate_builder = certificate_builder.add_extension(
+            x509.SubjectAlternativeName(names),
+            critical=False,
+        )
+    certificate_builder._version = x509.Version.v1
+    cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def generate_pfx_package(
+    certificate: bytes,
+    private_key: bytes,
+    package_password: str,
+    private_key_password: Optional[bytes] = None,
+) -> bytes:
+    """Generates a PFX package to contain the TLS certificate and private key.
+
+    Args:
+        certificate (bytes): TLS certificate
+        private_key (bytes): Private key
+        package_password (str): Password to open the PFX package
+        private_key_password (bytes): Private key password
+
+    Returns:
+        bytes:
+    """
+    private_key_object = serialization.load_pem_private_key(
+        private_key, password=private_key_password
+    )
+    certificate_object = x509.load_pem_x509_certificate(certificate)
+    name = certificate_object.subject.rfc4514_string()
+    pfx_bytes = pkcs12.serialize_key_and_certificates(
+        name=name.encode(),
+        cert=certificate_object,
+        key=private_key_object,  # type: ignore[arg-type]
+        cas=None,
+        encryption_algorithm=serialization.BestAvailableEncryption(package_password.encode()),
+    )
+    return pfx_bytes
+
+
+def generate_private_key(
+    password: Optional[bytes] = None,
+    key_size: int = 2048,
+    public_exponent: int = 65537,
+) -> bytes:
+    """Generates a private key.
+
+    Args:
+        password (bytes): Password for decrypting the private key
+        key_size (int): Key size in bytes
+        public_exponent: Public exponent.
+
+    Returns:
+        bytes: Private Key
+    """
+    private_key = rsa.generate_private_key(
+        public_exponent=public_exponent,
+        key_size=key_size,
+    )
+    key_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.BestAvailableEncryption(password)
+        if password
+        else serialization.NoEncryption(),
+    )
+    return key_bytes
+
+
+def generate_csr(
+    private_key: bytes,
+    subject: str,
+    add_unique_id_to_subject_name: bool = True,
+    organization: str = None,
+    email_address: str = None,
+    country_name: str = None,
+    private_key_password: Optional[bytes] = None,
+    sans: Optional[List[str]] = None,
+    additional_critical_extensions: Optional[List] = None,
+) -> bytes:
+    """Generates a CSR using private key and subject.
+
+    Args:
+        private_key (bytes): Private key
+        subject (str): CSR Subject.
+        add_unique_id_to_subject_name (bool): Whether a unique ID must be added to the CSR's
+            subject name. Always leave to "True" when the CSR is used to request certificates
+            using the tls-certificates relation.
+        organization (str): Name of organization.
+        email_address (str): Email address.
+        country_name (str): Country Name.
+        private_key_password (bytes): Private key password
+        sans (list): List of subject alternative names
+        additional_critical_extensions (list): List if critical additional extension objects.
+            Object must be a x509 ExtensionType.
+
+    Returns:
+        bytes: CSR
+    """
+    signing_key = serialization.load_pem_private_key(private_key, password=private_key_password)
+    subject_name = [x509.NameAttribute(x509.NameOID.COMMON_NAME, subject)]
+    if add_unique_id_to_subject_name:
+        unique_identifier = uuid.uuid4()
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.X500_UNIQUE_IDENTIFIER, str(unique_identifier))
+        )
+    if organization:
+        subject_name.append(x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, organization))
+    if email_address:
+        subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
+    if country_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
+    if sans:
+        csr = csr.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(san) for san in sans]), critical=False
+        )
+    if additional_critical_extensions:
+        for extension in additional_critical_extensions:
+            csr = csr.add_extension(extension, critical=True)
+    signed_certificate = csr.sign(signing_key, hashes.SHA256())  # type: ignore[arg-type]
+    return signed_certificate.public_bytes(serialization.Encoding.PEM)
+
+
+class CertificatesProviderCharmEvents(CharmEvents):
+    """List of events that the TLS Certificates provider charm can leverage."""
+
+    certificate_creation_request = EventSource(CertificateCreationRequestEvent)
+    certificate_revocation_request = EventSource(CertificateRevocationRequestEvent)
+
+
+class CertificatesRequirerCharmEvents(CharmEvents):
+    """List of events that the TLS Certificates requirer charm can leverage."""
+
+    certificate_available = EventSource(CertificateAvailableEvent)
+    certificate_expiring = EventSource(CertificateExpiringEvent)
+    certificate_expired = EventSource(CertificateExpiredEvent)
+
+
+class TLSCertificatesProvidesV1(Object):
+    """TLS certificates provider class to be instantiated by TLS certificates providers."""
+
+    on = CertificatesProviderCharmEvents()
+
+    def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name)
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+        self.charm = charm
+        self.relationship_name = relationship_name
+
+    def _add_certificate(
+        self,
+        relation_id: int,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: List[str],
+    ) -> None:
+        """Adds certificate to relation data.
+
+        Args:
+            relation_id (int): Relation id
+            certificate (str): Certificate
+            certificate_signing_request (str): Certificate Signing Request
+            ca (str): CA Certificate
+            chain (list): CA Chain
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name, relation_id=relation_id
+        )
+        if not relation:
+            raise RuntimeError(
+                f"Relation {self.relationship_name} does not exist - "
+                f"The certificate request can't be completed"
+            )
+        new_certificate = {
+            "certificate": certificate,
+            "certificate_signing_request": certificate_signing_request,
+            "ca": ca,
+            "chain": chain,
+        }
+        provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+        provider_certificates = provider_relation_data.get("certificates", [])
+        certificates = copy.deepcopy(provider_certificates)
+        if new_certificate in certificates:
+            logger.info("Certificate already in relation data - Doing nothing")
+            return
+        certificates.append(new_certificate)
+        relation.data[self.model.app]["certificates"] = json.dumps(certificates)
+
+    def _remove_certificate(
+        self,
+        relation_id: int,
+        certificate: str = None,
+        certificate_signing_request: str = None,
+    ) -> None:
+        """Removes certificate from a given relation based on user provided certificate or csr.
+
+        Args:
+            relation_id (int): Relation id
+            certificate (str): Certificate (optional)
+            certificate_signing_request: Certificate signing request (optional)
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name,
+            relation_id=relation_id,
+        )
+        if not relation:
+            raise RuntimeError(
+                f"Relation {self.relationship_name} with relation id {relation_id} does not exist"
+            )
+        provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+        provider_certificates = provider_relation_data.get("certificates", [])
+        certificates = copy.deepcopy(provider_certificates)
+        for certificate_dict in certificates:
+            if certificate and certificate_dict["certificate"] == certificate:
+                certificates.remove(certificate_dict)
+            if (
+                certificate_signing_request
+                and certificate_dict["certificate_signing_request"] == certificate_signing_request
+            ):
+                certificates.remove(certificate_dict)
+        relation.data[self.model.app]["certificates"] = json.dumps(certificates)
+
+    @staticmethod
+    def _relation_data_is_valid(certificates_data: dict) -> bool:
+        """Uses JSON schema validator to validate relation data content.
+
+        Args:
+            certificates_data (dict): Certificate data dictionary as retrieved from relation data.
+
+        Returns:
+            bool: True/False depending on whether the relation data follows the json schema.
+        """
+        try:
+            validate(instance=certificates_data, schema=REQUIRER_JSON_SCHEMA)
+            return True
+        except exceptions.ValidationError:
+            return False
+
+    def set_relation_certificate(
+        self,
+        certificate: str,
+        certificate_signing_request: str,
+        ca: str,
+        chain: List[str],
+        relation_id: int,
+    ) -> None:
+        """Adds certificates to relation data.
+
+        Args:
+            certificate (str): Certificate
+            certificate_signing_request (str): Certificate signing request
+            ca (str): CA Certificate
+            chain (list): CA Chain
+            relation_id (int): Juju relation ID
+
+        Returns:
+            None
+        """
+        certificates_relation = self.model.get_relation(
+            relation_name=self.relationship_name, relation_id=relation_id
+        )
+        if not certificates_relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        self._remove_certificate(
+            certificate_signing_request=certificate_signing_request.strip(),
+            relation_id=relation_id,
+        )
+        self._add_certificate(
+            relation_id=relation_id,
+            certificate=certificate.strip(),
+            certificate_signing_request=certificate_signing_request.strip(),
+            ca=ca.strip(),
+            chain=[cert.strip() for cert in chain],
+        )
+
+    def remove_certificate(self, certificate: str) -> None:
+        """Removes a given certificate from relation data.
+
+        Args:
+            certificate (str): TLS Certificate
+
+        Returns:
+            None
+        """
+        certificates_relation = self.model.relations[self.relationship_name]
+        if not certificates_relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        for certificate_relation in certificates_relation:
+            self._remove_certificate(certificate=certificate, relation_id=certificate_relation.id)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handler triggerred on relation changed event.
+
+        Looks at the relation data and either emits:
+        - certificate request event: If the unit relation data contains a CSR for which
+            a certificate does not exist in the provider relation data.
+        - certificate revocation event: If the provider relation data contains a CSR for which
+            a csr does not exist in the requirer relation data.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
+        provider_relation_data = _load_relation_data(event.relation.data[self.charm.app])
+        if not self._relation_data_is_valid(requirer_relation_data):
+            logger.warning(
+                f"Relation data did not pass JSON Schema validation: {requirer_relation_data}"
+            )
+            return
+        provider_certificates = provider_relation_data.get("certificates", [])
+        requirer_csrs = requirer_relation_data.get("certificate_signing_requests", [])
+        provider_csrs = [
+            certificate_creation_request["certificate_signing_request"]
+            for certificate_creation_request in provider_certificates
+        ]
+        requirer_unit_csrs = [
+            certificate_creation_request["certificate_signing_request"]
+            for certificate_creation_request in requirer_csrs
+        ]
+        for certificate_signing_request in requirer_unit_csrs:
+            if certificate_signing_request not in provider_csrs:
+                self.on.certificate_creation_request.emit(
+                    certificate_signing_request=certificate_signing_request,
+                    relation_id=event.relation.id,
+                )
+        self._revoke_certificates_for_which_no_csr_exists(relation_id=event.relation.id)
+
+    def _revoke_certificates_for_which_no_csr_exists(self, relation_id: int) -> None:
+        """Revokes certificates for which no unit has a CSR.
+
+        Goes through all generated certificates and compare agains the list of CSRS for all units
+        of a given relationship.
+
+        Args:
+            relation_id (int): Relation id
+
+        Returns:
+            None
+        """
+        certificates_relation = self.model.get_relation(
+            relation_name=self.relationship_name, relation_id=relation_id
+        )
+        if not certificates_relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        provider_relation_data = _load_relation_data(certificates_relation.data[self.charm.app])
+        list_of_csrs: List[str] = []
+        for unit in certificates_relation.units:
+            requirer_relation_data = _load_relation_data(certificates_relation.data[unit])
+            requirer_csrs = requirer_relation_data.get("certificate_signing_requests", [])
+            list_of_csrs.extend(csr["certificate_signing_request"] for csr in requirer_csrs)
+        provider_certificates = provider_relation_data.get("certificates", [])
+        for certificate in provider_certificates:
+            if certificate["certificate_signing_request"] not in list_of_csrs:
+                self.on.certificate_revocation_request.emit(
+                    certificate=certificate["certificate"],
+                    certificate_signing_request=certificate["certificate_signing_request"],
+                    ca=certificate["ca"],
+                    chain=certificate["chain"],
+                )
+                self.remove_certificate(certificate=certificate["certificate"])
+
+
+class TLSCertificatesRequiresV1(Object):
+    """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
+
+    on = CertificatesRequirerCharmEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relationship_name: str,
+        expiry_notification_time: int = 168,
+    ):
+        """Generates/use private key and observes relation changed event.
+
+        Args:
+            charm: Charm object
+            relationship_name: Juju relation name
+            expiry_notification_time (int): Time difference between now and expiry (in hours).
+                Used to trigger the CertificateExpiring event. Default: 7 days.
+        """
+        super().__init__(charm, relationship_name)
+        self.relationship_name = relationship_name
+        self.charm = charm
+        self.expiry_notification_time = expiry_notification_time
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+        self.framework.observe(charm.on.update_status, self._on_update_status)
+
+    @property
+    def _requirer_csrs(self) -> List[Dict[str, str]]:
+        """Returns list of requirer CSR's from relation data."""
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
+        return requirer_relation_data.get("certificate_signing_requests", [])
+
+    @property
+    def _provider_certificates(self) -> List[Dict[str, str]]:
+        """Returns list of provider CSR's from relation data."""
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+        if not relation.app:
+            raise RuntimeError(f"Remote app for relation {self.relationship_name} does not exist")
+        provider_relation_data = _load_relation_data(relation.data[relation.app])
+        return provider_relation_data.get("certificates", [])
+
+    def _add_requirer_csr(self, csr: str) -> None:
+        """Adds CSR to relation data.
+
+        Args:
+            csr (str): Certificate Signing Request
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            raise RuntimeError(
+                f"Relation {self.relationship_name} does not exist - "
+                f"The certificate request can't be completed"
+            )
+        new_csr_dict = {"certificate_signing_request": csr}
+        if new_csr_dict in self._requirer_csrs:
+            logger.info("CSR already in relation data - Doing nothing")
+            return
+        requirer_csrs = copy.deepcopy(self._requirer_csrs)
+        requirer_csrs.append(new_csr_dict)
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
+
+    def _remove_requirer_csr(self, csr: str) -> None:
+        """Removes CSR from relation data.
+
+        Args:
+            csr (str): Certificate signing request
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            raise RuntimeError(
+                f"Relation {self.relationship_name} does not exist - "
+                f"The certificate request can't be completed"
+            )
+        requirer_csrs = copy.deepcopy(self._requirer_csrs)
+        csr_dict = {"certificate_signing_request": csr}
+        if csr_dict not in requirer_csrs:
+            logger.info("CSR not in relation data - Doing nothing")
+            return
+        requirer_csrs.remove(csr_dict)
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
+
+    def request_certificate_creation(self, certificate_signing_request: bytes) -> None:
+        """Request TLS certificate to provider charm.
+
+        Args:
+            certificate_signing_request (bytes): Certificate Signing Request
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            message = (
+                f"Relation {self.relationship_name} does not exist - "
+                f"The certificate request can't be completed"
+            )
+            logger.error(message)
+            raise RuntimeError(message)
+        self._add_requirer_csr(certificate_signing_request.decode().strip())
+        logger.info("Certificate request sent to provider")
+
+    def request_certificate_revocation(self, certificate_signing_request: bytes) -> None:
+        """Removes CSR from relation data.
+
+        The provider of this relation is then expected to remove certificates associated to this
+        CSR from the relation data as well and emit a request_certificate_revocation event for the
+        provider charm to interpret.
+
+        Args:
+            certificate_signing_request (bytes): Certificate Signing Request
+
+        Returns:
+            None
+        """
+        self._remove_requirer_csr(certificate_signing_request.decode().strip())
+        logger.info("Certificate revocation sent to provider")
+
+    def request_certificate_renewal(
+        self, old_certificate_signing_request: bytes, new_certificate_signing_request: bytes
+    ) -> None:
+        """Renews certificate.
+
+        Removes old CSR from relation data and adds new one.
+
+        Args:
+            old_certificate_signing_request: Old CSR
+            new_certificate_signing_request: New CSR
+
+        Returns:
+            None
+        """
+        try:
+            self.request_certificate_revocation(
+                certificate_signing_request=old_certificate_signing_request
+            )
+        except RuntimeError:
+            logger.warning("Certificate revocation failed.")
+        self.request_certificate_creation(
+            certificate_signing_request=new_certificate_signing_request
+        )
+        logger.info("Certificate renewal request completed.")
+
+    @staticmethod
+    def _relation_data_is_valid(certificates_data: dict) -> bool:
+        """Checks whether relation data is valid based on json schema.
+
+        Args:
+            certificates_data: Certificate data in dict format.
+
+        Returns:
+            bool: Whether relation data is valid.
+        """
+        try:
+            validate(instance=certificates_data, schema=PROVIDER_JSON_SCHEMA)
+            return True
+        except exceptions.ValidationError:
+            return False
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handler triggerred on relation changed events.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            logger.warning(f"No relation: {self.relationship_name}")
+            return
+        if not relation.app:
+            logger.warning(f"No remote app in relation: {self.relationship_name}")
+            return
+        provider_relation_data = _load_relation_data(relation.data[relation.app])
+        if not self._relation_data_is_valid(provider_relation_data):
+            logger.warning(
+                f"Provider relation data did not pass JSON Schema validation: "
+                f"{event.relation.data[event.app]}"
+            )
+            return
+        requirer_csrs = [
+            certificate_creation_request["certificate_signing_request"]
+            for certificate_creation_request in self._requirer_csrs
+        ]
+        for certificate in self._provider_certificates:
+            if certificate["certificate_signing_request"] in requirer_csrs:
+                self.on.certificate_available.emit(
+                    certificate_signing_request=certificate["certificate_signing_request"],
+                    certificate=certificate["certificate"],
+                    ca=certificate["ca"],
+                    chain=certificate["chain"],
+                )
+
+    def _on_update_status(self, event: UpdateStatusEvent) -> None:
+        """Triggered on update status event.
+
+        Goes through each certificate in the "certificates" relation and checks their expiry date.
+        If they are close to expire (<7 days), emits a CertificateExpiringEvent event and if
+        they are expired, emits a CertificateExpiredEvent.
+
+        Args:
+            event (UpdateStatusEvent): Juju event
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(self.relationship_name)
+        if not relation:
+            logger.warning(f"No relation: {self.relationship_name}")
+            return
+        if not relation.app:
+            logger.warning(f"No remote app in relation: {self.relationship_name}")
+            return
+        provider_relation_data = _load_relation_data(relation.data[relation.app])
+        if not self._relation_data_is_valid(provider_relation_data):
+            logger.warning(
+                f"Provider relation data did not pass JSON Schema validation: "
+                f"{relation.data[relation.app]}"
+            )
+            return
+        for certificate_dict in self._provider_certificates:
+            certificate = certificate_dict["certificate"]
+            try:
+                certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
+            except ValueError:
+                logger.warning("Could not load certificate.")
+                continue
+            time_difference = certificate_object.not_valid_after - datetime.utcnow()
+            if time_difference.total_seconds() < 0:
+                logger.warning("Certificate is expired")
+                self.on.certificate_expired.emit(certificate=certificate)
+                self.request_certificate_revocation(certificate.encode())
+                continue
+            if time_difference.total_seconds() < (self.expiry_notification_time * 60 * 60):
+                logger.warning("Certificate almost expired")
+                self.on.certificate_expiring.emit(
+                    certificate=certificate, expiry=certificate_object.not_valid_after.isoformat()
+                )

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,6 +30,8 @@ resources:
 peers:
   database-peers:
     interface: mysql-peers
+  restart:
+    interface: rolling_op
 storage:
   database:
     type: filesystem
@@ -41,5 +43,9 @@ provides:
     interface: mysql_client
   osm-mysql:
     interface: mysql
+requires:
+  certificates:
+    interface: tls-certificates
+    limit: 1
 assumes:
   - k8s-api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ target-version = ["py38"]
 
 [tool.isort]
 profile = "black"
+known_third_party = "mysql.connector"
 
 # Linting tools configuration
 [tool.flake8]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ asyncio_mode = "auto"
 markers = [
     "charm_tests",
     "database_tests",
+    "tls_tests",
 ]
 
 # Formatting tools configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+cryptography==38.0.2
+jsonschema==4.16.0
 ops >= 1.5.2
 tenacity==8.0.1
+

--- a/src/charm.py
+++ b/src/charm.py
@@ -302,7 +302,7 @@ class MySQLOperatorCharm(CharmBase):
                 logger.debug("Cluster configured on unit")
                 # Create control file in data directory
                 container.push(CONFIGURED_FILE, make_dirs=True, source="configured")
-                self._peers.data[self.app]["units-added-to-cluster"] = "1"
+                self.peers.data[self.app]["units-added-to-cluster"] = "1"
                 self.unit.status = ActiveStatus()
             except MySQLCreateClusterError as e:
                 self.unit.status = BlockedStatus("Unable to create cluster")

--- a/src/charm.py
+++ b/src/charm.py
@@ -14,6 +14,7 @@ from charms.mysql.v0.mysql import (
     MySQLCreateClusterError,
     MySQLGetMySQLVersionError,
 )
+from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -25,6 +26,7 @@ from ops.charm import (
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.pebble import Layer
+from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
 from constants import (
     CLUSTER_ADMIN_PASSWORD_KEY,
@@ -48,6 +50,7 @@ from mysqlsh_helpers import (
 )
 from relations.database import DatabaseRelation
 from relations.mysql import MySQLRelation
+from relations.mysql_tls import MySQLTLS
 from relations.osm_mysql import MySQLOSMRelation
 from utils import generate_random_hash, generate_random_password
 
@@ -77,44 +80,48 @@ class MySQLOperatorCharm(CharmBase):
         self.mysql_relation = MySQLRelation(self)
         self.database_relation = DatabaseRelation(self)
         self.osm_mysql_relation = MySQLOSMRelation(self)
+        self.tls = MySQLTLS(self)
+        self.restart_manager = RollingOpsManager(
+            charm=self, relation="restart", callback=self._restart
+        )
 
     @property
-    def _peers(self):
+    def peers(self):
         """Retrieve the peer relation (`ops.model.Relation`)."""
         return self.model.get_relation(PEER)
 
     @property
     def _mysql(self):
         """Returns an instance of the MySQL object from mysqlsh_helpers."""
-        peer_data = self._peers.data[self.app]
+        peer_data = self.peers.data[self.app]
 
         return MySQL(
-            self._get_unit_fqdn(self.unit.name),
+            self.get_unit_hostname(self.unit.name),
             peer_data["cluster-name"],
-            self._get_secret("app", ROOT_PASSWORD_KEY),
+            self.get_secret("app", ROOT_PASSWORD_KEY),
             SERVER_CONFIG_USERNAME,
-            self._get_secret("app", SERVER_CONFIG_PASSWORD_KEY),
+            self.get_secret("app", SERVER_CONFIG_PASSWORD_KEY),
             CLUSTER_ADMIN_USERNAME,
-            self._get_secret("app", CLUSTER_ADMIN_PASSWORD_KEY),
+            self.get_secret("app", CLUSTER_ADMIN_PASSWORD_KEY),
             self.unit.get_container("mysql"),
         )
 
     @property
     def _is_peer_data_set(self):
-        peer_data = self._peers.data[self.app]
+        peer_data = self.peers.data[self.app]
 
         return (
             peer_data.get("cluster-name")
-            and self._get_secret("app", ROOT_PASSWORD_KEY)
-            and self._get_secret("app", SERVER_CONFIG_PASSWORD_KEY)
-            and self._get_secret("app", CLUSTER_ADMIN_PASSWORD_KEY)
+            and self.get_secret("app", ROOT_PASSWORD_KEY)
+            and self.get_secret("app", SERVER_CONFIG_PASSWORD_KEY)
+            and self.get_secret("app", CLUSTER_ADMIN_PASSWORD_KEY)
             and peer_data.get("allowlist")
         )
 
     @property
     def cluster_initialized(self):
         """Returns True if the cluster is initialized."""
-        return self._peers.data[self.app].get("units-added-to-cluster", "0") >= "1"
+        return self.peers.data[self.app].get("units-added-to-cluster", "0") >= "1"
 
     @property
     def _pebble_layer(self) -> Layer:
@@ -136,7 +143,7 @@ class MySQLOperatorCharm(CharmBase):
             }
         )
 
-    def _get_unit_hostname(self, unit_name: str) -> str:
+    def get_unit_hostname(self, unit_name: str) -> str:
         """Get the hostname.localdomain for a unit.
 
         Translate juju unit name to hostname.localdomain, necessary
@@ -159,7 +166,7 @@ class MySQLOperatorCharm(CharmBase):
         Returns:
             A string representing the fqdn of the unit.
         """
-        return f"{self._get_unit_hostname(unit_name)}.{self.model.name}.svc.cluster.local"
+        return f"{self.get_unit_hostname(unit_name)}.{self.model.name}.svc.cluster.local"
 
     # =========================================================================
     # Charm event handlers
@@ -172,7 +179,7 @@ class MySQLOperatorCharm(CharmBase):
             return
 
         # Set the cluster name in the peer relation databag if it is not already set
-        peer_data = self._peers.data[self.app]
+        peer_data = self.peers.data[self.app]
 
         if not peer_data.get("cluster-name"):
             peer_data["cluster-name"] = (
@@ -198,9 +205,9 @@ class MySQLOperatorCharm(CharmBase):
         ]
 
         for required_password in required_passwords:
-            if not self._get_secret("app", required_password):
+            if not self.get_secret("app", required_password):
                 logger.debug(f"Setting {required_password}")
-                self._set_secret(
+                self.set_secret(
                     "app", required_password, generate_random_password(PASSWORD_LENGTH)
                 )
 
@@ -254,8 +261,9 @@ class MySQLOperatorCharm(CharmBase):
             self._mysql.initialise_mysqld()
 
             # Create custom server config file
+            logger.debug("Create custom config")
             self._mysql.create_custom_config_file(
-                report_host=self._get_unit_hostname(self.unit.name)
+                report_host=self.get_unit_hostname(self.unit.name)
             )
 
             # Add the pebble layer
@@ -291,6 +299,7 @@ class MySQLOperatorCharm(CharmBase):
                 # Create the cluster when is the leader unit
                 unit_label = self.unit.name.replace("/", "-")
                 self._mysql.create_cluster(unit_label)
+                logger.debug("Cluster configured on unit")
                 # Create control file in data directory
                 container.push(CONFIGURED_FILE, make_dirs=True, source="configured")
                 self._peers.data[self.app]["units-added-to-cluster"] = "1"
@@ -339,8 +348,8 @@ class MySQLOperatorCharm(CharmBase):
             # Update 'units-added-to-cluster' counter in the peer relation databag
             # in order to trigger a relation_changed event which will move the added unit
             # into ActiveStatus
-            units_started = int(self._peers.data[self.app]["units-added-to-cluster"])
-            self._peers.data[self.app]["units-added-to-cluster"] = str(units_started + 1)
+            units_started = int(self.peers.data[self.app]["units-added-to-cluster"])
+            self.peers.data[self.app]["units-added-to-cluster"] = str(units_started + 1)
 
         except MySQLAddInstanceToClusterError:
             logger.debug(f"Unable to add instance {new_instance_fqdn} to cluster.")
@@ -402,7 +411,7 @@ class MySQLOperatorCharm(CharmBase):
         else:
             raise RuntimeError("Invalid username.")
 
-        event.set_results({"username": username, "password": self._get_secret("app", secret_key)})
+        event.set_results({"username": username, "password": self.get_secret("app", secret_key)})
 
     def _on_set_password(self, event: ActionEvent) -> None:
         """Action used to update/rotate the system user's password."""
@@ -427,7 +436,7 @@ class MySQLOperatorCharm(CharmBase):
 
         self._mysql.update_user_password(username, new_password)
 
-        self._set_secret("app", secret_key, new_password)
+        self.set_secret("app", secret_key, new_password)
 
     def _get_cluster_status(self, event: ActionEvent) -> None:
         """Get the cluster status without topology."""
@@ -436,20 +445,20 @@ class MySQLOperatorCharm(CharmBase):
     @property
     def app_peer_data(self) -> Dict:
         """Application peer relation data object."""
-        if self._peers is None:
+        if self.peers is None:
             return {}
 
-        return self._peers.data[self.app]
+        return self.peers.data[self.app]
 
     @property
     def unit_peer_data(self) -> Dict:
         """Unit peer relation data object."""
-        if self._peers is None:
+        if self.peers is None:
             return {}
 
-        return self._peers.data[self.unit]
+        return self.peers.data[self.unit]
 
-    def _get_secret(self, scope: str, key: str) -> Optional[str]:
+    def get_secret(self, scope: str, key: str) -> Optional[str]:
         """Get secret from the secret storage."""
         if scope == "unit":
             return self.unit_peer_data.get(key, None)
@@ -458,7 +467,7 @@ class MySQLOperatorCharm(CharmBase):
         else:
             raise RuntimeError("Unknown secret scope.")
 
-    def _set_secret(self, scope: str, key: str, value: Optional[str]) -> None:
+    def set_secret(self, scope: str, key: str, value: Optional[str]) -> None:
         """Set secret in the secret storage."""
         if scope == "unit":
             if not value:
@@ -472,6 +481,32 @@ class MySQLOperatorCharm(CharmBase):
             self.app_peer_data.update({key: value})
         else:
             raise RuntimeError("Unknown secret scope.")
+
+    def _restart(self, _) -> None:
+        """Restart server rolling ops callback function.
+
+        Hold execution until server is back in the cluster.
+        Used exclusively for rolling restarts.
+        """
+        logger.debug("Restarting mysqld daemon")
+
+        container = self.unit.get_container("mysql")
+        container.restart(MYSQLD_SERVICE)
+
+        unit_label = self.unit.name.replace("/", "-")
+
+        try:
+            for attempt in Retrying(stop=stop_after_attempt(24), wait=wait_fixed(5)):
+                with attempt:
+                    if self._mysql.is_instance_in_cluster(unit_label):
+                        # TODO: update status setting to set message with
+                        # `self.active_status_message` once it gets merged
+                        self.unit.status = ActiveStatus()
+                        return
+                    raise Exception
+        except RetryError:
+            logger.error("Unable to rejoin mysqld instance to the cluster.")
+            self.unit.status = BlockedStatus("Restarted node unable to rejoin the cluster")
 
 
 if __name__ == "__main__":

--- a/src/constants.py
+++ b/src/constants.py
@@ -17,3 +17,7 @@ ROOT_PASSWORD_KEY = "root-password"
 SERVER_CONFIG_PASSWORD_KEY = "server-config-password"
 CLUSTER_ADMIN_PASSWORD_KEY = "cluster-admin-password"
 REQUIRED_USERNAMES = [ROOT_USERNAME, SERVER_CONFIG_USERNAME, CLUSTER_ADMIN_USERNAME]
+TLS_RELATION = "certificates"
+TLS_SSL_CA_FILE = "custom-ca.pem"
+TLS_SSL_KEY_FILE = "custom-server-key.pem"
+TLS_SSL_CERT_FILE = "custom-server-cert.pem"

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -32,6 +32,9 @@ logger = logging.getLogger(__name__)
 MYSQLD_SOCK_FILE = "/var/run/mysqld/mysqld.sock"
 MYSQLSH_SCRIPT_FILE = "/tmp/script.py"
 MYSQLD_CONFIG_FILE = "/etc/mysql/conf.d/z-report-host-custom.cnf"
+MYSQL_SYSTEM_USER = "mysql"
+MYSQL_DATA_DIR = "/var/lib/mysql"
+MYSQLD_CONFIG_DIRECTORY = "/etc/mysql/conf.d"
 
 
 class MySQLInitialiseMySQLDError(Exception):
@@ -552,3 +555,30 @@ class MySQL(MySQLBase):
             return stdout
         except ExecError as e:
             raise MySQLClientError(e.stderr)
+
+    def write_content_to_file(
+        self,
+        path: str,
+        content: str,
+        owner: str = MYSQL_SYSTEM_USER,
+        group: str = MYSQL_SYSTEM_USER,
+        permission: int = 0o640,
+    ) -> None:
+        """Write content to file.
+
+        Args:
+            path: filesystem full path (with filename)
+            content: string content to write
+            owner: file owner
+            group: file group
+            permission: file permission
+        """
+        self.container.push(path, content, permissions=permission, user=owner, group=group)
+
+    def remove_file(self, path: str) -> None:
+        """Remove a file from container workload.
+
+        Args:
+            path: Full filesystem path to remove
+        """
+        self.container.remove_path(path)

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -46,7 +46,7 @@ class MySQLRelation(Object):
         Returns:
             a string representing the password for the mysql user
         """
-        peer_databag = self.charm._peers.data[self.charm.app]
+        peer_databag = self.charm.peers.data[self.charm.app]
 
         if peer_databag.get(f"{username}_password"):
             return peer_databag.get(f"{username}_password")
@@ -67,7 +67,7 @@ class MySQLRelation(Object):
             return
 
         relation_data = json.loads(
-            self.charm._peers.data[self.charm.app].get("mysql_relation_data", "{}")
+            self.charm.peers.data[self.charm.app].get("mysql_relation_data", "{}")
         )
 
         for relation in self.charm.model.relations.get(LEGACY_MYSQL, []):
@@ -152,14 +152,14 @@ class MySQLRelation(Object):
             "host": primary_address.split(":")[0],
             "password": password,
             "port": "3306",
-            "root_password": self.charm._peers.data[self.charm.app]["root-password"],
+            "root_password": self.charm.peers.data[self.charm.app]["root-password"],
             "user": username,
         }
 
         event.relation.data[self.charm.unit].update(updates)
 
         # Store the relation data into the peer relation databag
-        self.charm._peers.data[self.charm.app]["mysql_relation_data"] = json.dumps(updates)
+        self.charm.peers.data[self.charm.app]["mysql_relation_data"] = json.dumps(updates)
 
     def _on_mysql_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handle the 'mysql' legacy relation broken event.

--- a/src/relations/mysql_tls.py
+++ b/src/relations/mysql_tls.py
@@ -1,0 +1,229 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library containing the implementation of the tls certificates relation."""
+
+
+import base64
+import logging
+import re
+import socket
+from string import Template
+from typing import List, Optional, Tuple
+
+from charms.tls_certificates_interface.v1.tls_certificates import (
+    CertificateAvailableEvent,
+    CertificateExpiringEvent,
+    TLSCertificatesRequiresV1,
+    generate_csr,
+    generate_private_key,
+)
+from ops.charm import ActionEvent, CharmBase
+from ops.framework import Object
+from ops.model import MaintenanceStatus
+
+from constants import TLS_RELATION, TLS_SSL_CA_FILE, TLS_SSL_CERT_FILE, TLS_SSL_KEY_FILE
+from mysqlsh_helpers import MYSQL_DATA_DIR, MYSQLD_CONFIG_DIRECTORY
+
+logger = logging.getLogger(__name__)
+
+SCOPE = "unit"
+
+
+class MySQLTLS(Object):
+    """MySQL TLS Provider class."""
+
+    def __init__(self, charm: CharmBase):
+        super().__init__(charm, "certificates")
+        self.charm = charm
+
+        self.certs = TLSCertificatesRequiresV1(self.charm, TLS_RELATION)
+
+        self.framework.observe(
+            self.charm.on.set_tls_private_key_action,
+            self._on_set_tls_private_key,
+        )
+        self.framework.observe(
+            self.charm.on[TLS_RELATION].relation_joined, self._on_tls_relation_joined
+        )
+        self.framework.observe(
+            self.charm.on[TLS_RELATION].relation_broken, self._on_tls_relation_broken
+        )
+
+        self.framework.observe(self.certs.on.certificate_available, self._on_certificate_available)
+        self.framework.observe(self.certs.on.certificate_expiring, self._on_certificate_expiring)
+
+    # =======================
+    #  Event Handlers
+    # =======================
+    def _on_set_tls_private_key(self, event: ActionEvent) -> None:
+        """Action for setting a TLS private key."""
+        self._request_certificate(event.params.get("internal-key", None))
+
+    def _on_tls_relation_joined(self, _) -> None:
+        """Request certificate when TLS relation joined."""
+        self._request_certificate(None)
+
+    def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
+        """Enable TLS when TLS certificate available."""
+        if (
+            event.certificate_signing_request.strip()
+            != self.charm.get_secret(SCOPE, "csr").strip()
+        ):
+            logger.error("An unknown certificate expiring.")
+            return
+
+        self.charm.unit.status = MaintenanceStatus("Setting up TLS")
+
+        self.charm.set_secret(
+            SCOPE, "chain", "\n".join(event.chain) if event.chain is not None else None
+        )
+        self.charm.set_secret(SCOPE, "cert", event.certificate)
+        self.charm.set_secret(SCOPE, "ca", event.ca)
+
+        self.push_tls_files_to_workload()
+        self.create_tls_config_file()
+
+        # set member-state to avoid unwanted health-check actions
+        self.charm.unit_peer_data["member-state"] = "waiting"
+        # trigger rolling restart
+        self.charm.on[self.charm.restart_manager.name].acquire_lock.emit()
+
+    def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
+        """Request the new certificate when old certificate is expiring."""
+        if event.certificate != self.charm.get_secret(SCOPE, "cert"):
+            logger.error("An unknown certificate expiring.")
+            return
+
+        key = self.charm.get_secret(SCOPE, "key").encode("utf-8")
+        old_csr = self.charm.get_secret(SCOPE, "csr").encode("utf-8")
+        new_csr = generate_csr(
+            private_key=key,
+            subject=self.charm.get_unit_hostname(self.charm.unit.name),
+            organization=self.charm.app.name,
+            sans=self._get_sans(),
+        )
+        self.certs.request_certificate_renewal(
+            old_certificate_signing_request=old_csr,
+            new_certificate_signing_request=new_csr,
+        )
+        self.charm.set_secret(SCOPE, "csr", new_csr.decode("utf-8"))
+
+    def _on_tls_relation_broken(self, _) -> None:
+        """Disable TLS when TLS relation broken."""
+        self.charm.set_secret(SCOPE, "ca", None)
+        self.charm.set_secret(SCOPE, "cert", None)
+        self.charm.set_secret(SCOPE, "chain", None)
+        self.remove_tls_config_file()
+        # set member-state to avoid unwanted health-check actions
+        self.charm.unit_peer_data["member-state"] = "waiting"
+        # trigger rolling restart
+        self.charm.on[self.charm.restart_manager.name].acquire_lock.emit()
+
+    # =======================
+    #  Helpers
+    # =======================
+    def _request_certificate(self, param: Optional[str]):
+        """Request a certificate to TLS Certificates Operator."""
+        if param is None:
+            key = generate_private_key()
+        else:
+            key = self._parse_tls_file(param)
+
+        csr = generate_csr(
+            private_key=key,
+            subject=self.charm.get_unit_hostname(self.charm.unit.name),
+            organization=self.charm.app.name,
+            sans=self._get_sans(),
+        )
+
+        # store secrets
+        self.charm.set_secret(SCOPE, "key", key.decode("utf-8"))
+        self.charm.set_secret(SCOPE, "csr", csr.decode("utf-8"))
+
+        if self.charm.model.get_relation(TLS_RELATION):
+            self.certs.request_certificate_creation(certificate_signing_request=csr)
+
+    @staticmethod
+    def _parse_tls_file(raw_content: str) -> bytes:
+        """Parse TLS files from both plain text or base64 format."""
+        if re.match(r"(-+(BEGIN|END) [A-Z ]+-+)", raw_content):
+            return re.sub(
+                r"(-+(BEGIN|END) [A-Z ]+-+)",
+                "\n\\1\n",
+                raw_content,
+            ).encode("utf-8")
+        return base64.b64decode(raw_content)
+
+    def _get_sans(self) -> List[str]:
+        """Create a list of DNS names for a unit.
+
+        Returns:
+            A list representing the hostnames of the unit.
+        """
+        unit_id = self.charm.unit.name.split("/")[1]
+        return [
+            f"{self.charm.app.name}-{unit_id}",
+            socket.getfqdn(),
+            str(self.charm.model.get_binding(self.charm.peers).network.bind_address),
+        ]
+
+    def get_tls_content(self) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        """Retrieve TLS content.
+
+        Return TLS files as required by mysql.
+
+        Returns:
+            A tuple of strings with the content of server-key, ca and server-cert
+        """
+        ca = self.charm.get_secret(SCOPE, "ca")
+        chain = self.charm.get_secret(SCOPE, "chain")
+        ca_file = chain or ca
+
+        key = self.charm.get_secret(SCOPE, "key")
+        cert = self.charm.get_secret(SCOPE, "cert")
+        return key, ca_file, cert
+
+    def push_tls_files_to_workload(self) -> None:
+        """Push TLS files to unit."""
+        ssl_key, ssl_ca, ssl_cert = self.get_tls_content()
+
+        if ssl_key:
+            self.charm._mysql.write_content_to_file(
+                f"{MYSQL_DATA_DIR}/{TLS_SSL_KEY_FILE}", ssl_key, permission=0o400
+            )
+
+        if ssl_ca:
+            self.charm._mysql.write_content_to_file(
+                f"{MYSQL_DATA_DIR}/{TLS_SSL_CA_FILE}", ssl_ca, permission=0o400
+            )
+
+        if ssl_cert:
+            self.charm._mysql.write_content_to_file(
+                f"{MYSQL_DATA_DIR}/{TLS_SSL_CERT_FILE}", ssl_cert, permission=0o400
+            )
+
+    def create_tls_config_file(self) -> None:
+        """Render TLS template directly to file.
+
+        Render and write TLS enabling config file from template.
+        """
+        with open("templates/tls.cnf", "r") as template_file:
+            template = Template(template_file.read())
+            config_string = template.substitute(
+                tls_ssl_ca_file=TLS_SSL_CA_FILE,
+                tls_ssl_key_file=TLS_SSL_KEY_FILE,
+                tls_ssl_cert_file=TLS_SSL_CERT_FILE,
+            )
+
+        self.charm._mysql.write_content_to_file(
+            f"{MYSQLD_CONFIG_DIRECTORY}/z-custom-tls.cnf",
+            config_string,
+            owner="root",
+            group="root",
+            permission=0o644,
+        )
+
+    def remove_tls_config_file(self) -> None:
+        """Remove TLS configuration file."""
+        self.charm._mysql.remove_file(f"{MYSQLD_CONFIG_DIRECTORY}/z-custom-tls.cnf")

--- a/src/relations/osm_mysql.py
+++ b/src/relations/osm_mysql.py
@@ -50,7 +50,7 @@ class MySQLOSMRelation(Object):
         Returns:
             a string representing the password for the mysql user
         """
-        peer_databag = self.charm._peers.data[self.charm.app]
+        peer_databag = self.charm.peers.data[self.charm.app]
 
         if peer_databag.get(f"{username}_password"):
             return peer_databag.get(f"{username}_password")
@@ -71,7 +71,7 @@ class MySQLOSMRelation(Object):
             return
 
         relation_data = json.loads(
-            self.charm._peers.data[self.charm.app].get("osm_mysql_relation_data", "{}")
+            self.charm.peers.data[self.charm.app].get("osm_mysql_relation_data", "{}")
         )
 
         for relation in self.charm.model.relations.get(LEGACY_OSM_MYSQL, []):
@@ -128,7 +128,7 @@ class MySQLOSMRelation(Object):
 
         # Only execute if the application user does not exist
         if user_exists:
-            osm_mysql_relation_data = self.charm._peers.data[self.charm.app][
+            osm_mysql_relation_data = self.charm.peers.data[self.charm.app][
                 "osm_mysql_relation_data"
             ]
 
@@ -159,14 +159,14 @@ class MySQLOSMRelation(Object):
             "host": primary_address.split(":")[0],
             "password": password,
             "port": "3306",
-            "root_password": self.charm._peers.data[self.charm.app]["root-password"],
+            "root_password": self.charm.peers.data[self.charm.app]["root-password"],
             "user": username,
         }
 
         event.relation.data[self.charm.unit].update(updates)
 
         # Store the relation data into the peer relation databag
-        self.charm._peers.data[self.charm.app]["osm_mysql_relation_data"] = json.dumps(updates)
+        self.charm.peers.data[self.charm.app]["osm_mysql_relation_data"] = json.dumps(updates)
 
     def _on_osm_mysql_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handle the 'mysql' legacy relation broken event.

--- a/templates/tls.cnf
+++ b/templates/tls.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+ssl_ca = "$tls_ssl_ca_file"
+ssl_cert = "$tls_ssl_cert_file"
+ssl_key = "$tls_ssl_key_file"
+group_replication_ssl_mode = VERIFY_CA
+group_replication_recovery_use_ssl = ON
+require_secure_transport = ON

--- a/tests/integration/connector.py
+++ b/tests/integration/connector.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import mysql.connector
+
+
+class MysqlConnector:
+    """Context manager for mysql connector."""
+
+    def __init__(self, config: dict, commit: bool = True):
+        """Initialize the context manager.
+
+        Args:
+            config: Configuration dict for the mysql connector, like:
+                config = {
+                    "user": user,
+                    "password": remote_data["password"],
+                    "host": host,
+                    "database": database,
+                    "raise_on_warnings": False,
+                }
+            commit: Commit the transaction after the context is exited.
+        """
+        self.config = config
+        self.commit = commit
+
+    def __enter__(self):
+        """Create the connection and return a cursor."""
+        self.connection = mysql.connector.connect(**self.config)
+        self.cursor = self.connection.cursor()
+        return self.cursor
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Handle transaction and connection close."""
+        if self.commit:
+            self.connection.commit()
+        self.cursor.close()
+        self.connection.close()

--- a/tests/integration/connector.py
+++ b/tests/integration/connector.py
@@ -6,7 +6,7 @@
 import mysql.connector
 
 
-class MysqlConnector:
+class MySQLConnector:
     """Context manager for mysql connector."""
 
     def __init__(self, config: dict, commit: bool = True):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -9,7 +9,7 @@ from typing import Dict, List
 
 import mysql.connector
 import yaml
-from connector import MysqlConnector
+from connector import MySQLConnector
 from juju.unit import Unit
 from mysql.connector.errors import (
     DatabaseError,
@@ -282,7 +282,7 @@ def is_connection_possible(credentials: Dict, **extra_opts) -> bool:
     }
 
     try:
-        with MysqlConnector(config) as cursor:
+        with MySQLConnector(config) as cursor:
             cursor.execute("SELECT 1")
             return cursor.fetchone()[0] == 1
     except (DatabaseError, InterfaceError, OperationalError, ProgrammingError):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -5,10 +5,10 @@ import itertools
 import json
 import secrets
 import string
-import yaml
 from typing import Dict, List
 
 import mysql.connector
+import yaml
 from connector import MysqlConnector
 from juju.unit import Unit
 from mysql.connector.errors import (

--- a/tests/integration/relations/application-charm/src/charm.py
+++ b/tests/integration/relations/application-charm/src/charm.py
@@ -16,7 +16,7 @@ from charms.data_platform_libs.v0.database_requires import (
     DatabaseEndpointsChangedEvent,
     DatabaseRequires,
 )
-from connector import MysqlConnector
+from connector import MySQLConnector
 from mysql.connector.errors import DatabaseError
 from ops.charm import CharmBase, RelationChangedEvent
 from ops.main import main
@@ -69,7 +69,7 @@ class ApplicationCharm(CharmBase):
             "raise_on_warnings": False,
         }
 
-        with MysqlConnector(config) as cursor:
+        with MySQLConnector(config) as cursor:
             self._create_test_table(cursor)
 
             self._insert_test_data(
@@ -125,7 +125,7 @@ class ApplicationCharm(CharmBase):
         }
 
         # Assert data reads
-        with MysqlConnector(config, commit=False) as cursor:
+        with MySQLConnector(config, commit=False) as cursor:
             rows = self._read_test_data(cursor, remote_relation.id)
             first_row = rows[0]
             # username, password, endpoints, version, ro-endpoints
@@ -138,7 +138,7 @@ class ApplicationCharm(CharmBase):
         logger.info("Relation data replicated in the cluster")
 
         # Assert not data writes
-        with MysqlConnector(config, commit=True) as cursor:
+        with MySQLConnector(config, commit=True) as cursor:
             try:
                 self._insert_test_data(
                     cursor,

--- a/tests/integration/relations/application-charm/src/connector.py
+++ b/tests/integration/relations/application-charm/src/connector.py
@@ -6,7 +6,7 @@
 import mysql.connector
 
 
-class MysqlConnector:
+class MySQLConnector:
     """Context manager for mysql connector."""
 
     def __init__(self, config: dict, commit: bool = True):

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -1,0 +1,226 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+from constants import CLUSTER_ADMIN_USERNAME, TLS_SSL_CERT_FILE
+from tests.integration.helpers import (
+    app_name,
+    get_process_pid,
+    fetch_credentials,
+    get_tls_ca,
+    get_unit_address,
+    is_connection_possible,
+    scale_application,
+    unit_file_md5,
+)
+
+logger = logging.getLogger(__name__)
+
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+TLS_APP_NAME = "tls-certificates-operator"
+
+
+@pytest.mark.order(1)
+@pytest.mark.abort_on_fail
+@pytest.mark.tls_tests
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
+    """Build the charm and deploy 3 units to ensure a cluster is formed."""
+    if app := await app_name(ops_test):
+        if len(ops_test.model.applications[app].units) == 3:
+            return
+        else:
+            async with ops_test.fast_forward():
+                await scale_application(ops_test, app, 3)
+            return
+
+    # Build and deploy charm from local source folder
+    charm = await ops_test.build_charm(".")
+    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+
+    # Reduce the update_status frequency until the cluster is deployed
+    async with ops_test.fast_forward():
+
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[APP_NAME].units) == 3
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+        )
+
+
+@pytest.mark.order(2)
+@pytest.mark.abort_on_fail
+@pytest.mark.tls_tests
+async def test_connection_before_tls(ops_test: OpsTest) -> None:
+    app = await app_name(ops_test)
+    all_units = ops_test.model.applications[app].units
+
+    password_result = await fetch_credentials(all_units[0], CLUSTER_ADMIN_USERNAME)
+    # set global config dict once
+    global config
+    config = {
+        "username": CLUSTER_ADMIN_USERNAME,
+        "password": password_result["password"],
+    }
+
+    # Before relating to TLS charm both encrypted and unencrypted connection should be possible
+    logger.info("Asserting connections before relation")
+    for unit in all_units:
+        unit_ip = await get_unit_address(ops_test, unit.name)
+        config["host"] = unit_ip
+
+        assert is_connection_possible(
+            config, **{"ssl_disabled": False}
+        ), f"❌ Encrypted connection not possible to unit {unit.name} with disabled TLS"
+
+        assert is_connection_possible(
+            config, **{"ssl_disabled": True}
+        ), f"❌ Unencrypted connection not possible to unit {unit.name} with disabled TLS"
+
+
+@pytest.mark.order(3)
+@pytest.mark.abort_on_fail
+@pytest.mark.tls_tests
+async def test_enable_tls(ops_test: OpsTest) -> None:
+    """Test for encryption enablement when relation to TLS charm."""
+    app = await app_name(ops_test)
+    all_units = ops_test.model.applications[app].units
+
+    # Deploy TLS Certificates operator.
+    logger.info("Deploy TLS operator")
+    async with ops_test.fast_forward():
+        tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
+        await ops_test.model.deploy(TLS_APP_NAME, channel="edge", config=tls_config)
+        await ops_test.model.wait_for_idle(apps=[TLS_APP_NAME], status="active", timeout=1000)
+
+    # Relate with TLS charm
+    logger.info("Relate to TLS operator")
+    await ops_test.model.relate(app, TLS_APP_NAME)
+
+    # Wait for hooks start reconfiguring app
+    await ops_test.model.block_until(
+        lambda: ops_test.model.applications[app].status != "active", timeout=200
+    )
+
+    await ops_test.model.wait_for_idle(status="active", timeout=1000)
+
+    # After relating to only encrypted connection should be possible
+    logger.info("Asserting connections after relation")
+    for unit in all_units:
+        unit_ip = await get_unit_address(ops_test, unit.name)
+        config["host"] = unit_ip
+        assert is_connection_possible(
+            config, **{"ssl_disabled": False}
+        ), f"❌ Encrypted connection not possible to unit {unit.name} with enabled TLS"
+
+        assert not is_connection_possible(
+            config, **{"ssl_disabled": True}
+        ), f"❌ Unencrypted connection possible to unit {unit.name} with enabled TLS"
+
+    # test for ca presence in a given unit
+    logger.info("Assert TLS file exists")
+    assert await get_tls_ca(ops_test, all_units[0].name), "❌ No CA found after TLS relation"
+
+
+@pytest.mark.order(4)
+@pytest.mark.abort_on_fail
+@pytest.mark.tls_tests
+async def test_rotate_tls_key(ops_test: OpsTest) -> None:
+    """Verify rotating tls private keys restarts cluster with new certificates.
+
+    This test rotates tls private keys to randomly generated keys.
+    """
+    app = await app_name(ops_test)
+    all_units = ops_test.model.applications[app].units
+    # dict of values for cert file md5sum and mysql service PID. After resetting the
+    # private keys these certificates should be updated and the mysql service should be
+    # restarted
+    original_tls = {}
+    for unit in all_units:
+        original_tls[unit.name] = {}
+        original_tls[unit.name]["cert"] = await unit_file_md5(
+            ops_test, unit.name, f"/var/lib/mysql/{TLS_SSL_CERT_FILE}"
+        )
+        original_tls[unit.name]["mysql_pid"] = await get_process_pid(ops_test, unit.name, "mysqld")
+
+    # set key using auto-generated key for each unit
+    for unit in ops_test.model.applications[app].units:
+        action = await unit.run_action(action_name="set-tls-private-key")
+        action = await action.wait()
+        assert action.status == "completed", "❌ setting key failed"
+
+    # Wait for hooks start reconfiguring app
+    await ops_test.model.block_until(
+        lambda: ops_test.model.applications[app].status != "active", timeout=200
+    )
+    await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=1000)
+
+    # After updating both the external key and the internal key a new certificate request will be
+    # made; then the certificates should be available and updated.
+    for unit in all_units:
+        new_cert_md5 = await unit_file_md5(
+            ops_test, unit.name, f"/var/lib/mysql/{TLS_SSL_CERT_FILE}"
+        )
+        new_mysql_pid = await get_process_pid(ops_test, unit.name, "mysqld")
+
+        assert (
+            new_cert_md5 != original_tls[unit.name]["cert"]
+        ), f"cert for {unit.name} was not updated."
+        assert new_mysql_pid > original_tls[unit.name]["mysql_pid"], "❌ mysqld was not restarted"
+
+    # Asserting only encrypted connection should be possible
+    logger.info("Asserting connections after relation")
+    for unit in all_units:
+        unit_ip = await get_unit_address(ops_test, unit.name)
+        config["host"] = unit_ip
+        assert is_connection_possible(
+            config, **{"ssl_disabled": False}
+        ), f"❌ Encrypted connection not possible to unit {unit.name} with enabled TLS"
+
+        assert not is_connection_possible(
+            config, **{"ssl_disabled": True}
+        ), f"❌ Unencrypted connection possible to unit {unit.name} with enabled TLS"
+
+
+@pytest.mark.order(5)
+@pytest.mark.abort_on_fail
+@pytest.mark.tls_tests
+async def test_disable_tls(ops_test: OpsTest) -> None:
+    # Remove the relation
+    app = await app_name(ops_test)
+    all_units = ops_test.model.applications[app].units
+
+    logger.info("Removing relation")
+    await ops_test.model.applications[app].remove_relation(
+        f"{app}:certificates", f"{TLS_APP_NAME}:certificates"
+    )
+
+    # Wait for hooks start reconfiguring app
+    await ops_test.model.block_until(
+        lambda: ops_test.model.applications[app].status != "active", timeout=200
+    )
+    await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=1000)
+
+    # After relation removal both encrypted and unencrypted connection should be possible
+    for unit in all_units:
+        unit_ip = await get_unit_address(ops_test, unit.name)
+        config["host"] = unit_ip
+        assert is_connection_possible(
+            config, **{"ssl_disabled": False}
+        ), f"❌ Encrypted connection not possible to unit {unit.name} after relation removal"
+
+        assert is_connection_possible(
+            config, **{"ssl_disabled": True}
+        ), f"❌ Unencrypted connection not possible to unit {unit.name} after relation removal"

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -44,7 +44,8 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     # Build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+    resources = {"mysql-image": METADATA["resources"]["mysql-image"]["upstream-source"]}
+    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME, num_units=3)
 
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -12,8 +12,8 @@ from pytest_operator.plugin import OpsTest
 from constants import CLUSTER_ADMIN_USERNAME, TLS_SSL_CERT_FILE
 from tests.integration.helpers import (
     app_name,
-    get_process_pid,
     fetch_credentials,
+    get_process_pid,
     get_tls_ca,
     get_unit_address,
     is_connection_possible,

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -65,6 +65,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 @pytest.mark.abort_on_fail
 @pytest.mark.tls_tests
 async def test_connection_before_tls(ops_test: OpsTest) -> None:
+    """Ensure connections (with and without ssl) are possible before relating with TLS operator."""
     app = await app_name(ops_test)
     all_units = ops_test.model.applications[app].units
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -56,7 +56,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
             apps=[APP_NAME],
             status="active",
             raise_on_blocked=True,
-            timeout=1000,
+            timeout=15 * 60,
         )
 
 
@@ -103,7 +103,7 @@ async def test_enable_tls(ops_test: OpsTest) -> None:
     async with ops_test.fast_forward():
         tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
         await ops_test.model.deploy(TLS_APP_NAME, channel="edge", config=tls_config)
-        await ops_test.model.wait_for_idle(apps=[TLS_APP_NAME], status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(apps=[TLS_APP_NAME], status="active", timeout=15 * 60)
 
     # Relate with TLS charm
     logger.info("Relate to TLS operator")
@@ -111,10 +111,10 @@ async def test_enable_tls(ops_test: OpsTest) -> None:
 
     # Wait for hooks start reconfiguring app
     await ops_test.model.block_until(
-        lambda: ops_test.model.applications[app].status != "active", timeout=200
+        lambda: ops_test.model.applications[app].status != "active", timeout=4 * 60
     )
 
-    await ops_test.model.wait_for_idle(status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(status="active", timeout=15 * 60)
 
     # After relating to only encrypted connection should be possible
     logger.info("Asserting connections after relation")
@@ -163,9 +163,9 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
 
     # Wait for hooks start reconfiguring app
     await ops_test.model.block_until(
-        lambda: ops_test.model.applications[app].status != "active", timeout=200
+        lambda: ops_test.model.applications[app].status != "active", timeout=4 * 60
     )
-    await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=15 * 60)
 
     # After updating both the external key and the internal key a new certificate request will be
     # made; then the certificates should be available and updated.
@@ -209,9 +209,9 @@ async def test_disable_tls(ops_test: OpsTest) -> None:
 
     # Wait for hooks start reconfiguring app
     await ops_test.model.block_until(
-        lambda: ops_test.model.applications[app].status != "active", timeout=200
+        lambda: ops_test.model.applications[app].status != "active", timeout=4 * 60
     )
-    await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=15 * 60)
 
     # After relation removal both encrypted and unencrypted connection should be possible
     for unit in all_units:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -118,12 +118,12 @@ class TestCharm(unittest.TestCase):
 
     def test_on_config_changed(self):
         # Test config changed set of cluster name
-        self.assertEqual(self.charm._peers.data[self.charm.app].get("cluster-name"), None)
+        self.assertEqual(self.charm.peers.data[self.charm.app].get("cluster-name"), None)
         self.harness.set_leader()
         self.charm.on.config_changed.emit()
         # Cluster name is `cluster-<hash>`
         self.assertNotEqual(
-            self.charm._peers.data[self.charm.app]["cluster-name"], "not_valid_cluster_name"
+            self.charm.peers.data[self.charm.app]["cluster-name"], "not_valid_cluster_name"
         )
 
     def test_mysql_property(self):
@@ -168,18 +168,18 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader()
 
         # Test application scope.
-        assert self.charm._get_secret("app", "password") is None
+        assert self.charm.get_secret("app", "password") is None
         self.harness.update_relation_data(
             self.peer_relation_id, self.charm.app.name, {"password": "test-password"}
         )
-        assert self.charm._get_secret("app", "password") == "test-password"
+        assert self.charm.get_secret("app", "password") == "test-password"
 
         # Test unit scope.
-        assert self.charm._get_secret("unit", "password") is None
+        assert self.charm.get_secret("unit", "password") is None
         self.harness.update_relation_data(
             self.peer_relation_id, self.charm.unit.name, {"password": "test-password"}
         )
-        assert self.charm._get_secret("unit", "password") == "test-password"
+        assert self.charm.get_secret("unit", "password") == "test-password"
 
     # @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm._on_leader_elected")
@@ -190,7 +190,7 @@ class TestCharm(unittest.TestCase):
         assert "password" not in self.harness.get_relation_data(
             self.peer_relation_id, self.charm.app.name
         )
-        self.charm._set_secret("app", "password", "test-password")
+        self.charm.set_secret("app", "password", "test-password")
         assert (
             self.harness.get_relation_data(self.peer_relation_id, self.charm.app.name)["password"]
             == "test-password"
@@ -200,7 +200,7 @@ class TestCharm(unittest.TestCase):
         assert "password" not in self.harness.get_relation_data(
             self.peer_relation_id, self.charm.unit.name
         )
-        self.charm._set_secret("unit", "password", "test-password")
+        self.charm.set_secret("unit", "password", "test-password")
         assert (
             self.harness.get_relation_data(self.peer_relation_id, self.charm.unit.name)["password"]
             == "test-password"

--- a/tox.ini
+++ b/tox.ini
@@ -101,3 +101,16 @@ deps =
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "osm_mysql_tests"
 
+[testenv:integration-tls]
+description = Run TLS tests
+deps =
+    juju==2.9.11 # juju 3.3.0 has issues with retrieving action results
+    mysql-connector-python
+    pdbpp
+    pytest
+    pytest-operator
+    pytest-order
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "tls_tests"
+


### PR DESCRIPTION
# Issue

TLS support for MySQL k8s charm.
Ref. tasks:
[DPE-641](https://warthogs.atlassian.net/browse/DPE-641), [DPE-643](https://warthogs.atlassian.net/browse/DPE-643), [DPE-644](https://warthogs.atlassian.net/browse/DPE-644) and [DPE-645](https://warthogs.atlassian.net/browse/DPE-645)


# Solution

This is the port of pretty much the same codebase from MySQL VM [PR48](https://github.com/canonical/mysql-operator/pull/48) that's already approved. The main differences are:
* included integration tests
* modifications to work under k8s

# Testing

Tests implemented as integration test at `tests/integration/test_tls.py`

# Release Notes

*quick math: it looks big to the incautious eyes at +2382-39 lines, but ignoring new libs being added/updated it's only +770 lines, so fear not*

**Important changes**:
* `actions.yaml` - TLS action
* `src/charm.py` - rollings ops support, TLS instatiation
* `src/mysqlsh_helpers.py` - extra methods to manage container files
* `src/relations/mysql_tls.py` - tls implementation
* `tests/integration/helpers.py` - itest helpers
* `tests/integration/test_tls.py` - itest for tls



