### PR TITLE
Fix/first unit restart

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -69,7 +69,7 @@ import json
 import logging
 import re
 from abc import ABC, abstractmethod
-from typing import Iterable, List, Optional, Set, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -83,7 +83,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 
@@ -1075,17 +1075,11 @@ class MySQLBase(ABC):
         # MEMBER_ROLE is empty if member is not in a group
         return results[0], results[1] if len(results) == 2 else "unknown"
 
-    def reboot_from_complete_outage(self, instance_names: Set[str]) -> None:
-        """Wrapper for reboot_cluster_from_complete_outage command.
-
-        Args:
-            instance_names: set of instance names (e.g. `juju-e3f183-4:3306`)
-        """
-        options = {"rejoinInstances": list(instance_names)}
-
+    def reboot_from_complete_outage(self) -> None:
+        """Wrapper for reboot_cluster_from_complete_outage command."""
         rejoin_command = (
             f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-            f"dba.reboot_cluster_from_complete_outage('{self.cluster_name}', {json.dumps(options)} )",
+            f"dba.reboot_cluster_from_complete_outage('{self.cluster_name}')",
         )
 
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -513,6 +513,12 @@ class MySQLOperatorCharm(CharmBase):
         container = self.unit.get_container(CONTAINER_NAME)
         container.restart(MYSQLD_SERVICE)
 
+        # when restart done right after cluster creation (e.g bundles)
+        # or for single unit deployments, it's necessary reboot the
+        # cluster from outage to restore unit as primary
+        if self.app_peer_data["units-added-to-cluster"] == "1":
+            self._mysql.reboot_from_complete_outage()
+
         unit_label = self.unit.name.replace("/", "-")
 
         try:
@@ -523,10 +529,11 @@ class MySQLOperatorCharm(CharmBase):
                         # `self.active_status_message` once it gets merged
                         self.unit.status = ActiveStatus()
                         return
+                    logger.debug("Restarted instance not yet in cluster")
                     raise Exception
         except RetryError:
             logger.error("Unable to rejoin mysqld instance to the cluster.")
-            self.unit.status = BlockedStatus("Restarted node unable to rejoin the cluster")
+            self.unit.status = BlockedStatus("Restarted instance unable to rejoin the cluster")
 
 
 if __name__ == "__main__":

--- a/src/relations/mysql_tls.py
+++ b/src/relations/mysql_tls.py
@@ -18,7 +18,7 @@ from charms.tls_certificates_interface.v1.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
-from ops.charm import ActionEvent, CharmBase, RelationJoinedEvent
+from ops.charm import ActionEvent, CharmBase
 from ops.framework import Object
 from ops.model import MaintenanceStatus
 

--- a/src/relations/mysql_tls.py
+++ b/src/relations/mysql_tls.py
@@ -18,7 +18,7 @@ from charms.tls_certificates_interface.v1.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
-from ops.charm import ActionEvent, CharmBase
+from ops.charm import ActionEvent, CharmBase, RelationJoinedEvent
 from ops.framework import Object
 from ops.model import MaintenanceStatus
 
@@ -66,6 +66,11 @@ class MySQLTLS(Object):
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Enable TLS when TLS certificate available."""
+        if not self.charm.unit_initialized:
+            logger.debug("Wait unit initialise before request certificate.")
+            event.defer()
+            return
+
         if (
             event.certificate_signing_request.strip()
             != self.charm.get_secret(SCOPE, "csr").strip()


### PR DESCRIPTION
# Issue

When restarting mysqld service for a single node cluster (case when rolling restart right after cluster creation that happens in clusters), the node does not set itself as cluster primary.


# Solution

Detect deployment/state as single node cluster and `reboot from outage` when restarting.


# Context

Necessary for bundle with TLS.


# Testing

Manual validation only for now. Test to follow on bundle repo.


# Release Notes

Ignore changes to lib file, bumped only.

