### PR TITLE
Upgrade charming actions to v2.1.0 to resolve upload to charmhub issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,10 +37,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.0.0-rc2
+        uses: canonical/charming-actions/channel@2.1.0
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.0.0-rc2
+        uses: canonical/charming-actions/upload-charm@2.1.0
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Issue
Release to charmhub action is [failing](https://github.com/canonical/mysql-k8s-operator/actions/runs/3256480064/jobs/5347273232#step:4:63) due to a change in the way resources are uploaded to charmhub.

# Solution
Upgrade the charming action to v2.1.0 which should resolve the issue

# Release Notes
Upgrade charming actions to v2.1.0 to resolve upload to charmhub issue
