### PR TITLE
Noop peer relation changed event handler for mysql relation if relation does not exist

### DIFF
--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -111,7 +111,7 @@ class MySQLRelation(Object):
         """
         if not self.charm._is_peer_data_set or not self.model.get_relation(LEGACY_MYSQL):
             # Avoid running too early
-            logger.info("Unit not ready to set `mysql` relation data. Deferring")
+            logger.debug("Unit not ready to set `mysql` relation data. Deferring")
             event.defer()
             return
 
@@ -154,7 +154,7 @@ class MySQLRelation(Object):
             not self.charm._is_peer_data_set
             or self.charm.unit_peer_data.get("member-state") != "online"
         ):
-            logger.info("Unit not ready to execute `mysql` relation created. Deferring")
+            logger.debug("Unit not ready to execute `mysql` relation created. Deferring")
             event.defer()
             return
 

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -109,9 +109,12 @@ class MySQLRelation(Object):
         Stores and refreshes the relation data on all units (as some consumer
         applications retrieve the relation data from random units).
         """
-        if not self.charm._is_peer_data_set or not self.model.get_relation(LEGACY_MYSQL):
+        if not self.model.get_relation(LEGACY_MYSQL):
+            return
+
+        if not self.charm._is_peer_data_set:
             # Avoid running too early
-            logger.debug("Unit not ready to set `mysql` relation data. Deferring")
+            logger.info("Unit not ready to set `mysql` relation data. Deferring")
             event.defer()
             return
 

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -157,7 +157,7 @@ class MySQLRelation(Object):
             not self.charm._is_peer_data_set
             or self.charm.unit_peer_data.get("member-state") != "online"
         ):
-            logger.debug("Unit not ready to execute `mysql` relation created. Deferring")
+            logger.info("Unit not ready to execute `mysql` relation created. Deferring")
             event.defer()
             return
 


### PR DESCRIPTION
# Issue
We are spitting out a lot of info statements when deferring events
See [the following pastebin](https://pastebin.canonical.com/p/P5VVP8Q4DZ/) for such logs

# Solution
Noop and return from the peer relation changed event handler if `mysql` relation does not exist. 

# Release Notes
Noop peer relation changed event handler for mysql relation if relation does not exist
