### PR TITLE
Bump action to fix charm release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.0.0-rc2
+        uses: canonical/charming-actions/check-libraries@2.1.1
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -37,11 +37,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.0.0-rc2
+        uses: canonical/charming-actions/channel@2.1.1
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.0.0-rc2
+        uses: canonical/charming-actions/upload-charm@2.1.1
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
+


### PR DESCRIPTION
# Issue

There's an issue on publishing k8s charm when downloading OCI

# Solution

Bumping to the latest version should fix
