### PR TITLE
Register missing pytest custom mark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ asyncio_mode = "auto"
 markers = [
     "charm_tests",
     "database_tests",
+    "osm_mysql_tests",
     "replication_tests",
     "self_healing_tests",
     "tls_tests",


### PR DESCRIPTION
# Issue
pytest warning: unregistered custom mark

tox output:
```
=============================== warnings summary ===============================
tests/integration/relations/test_osm_mysql.py:30
  /home/ubuntu/repos/mysql-k8s-operator/tests/integration/relations/test_osm_mysql.py:30: PytestUnknownMarkWarning: Unknown pytest.mark.osm_mysql_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.osm_mysql_tests

tests/integration/relations/test_osm_mysql.py:139
  /home/ubuntu/repos/mysql-k8s-operator/tests/integration/relations/test_osm_mysql.py:139: PytestUnknownMarkWarning: Unknown pytest.mark.osm_mysql_tests - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.osm_mysql_tests

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```


# Solution
Register custom mark in `pyproject.toml`


# Context
https://docs.pytest.org/en/stable/how-to/capture-warnings.html


# Testing
Check that relevant warnings no longer appear in CI


# Release Notes
Fix integration test warning
