### PR TITLE
Attempt to fix errors while relating/unrelating kubeflow using mysql interface

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -425,7 +425,11 @@ class MySQLBase(ABC):
         )
 
         try:
-            output = self._run_mysqlcli_script("; ".join(get_unit_user_commands))
+            output = self._run_mysqlcli_script(
+                "; ".join(get_unit_user_commands),
+                user=self.server_config_user,
+                password=self.server_config_password,
+            )
             users = [line.strip() for line in output.split("\n") if line.strip()][1:]
             users = [f"'{user.split('@')[0]}'@'{user.split('@')[1]}'" for user in users]
 
@@ -434,6 +438,8 @@ class MySQLBase(ABC):
                 return
 
             primary_address = self.get_cluster_primary_address()
+            if not primary_address:
+                raise MySQLDeleteUsersForUnitError("Unable to query cluster primary address")
 
             # Using server_config_user as we are sure it has drop user grants
             drop_users_command = (

--- a/src/charm.py
+++ b/src/charm.py
@@ -356,12 +356,18 @@ class MySQLOperatorCharm(CharmBase):
             # Create control file in data directory
             self.app_peer_data["units-added-to-cluster"] = "1"
             self.unit_peer_data["unit-initialized"] = "True"
-            self.unit_peer_data["member-role"] = "primary"
+
+            state, role = self._mysql.get_member_state()
+
+            self.unit_peer_data["member-role"] = role
+            self.unit_peer_data["member_state"] = state
 
             self.unit.status = ActiveStatus(self.active_status_message)
         except MySQLCreateClusterError as e:
             self.unit.status = BlockedStatus("Unable to create cluster")
             logger.debug("Unable to create cluster: {}".format(e))
+        except MySQLGetMemberStateError:
+            self.unit.status = BlockedStatus("Unable to query member state and role")
 
     def _handle_potential_cluster_crash_scenario(self) -> bool:
         """Handle potential full cluster crash scenarios.

--- a/src/charm.py
+++ b/src/charm.py
@@ -360,7 +360,7 @@ class MySQLOperatorCharm(CharmBase):
             state, role = self._mysql.get_member_state()
 
             self.unit_peer_data["member-role"] = role
-            self.unit_peer_data["member_state"] = state
+            self.unit_peer_data["member-state"] = state
 
             self.unit.status = ActiveStatus(self.active_status_message)
         except MySQLCreateClusterError as e:

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -7,6 +7,7 @@
 import json
 import logging
 import os
+from typing import Optional
 
 from charms.mysql.v0.mysql import (
     Error,
@@ -459,7 +460,9 @@ class MySQL(MySQLBase):
             )
             raise MySQLDeleteUsersWithLabelError(e.message)
 
-    def _run_mysqlsh_script(self, script: str, verbose: int = 1) -> str:
+    def _run_mysqlsh_script(
+        self, script: str, verbose: int = 1, timeout: Optional[int] = None
+    ) -> str:
         """Execute a MySQL shell script.
 
         Raises ExecError if the script gets a non-zero return code.
@@ -471,6 +474,7 @@ class MySQL(MySQLBase):
         Returns:
             stdout of the script
         """
+        # TODO: remove timeout from _run_mysqlsh_script contract/signature in the mysql lib
         self.container.push(path=MYSQLSH_SCRIPT_FILE, source=script)
 
         # render command with remove file after run

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -111,14 +111,17 @@ class MySQLRelation(Object):
         """
         if not self.charm._is_peer_data_set or not self.model.get_relation(LEGACY_MYSQL):
             # Avoid running too early
+            logger.info("Unit not ready to set `mysql` relation data. Deferring")
             event.defer()
             return
 
         if (relation_data := self.charm.app_peer_data.get("mysql_relation_data", "{}")) == "{}":
+            logger.debug("No `mysql` relation data present")
             return
 
         container = self.charm.unit.get_container(CONTAINER_NAME)
         if not container.can_connect():
+            logger.info("Cannot connect to the workload container")
             return
 
         updates = json.loads(relation_data)
@@ -126,6 +129,7 @@ class MySQLRelation(Object):
         # Update the host (in case it has changed)
         primary_address = self.charm._mysql.get_cluster_primary_address()
         if not primary_address:
+            logger.error("Unable to query the cluster primary address")
             self.charm.unit.status = BlockedStatus("Failed to retrieve cluster primary address")
             return
         updates["host"] = primary_address.split(":")[0]
@@ -141,6 +145,7 @@ class MySQLRelation(Object):
         being elected).
         """
         if not self.charm.unit.is_leader():
+            logger.info("Unit is not leader, nooping `mysql` relation created")
             return
 
         # Wait until on-config-changed event is executed (for root password to have been set)
@@ -149,6 +154,7 @@ class MySQLRelation(Object):
             not self.charm._is_peer_data_set
             or self.charm.unit_peer_data.get("member-state") != "online"
         ):
+            logger.info("Unit not ready to execute `mysql` relation created. Deferring")
             event.defer()
             return
 
@@ -160,11 +166,13 @@ class MySQLRelation(Object):
         # Only execute handler if config values are set
         # else we'd be unable to create database and user
         if not username or not database:
+            logger.warning("mysql-interface-user or mysql-interface-database not set")
             self.charm.unit.status = BlockedStatus("Missing `mysql` relation data")
             return
 
         user_exists = False
         try:
+            logger.info(f"Checking if mysql user {username} exists")
             user_exists = self.charm._mysql.does_mysql_user_exist(username, "%")
         except MySQLCheckUserExistenceError:
             self.charm.unit.status = BlockedStatus("Failed to check user existence")
@@ -172,11 +180,13 @@ class MySQLRelation(Object):
 
         # Only execute if the application user does not exist
         if user_exists:
+            logger.info(f"mysql user {username} exists. nooping")
             return
 
         password = self._get_or_set_password_in_peer_databag(username)
 
         try:
+            logger.info("Creating application database and scoped user")
             self.charm._mysql.create_application_database_and_scoped_user(
                 database,
                 username,
@@ -192,6 +202,7 @@ class MySQLRelation(Object):
 
         primary_address = self.charm._mysql.get_cluster_primary_address()
         if not primary_address:
+            logger.error("Unable to get cluster primary address")
             self.charm.unit.status = BlockedStatus("Failed to retrieve cluster primary address")
 
         updates = {
@@ -212,16 +223,21 @@ class MySQLRelation(Object):
         event handler.
         """
         if not self.charm.unit.is_leader():
+            logger.info("Unit is not leader, nooping `mysql` relation broken")
             return
 
-        # Only execute if the last `osm-mysql` relation is broken
+        # Only execute if the last `mysql` relation is broken
         # as there can be multiple applications using the same relation interface
         if len(self.charm.model.relations[LEGACY_MYSQL]) > 1:
+            logger.info("More than one `mysql` relations present. Not deleting user for unit")
             return
 
         logger.warning("DEPRECATION WARNING - `mysql` is a legacy interface")
 
         try:
+            logger.info("Deleting users for unit (`mysql` relation)")
             self.charm._mysql.delete_users_for_unit("mysql-legacy-relation")
         except MySQLDeleteUsersForUnitError:
             self.charm.unit.status = BlockedStatus("Failed to delete users for unit")
+
+        del self.charm.app_peer_data["mysql_relation_data"]

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -143,9 +143,12 @@ class MySQLRelation(Object):
         if not self.charm.unit.is_leader():
             return
 
-        # Wait until on-config-changed event is executed
-        # (wait for root password to have been set)
-        if not self.charm._is_peer_data_set:
+        # Wait until on-config-changed event is executed (for root password to have been set)
+        # and for the member to be online
+        if (
+            not self.charm._is_peer_data_set
+            or self.charm.unit_peer_data.get("member-state") != "online"
+        ):
             event.defer()
             return
 

--- a/tests/integration/relations/test_database.py
+++ b/tests/integration/relations/test_database.py
@@ -54,7 +54,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():
-
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[DATABASE_APP_NAME].units) == 3
         )

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -49,7 +49,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():
-
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[APP_NAME].units) == 3
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -64,8 +64,10 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.create_custom_config_file")
     @patch("mysql_k8s_helpers.MySQL.initialise_mysqld")
     @patch("mysql_k8s_helpers.MySQL.is_instance_in_cluster")
+    @patch("mysql_k8s_helpers.MySQL.get_member_state", return_value=("online", "primary"))
     def test_mysql_pebble_ready(
         self,
+        _get_member_state,
         _is_instance_in_cluster,
         _initialise_mysqld,
         _create_custom_config_file,


### PR DESCRIPTION
# Issue
[DPE-1223](https://warthogs.atlassian.net/browse/DPE-1223)
1. we are not checking if the member relating with the `mysql` interface is online when forming the relation
2. we are using the `root` mysql user to query users to delete (in `delete_users_for_unit`). the root user is unable to connect with the `mysql` client (using a unix socket)

# Solution
1. if a relation is formed before the leader instance goes into `online` state, defer the formation of the relation until it is `online`
2. use the `serverconfig` user to query users to delete

# Testing
<!-- What steps need to be taken to test this PR? -->
```
juju deploy --channel=latest/edge --trust --resource keystone-image=opensourcemano/keystone:testing-daily osm-keystone keystone
juju deploy -n 1 ./mysql-k8s_ubuntu-22.04-amd64.charm --resource mysql-image=dataplatformoci/mysql-and-shell:latest --config mysql-interface-user=keystone --config mysql-interface-database=keystone mysql-k8s
juju relate mysql-k8s:mysql keystone:db
juju remove-relation mysql-k8s:mysql keystone:db
juju relate mysql-k8s:mysql keystone:db
juju remove-relation mysql-k8s:mysql keystone:db
```

# Release Notes
Attempt to fix errors while relating/unrelating kubeflow using mysql interface


[DPE-1223]: https://warthogs.atlassian.net/browse/DPE-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ