### PR TITLE
DPE-1116 Add shellcheck GH Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,20 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+
   integration-test-microk8s-charm:
     name: Charm integration tests (microk8s)
     needs:
       - lint
       - unit-test
+      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -50,6 +59,7 @@ jobs:
     needs:
       - lint
       - unit-test
+      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -68,6 +78,7 @@ jobs:
     needs:
       - lint
       - unit-test
+      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -86,6 +97,7 @@ jobs:
     needs:
       - lint
       - unit-test
+      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -105,6 +117,7 @@ jobs:
 #    needs:
 #      - lint
 #      - unit-test
+#      - shellcheck
 #    runs-on: ubuntu-latest
 #    steps:
 #      - name: Checkout
@@ -123,6 +136,7 @@ jobs:
     needs:
       - lint
       - unit-test
+      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,9 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: python -m pip install tox
       - name: Shellcheck tests
         run: tox -e shellcheck
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python3 -m pip install tox
       - name: Run linters
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: python -m pip install tox
       - name: Run tests
@@ -31,7 +31,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: python -m pip install tox
       - name: Shellcheck tests
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -123,7 +123,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    steps:
 #      - name: Checkout
-#        uses: actions/checkout@v2
+#        uses: actions/checkout@v3
 #      - name: Setup operator environment
 #        uses: charmed-kubernetes/actions-operator@main
 #        with:
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Run ShellCheck
-        # Code 6d3f514f validated for 3rd party action
-        uses: ludeeus/action-shellcheck@6d3f514f44620b9d4488e380339edc0d9bbe2fba
+      - name: Shellcheck tests
+        run: tox -e shellcheck
 
   integration-test-microk8s-charm:
     name: Charm integration tests (microk8s)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
         # Code 6d3f514f validated for 3rd party action
-        uses: ludeeus/action-shellcheck@6d3f514f
+        uses: ludeeus/action-shellcheck@6d3f514f44620b9d4488e380339edc0d9bbe2fba
 
   integration-test-microk8s-charm:
     name: Charm integration tests (microk8s)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,22 +27,11 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
-  shellcheck:
-    name: Shellcheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install dependencies
-        run: python -m pip install tox
-      - name: Shellcheck tests
-        run: tox -e shellcheck
-
   integration-test-microk8s-charm:
     name: Charm integration tests (microk8s)
     needs:
       - lint
       - unit-test
-      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -61,7 +50,6 @@ jobs:
     needs:
       - lint
       - unit-test
-      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -80,7 +68,6 @@ jobs:
     needs:
       - lint
       - unit-test
-      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -99,7 +86,6 @@ jobs:
     needs:
       - lint
       - unit-test
-      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -119,7 +105,6 @@ jobs:
 #    needs:
 #      - lint
 #      - unit-test
-#      - shellcheck
 #    runs-on: ubuntu-latest
 #    steps:
 #      - name: Checkout
@@ -138,7 +123,6 @@ jobs:
     needs:
       - lint
       - unit-test
-      - shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        # Code 6d3f514f validated for 3rd party action
+        uses: ludeeus/action-shellcheck@6d3f514f
 
   integration-test-microk8s-charm:
     name: Charm integration tests (microk8s)

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set target channel
         env:
           PROMOTE_FROM: ${{ github.event.inputs.promotion }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check libs
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Select charmhub channel

--- a/tests/integration/high_availability/scripts/deploy_chaos_mesh.sh
+++ b/tests/integration/high_availability/scripts/deploy_chaos_mesh.sh
@@ -6,7 +6,7 @@ chaos_mesh_ns=$1
 chaos_mesh_version="2.4.1"
 
 if [ -z "${chaos_mesh_ns}" ]; then
-    echo "Error: missing mandatory argument. Aborting" >&2
+	echo "Error: missing mandatory argument. Aborting" >&2
 	exit 1
 fi
 

--- a/tests/integration/high_availability/scripts/deploy_chaos_mesh.sh
+++ b/tests/integration/high_availability/scripts/deploy_chaos_mesh.sh
@@ -1,20 +1,31 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 chaos_mesh_ns=$1
 chaos_mesh_version="2.4.1"
 
 if [ -z "${chaos_mesh_ns}" ]; then
+    echo "Error: missing mandatory argument. Aborting" >&2
 	exit 1
 fi
 
 deploy_chaos_mesh() {
-	if [ "$(sg microk8s -c 'microk8s.helm3 repo list' | grep 'chaos-mesh' | wc -l)" != "1" ]; then
+	if sg microk8s -c 'microk8s.helm3 repo list' | grep -q 'chaos-mesh'; then
 		echo "adding chaos-mesh helm repo"
 		sg microk8s -c "microk8s.helm3 repo add chaos-mesh https://charts.chaos-mesh.org"
 	fi
 	
 	echo "installing chaos-mesh"
-    sg microk8s -c "microk8s.helm3 install chaos-mesh chaos-mesh/chaos-mesh --namespace=${chaos_mesh_ns} --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock --set dashboard.create=false --version ${chaos_mesh_version} --set clusterScoped=false --set controllerManager.targetNamespace=${chaos_mesh_ns}"
+        sg microk8s -c "microk8s.helm3 install chaos-mesh chaos-mesh/chaos-mesh \
+          --namespace=\"${chaos_mesh_ns}\" \
+          --set chaosDaemon.runtime=containerd \
+          --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock \
+          --set dashboard.create=false \
+          --version \"${chaos_mesh_version}\" \
+          --set clusterScoped=false \
+          --set controllerManager.targetNamespace=\"${chaos_mesh_ns}\" \
+          "
 	sleep 10
 }
 

--- a/tests/integration/high_availability/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/high_availability/scripts/destroy_chaos_mesh.sh
@@ -29,19 +29,19 @@ destroy_chaos_mesh() {
 
 	if kubectl get clusterrolebinding | grep -q 'chaos-mesh'; then
 		echo "deleting clusterrolebindings"
-		read -ra args < <(kubectl get clusterrolebinding | awk '/chaos-mesh/ {print $1}')
+		readarray -t args < <(kubectl get clusterrolebinding | awk '/chaos-mesh/ {print $1}')
 		timeout 30 kubectl delete clusterrolebinding "${args[@]}" || true
 	fi
 
 	if kubectl get clusterrole | grep -q 'chaos-mesh'; then
 		echo "deleting clusterroles"
-		read -ra args < <(kubectl get clusterrole | awk '/chaos-mesh/ {print $1}')
+		readarray -t args < <(kubectl get clusterrole | awk '/chaos-mesh/ {print $1}')
 		timeout 30 kubectl delete clusterrole "${args[@]}" || true
 	fi
 
 	if kubectl get crd | grep -q 'chaos-mesh.org'; then
 		echo "deleting crds"
-		read -ra args < <(kubectl get crd | awk '/chaos-mesh.org/ {print $1}')
+		readarray -t args < <(kubectl get crd | awk '/chaos-mesh.org/ {print $1}')
 		timeout 30 kubectl delete crd "${args[@]}" || true
 	fi
 

--- a/tests/integration/high_availability/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/high_availability/scripts/destroy_chaos_mesh.sh
@@ -1,45 +1,53 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 chaos_mesh_ns=$1
 
 if [ -z "${chaos_mesh_ns}" ]; then
+    echo "Error: missing mandatory argument. Aborting" >&2
 	exit 1
 fi
 
 destroy_chaos_mesh() {
 	echo "deleting api-resources"
-	for i in $(kubectl api-resources | grep chaos-mesh | awk '{print $1}'); do timeout 30 kubectl delete ${i} --all --all-namespaces || :; done
+	for i in $(kubectl api-resources | awk '/chaos-mesh/ {print $1}'); do
+	    timeout 30 kubectl delete "${i}" --all --all-namespaces || true
+	done
 
-	if [ "$(kubectl -n ${chaos_mesh_ns} get mutatingwebhookconfiguration | grep 'choas-mesh-mutation' | wc -l)" = "1" ]; then
-		timeout 30 kubectl -n ${chaos_mesh_ns} delete mutatingwebhookconfiguration chaos-mesh-mutation || :
+	if kubectl -n "${chaos_mesh_ns}" get mutatingwebhookconfiguration | grep -q 'choas-mesh-mutation'; then
+		timeout 30 kubectl -n "${chaos_mesh_ns}" delete mutatingwebhookconfiguration chaos-mesh-mutation || true
 	fi
 
-	if [ "$(kubectl -n ${chaos_mesh_ns} get validatingwebhookconfiguration | grep 'chaos-mesh-validation' | wc -l)" = "1" ]; then
-		timeout 30 kubectl -n ${chaos_mesh_ns} delete validatingwebhookconfiguration chaos-mesh-validation || :
+	if kubectl -n "${chaos_mesh_ns}" get validatingwebhookconfiguration | grep -q 'chaos-mesh-validation'; then
+		timeout 30 kubectl -n "${chaos_mesh_ns}" delete validatingwebhookconfiguration chaos-mesh-validation || true
 	fi
 
-	if [ "$(kubectl -n ${chaos_mesh_ns}) get validatingwebhookconfiguration | grep 'chaos-mesh-validate-auth' | wc -l)" = "1" ]; then
-		timeout 30 kubectl -n ${chaos_mesh_ns} delete validatingwebhookconfiguration chaos-mesh-validate-auth || :
+	if kubectl -n "${chaos_mesh_ns}" get validatingwebhookconfiguration | grep -q 'chaos-mesh-validate-auth'; then
+		timeout 30 kubectl -n "${chaos_mesh_ns}" delete validatingwebhookconfiguration chaos-mesh-validate-auth || true
 	fi
 
-	if [ "$(kubectl get clusterrolebinding | grep 'chaos-mesh' | awk '{print $1}' | wc -l)" != "0" ]; then
+	if kubectl get clusterrolebinding | grep -q 'chaos-mesh'; then
 		echo "deleting clusterrolebindings"
-		timeout 30 kubectl delete clusterrolebinding $(kubectl get clusterrolebinding | grep 'chaos-mesh' | awk '{print $1}') || :
+		read -ra args < <(kubectl get clusterrolebinding | awk '/chaos-mesh/ {print $1}')
+		timeout 30 kubectl delete clusterrolebinding "${args[@]}" || true
 	fi
 
-	if [ "$(kubectl get clusterrole | grep 'chaos-mesh' | awk '{print $1}' | wc -l)" != "0" ]; then
+	if kubectl get clusterrole | grep -q 'chaos-mesh'; then
 		echo "deleting clusterroles"
-		timeout 30 kubectl delete clusterrole $(kubectl get clusterrole | grep 'chaos-mesh' | awk '{print $1}') || :
+		read -ra args < <(kubectl get clusterrole | awk '/chaos-mesh/ {print $1}')
+		timeout 30 kubectl delete clusterrole "${args[@]}" || true
 	fi
 
-	if [ "$(kubectl get crd | grep 'chaos-mesh.org' | awk '{print $1}' | wc -l)" != "0" ]; then
+	if kubectl get crd | grep -q 'chaos-mesh.org'; then
 		echo "deleting crds"
-		timeout 30 kubectl delete crd $(kubectl get crd | grep 'chaos-mesh.org' | awk '{print $1}') || :
+		read -ra args < <(kubectl get crd | awk '/chaos-mesh.org/ {print $1}')
+		timeout 30 kubectl delete crd "${args[@]}" || true
 	fi
 
-	if [ -n "$chaos_mesh_ns" ] && [ "$(sg microk8s -c 'microk8s.helm3 repo list --namespace=$chaos_mesh_ns' | grep 'chaos-mesh' | wc -l)" = "1" ]; then
+	if [ -n "$chaos_mesh_ns" ] && sg microk8s -c 'microk8s.helm3 repo list --namespace=$chaos_mesh_ns' | grep -q 'chaos-mesh'; then
 		echo "uninstalling chaos-mesh helm repo"
-		sg microk8s -c "microk8s.helm3 uninstall chaos-mesh --namespace=${chaos_mesh_ns}" || :
+		sg microk8s -c "microk8s.helm3 uninstall chaos-mesh --namespace=\"${chaos_mesh_ns}\"" || true
 	fi
 }
 

--- a/tests/integration/high_availability/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/high_availability/scripts/destroy_chaos_mesh.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 chaos_mesh_ns=$1
 
 if [ -z "${chaos_mesh_ns}" ]; then
-    echo "Error: missing mandatory argument. Aborting" >&2
+	echo "Error: missing mandatory argument. Aborting" >&2
 	exit 1
 fi
 

--- a/tests/integration/high_availability/scripts/destroy_chaos_mesh.sh
+++ b/tests/integration/high_availability/scripts/destroy_chaos_mesh.sh
@@ -45,7 +45,7 @@ destroy_chaos_mesh() {
 		timeout 30 kubectl delete crd "${args[@]}" || true
 	fi
 
-	if [ -n "$chaos_mesh_ns" ] && sg microk8s -c 'microk8s.helm3 repo list --namespace=$chaos_mesh_ns' | grep -q 'chaos-mesh'; then
+	if [ -n "${chaos_mesh_ns}" ] && sg microk8s -c "microk8s.helm3 repo list --namespace=${chaos_mesh_ns}" | grep -q 'chaos-mesh'; then
 		echo "uninstalling chaos-mesh helm repo"
 		sg microk8s -c "microk8s.helm3 uninstall chaos-mesh --namespace=\"${chaos_mesh_ns}\"" || true
 	fi

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ commands =
 description = Run shellcheck tests
 deps =
     shellcheck-py==0.9.0.2
-whitelist-externals = /bin/bash
+allowlist_externals = /bin/bash
 commands = /bin/bash -c 'shellcheck --color=always $(git ls-files "*.bash" "*.sh")'
 
 [testenv:integration-charm]

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,8 @@ deps =
     pep8-naming
     isort
     codespell
+    shellcheck-py==0.9.0.2
+allowlist_externals = /bin/bash
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
@@ -54,6 +56,7 @@ commands =
     pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
+    /bin/bash -c 'shellcheck --color=always $(git ls-files "*.bash" "*.sh")'
 
 [testenv:unit]
 description = Run unit tests
@@ -65,13 +68,6 @@ commands =
     coverage run --source={[vars]src_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
-
-[testenv:shellcheck]
-description = Run shellcheck tests
-deps =
-    shellcheck-py==0.9.0.2
-allowlist_externals = /bin/bash
-commands = /bin/bash -c 'shellcheck --color=always $(git ls-files "*.bash" "*.sh")'
 
 [testenv:integration-charm]
 description = Run charm integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,13 @@ commands =
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
 
+[testenv:shellcheck]
+description = Run shellcheck tests
+deps =
+    shellcheck-py==0.9.0.2
+whitelist-externals = /bin/bash
+commands = /bin/bash -c 'shellcheck --color=always $(git ls-files "*.bash" "*.sh")'
+
 [testenv:integration-charm]
 description = Run charm integration tests
 deps =


### PR DESCRIPTION
# Issue
We are using more and more shell (bash) scripts but have no static code analyses for them.

# Solution
Use `shellcheck` to make sure our shell scripts are OK.

# Testing
GH Action for now and tox.ini to test locally.

# Release Notes
Test all shell scripts using `shellcheck`.