### PR TITLE
Refactor scale down logic to not blindly remove all unreachable instances from the cluster

### DIFF
--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -279,7 +279,15 @@ class MySQL(MySQLBase):
             raise MySQLWaitUntilUnitRemovedFromClusterError()
 
     def force_remove_unit_from_cluster(self, unit_address: str) -> None:
-        """Force removes the provided unit from the cluster."""
+        """Force removes the provided unit from the cluster.
+
+        Args:
+            unit_address: The address of unit to force remove from cluster
+
+        Raises:
+            MySQLForceRemoveUnitFromClusterError - if there was an issue force
+                removing the unit from the cluster
+        """
         cluster_status = self.get_cluster_status()
         if not cluster_status:
             raise MySQLForceRemoveUnitFromClusterError()

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -9,6 +9,7 @@ import logging
 import os
 
 from charms.mysql.v0.mysql import (
+    Error,
     MySQLBase,
     MySQLClientError,
     MySQLConfigureInstanceError,
@@ -34,39 +35,39 @@ from constants import (
 logger = logging.getLogger(__name__)
 
 
-class MySQLInitialiseMySQLDError(Exception):
+class MySQLInitialiseMySQLDError(Error):
     """Exception raised when there is an issue initialising an instance."""
 
 
-class MySQLServiceNotRunningError(Exception):
+class MySQLServiceNotRunningError(Error):
     """Exception raised when the MySQL service is not running."""
 
 
-class MySQLCreateCustomConfigFileError(Exception):
+class MySQLCreateCustomConfigFileError(Error):
     """Exception raised when there is an issue creating custom config file."""
 
 
-class MySQLCreateDatabaseError(Exception):
+class MySQLCreateDatabaseError(Error):
     """Exception raised when there is an issue creating a database."""
 
 
-class MySQLCreateUserError(Exception):
+class MySQLCreateUserError(Error):
     """Exception raised when there is an issue creating a user."""
 
 
-class MySQLEscalateUserPrivilegesError(Exception):
+class MySQLEscalateUserPrivilegesError(Error):
     """Exception raised when there is an issue escalating user privileges."""
 
 
-class MySQLDeleteUsersWithLabelError(Exception):
+class MySQLDeleteUsersWithLabelError(Error):
     """Exception raised when there is an issue deleting users with a label."""
 
 
-class MySQLForceRemoveUnitFromClusterError(Exception):
+class MySQLForceRemoveUnitFromClusterError(Error):
     """Exception raised when there is an issue force removing a unit from the cluster."""
 
 
-class MySQLWaitUntilUnitRemovedFromClusterError(Exception):
+class MySQLWaitUntilUnitRemovedFromClusterError(Error):
     """Exception raised when there is an issue checking if a unit is removed from the cluster."""
 
 
@@ -268,7 +269,7 @@ class MySQL(MySQLBase):
         """
         cluster_status = self.get_cluster_status()
         if not cluster_status:
-            raise MySQLWaitUntilUnitRemovedFromClusterError()
+            raise MySQLWaitUntilUnitRemovedFromClusterError("Unable to get cluster status")
 
         members_in_cluster = [
             member["address"]
@@ -276,7 +277,7 @@ class MySQL(MySQLBase):
         ]
 
         if unit_address in members_in_cluster:
-            raise MySQLWaitUntilUnitRemovedFromClusterError()
+            raise MySQLWaitUntilUnitRemovedFromClusterError("Remove member still in cluster")
 
     def force_remove_unit_from_cluster(self, unit_address: str) -> None:
         """Force removes the provided unit from the cluster.

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -314,6 +314,8 @@ class MySQL(MySQLBase):
                 self._run_mysqlsh_script("\n".join(force_quorum_commands))
 
             self._run_mysqlsh_script("\n".join(remove_instance_commands))
+
+            self._wait_until_unit_removed_from_cluster(unit_address)
         except (
             MySQLClientError,
             MySQLWaitUntilUnitRemovedFromClusterError,

--- a/tests/integration/high_availability/test_replication.py
+++ b/tests/integration/high_availability/test_replication.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 
 import lightkube
 import pytest
@@ -56,6 +57,8 @@ async def test_kill_primary_check_reelection(ops_test: OpsTest, continuous_write
     # kill the primary pod
     client = lightkube.Client()
     client.delete(Pod, primary.name.replace("/", "-"), namespace=ops_test.model.info.name)
+
+    time.sleep(60)
 
     async with ops_test.fast_forward():
         # wait for model to stabilize, k8s will re-create the killed pod

--- a/tests/integration/high_availability/test_replication.py
+++ b/tests/integration/high_availability/test_replication.py
@@ -64,6 +64,7 @@ async def test_kill_primary_check_reelection(ops_test: OpsTest, continuous_write
             status="active",
             raise_on_blocked=True,
             timeout=TIMEOUT,
+            idle_period=30,
         )
 
         # ensure a new primary was elected

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -8,6 +8,7 @@ import pytest
 from helpers import get_primary_unit, get_process_pid
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_delay, wait_fixed
+import time
 
 from tests.integration.high_availability.high_availability_helpers import (
     clean_up_database_and_table,
@@ -60,6 +61,9 @@ async def test_kill_db_process(ops_test: OpsTest, continuous_writes) -> None:
         MYSQLD_PROCESS_NAME,
         "SIGKILL",
     )
+
+    # Wait for the SIGKILL above to take effect before continuining with test checks
+    time.sleep(10)
 
     assert await ensure_n_online_mysql_members(
         ops_test, 3

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -3,12 +3,12 @@
 # See LICENSE file for licensing details.
 
 import logging
+import time
 
 import pytest
 from helpers import get_primary_unit, get_process_pid
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_delay, wait_fixed
-import time
 
 from tests.integration.high_availability.high_availability_helpers import (
     clean_up_database_and_table,

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -5,7 +5,6 @@ import json
 import unittest
 from unittest.mock import MagicMock, call, patch
 
-import tenacity
 from charms.mysql.v0.mysql import (
     MySQLClientError,
     MySQLConfigureInstanceError,
@@ -367,7 +366,7 @@ class TestMySQL(unittest.TestCase):
             (
                 "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
                 "cluster = dba.get_cluster('test_cluster')",
-                "cluster.remove_instance('1.2.3.4', {\"force\": \"true\"})",
+                'cluster.remove_instance(\'1.2.3.4\', {"force": "true"})',
             )
         )
 
@@ -395,7 +394,9 @@ class TestMySQL(unittest.TestCase):
 
     @patch("mysql_k8s_helpers.MySQL.get_cluster_status", return_value=GET_CLUSTER_STATUS_RETURN)
     @patch("mysql_k8s_helpers.MySQL._run_mysqlsh_script")
-    def test_force_remove_unit_from_cluster_exception(self, _run_mysqlsh_script, _get_cluster_status):
+    def test_force_remove_unit_from_cluster_exception(
+        self, _run_mysqlsh_script, _get_cluster_status
+    ):
         """Test exceptions raised when executing force_remove_unit_from_cluster."""
         _get_cluster_status.return_value = None
 


### PR DESCRIPTION
# Issue
Since there is an issue with juju in k8s (where teardown event dont fire), we use `force remove instance` from the cluster to remove scaled down units. However, we are currently (on leader-elected and peer-relation-departed) removing all unreachable instances from the cluster. This is problematic as an instance could be unreachable due to a network partition, but should be able to rejoin the cluster once the partition has been resolved.

# Solution
Only `force remove instance`s that are scaled down. For this, we rely on `planned units` (which returns the number of planned units for an application) and the fact that juju with k8s provisions units in sequence 0, 1, 2,... Thus we will only remove any instance from the cluster whose index is >= planned units.

# Release Notes
Refactor scale down logic to not blindly remove all unreachable instances from the cluster
