### PR TITLE
fix update pod labels

### DIFF
--- a/src/k8s_helpers.py
+++ b/src/k8s_helpers.py
@@ -110,6 +110,7 @@ class KubernetesHelpers:
         except ApiError as e:
             if e.status.code == 404:
                 logger.warning(f"Kubernetes pod {pod_name} not found. Scaling in?")
+                return
             if e.status.code == 403:
                 logger.error("Kubernetes pod label creation failed: `juju trust` needed")
             else:

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -148,6 +148,9 @@ class MySQLProvider(Object):
             self.database.set_credentials(relation_id, db_user, db_pass)
             self.database.set_version(relation_id, db_version)
 
+            # make sure pods are labeled before adding service
+            self._update_endpoints()
+
             # create k8s services for endpoints
             self.k8s_helpers.create_endpoint_services(["primary", "replicas"])
 

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -86,32 +86,30 @@ class MySQLProvider(Object):
         relation.data[self.charm.app]["password"] = password
         return password
 
+    @staticmethod
+    def _endpoints_to_pod_list(endpoints: str) -> List[str]:
+        """Converts a comma separated list of endpoints to a list of pods."""
+        return [p.split(".")[0] for p in endpoints.split(",")]
+
     def _update_endpoints(self) -> None:
-        """Updates pod labels to reflect role of the unit.
-
-        Args:
-            relation_id: The id of the relation for which to update the endpoints
-        """
-
-        def _endpoints_to_pod_list(endpoints: str) -> List[str]:
-            """Converts a comma separated list of endpoints to a list of pods."""
-            return [p.split(".")[0] for p in endpoints.split(",")]
-
+        """Updates pod labels to reflect role of the unit."""
         logger.debug("Updating pod labels")
         try:
-            rw_endpoints, ro_endpoints, offline = self.charm._mysql.get_cluster_endpoints(get_ips=False)
+            rw_endpoints, ro_endpoints, offline = self.charm._mysql.get_cluster_endpoints(
+                get_ips=False
+            )
 
             # rw pod labels
             if rw_endpoints:
-                for pod in _endpoints_to_pod_list(rw_endpoints):
+                for pod in self._endpoints_to_pod_list(rw_endpoints):
                     self.k8s_helpers.label_pod("primary", pod)
             # ro pod labels
             if ro_endpoints:
-                for pod in _endpoints_to_pod_list(ro_endpoints):
+                for pod in self._endpoints_to_pod_list(ro_endpoints):
                     self.k8s_helpers.label_pod("replicas", pod)
             # offline pod labels
             if offline:
-                for pod in _endpoints_to_pod_list(offline):
+                for pod in self._endpoints_to_pod_list(offline):
                     self.k8s_helpers.label_pod("offline", pod)
         except MySQLGetClusterEndpointsError as e:
             logger.exception("Failed to get cluster members", exc_info=e)

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -51,6 +51,7 @@ class TestDatabase(unittest.TestCase):
     def tearDown(self) -> None:
         self.patcher.stop()
 
+    @patch("relations.mysql_provider.MySQLProvider._update_endpoints")
     @patch("k8s_helpers.KubernetesHelpers.create_endpoint_services")
     @patch("mysql_k8s_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")
     @patch("mysql_k8s_helpers.MySQL.create_application_database_and_scoped_user")
@@ -63,6 +64,7 @@ class TestDatabase(unittest.TestCase):
         _create_application_database_and_scoped_user,
         _get_mysql_version,
         _create_endpoint_services,
+        _update_endpoints,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
@@ -105,6 +107,7 @@ class TestDatabase(unittest.TestCase):
         _create_application_database_and_scoped_user.assert_called_once()
         _get_mysql_version.assert_called_once()
         _create_endpoint_services.assert_called_once()
+        _update_endpoints.assert_called_once()
 
     @patch("k8s_helpers.KubernetesHelpers.delete_endpoint_services")
     @patch("mysql_k8s_helpers.MySQL.delete_user_for_relation")

--- a/tox.ini
+++ b/tox.ini
@@ -165,3 +165,21 @@ deps =
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/test_tls.py
+
+[testenv:dev]
+description = Run in development test
+pass_env =
+    {[testenv]pass_env}
+    CI
+    CI_PACKED_CHARMS
+deps =
+    juju==2.9.38.1
+    mysql-connector-python
+    pytest
+    pdbpp
+    pytest-operator
+    pyyaml
+    -r {tox_root}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tests_path}/unit --log-cli-level=INFO -s {posargs} -m "dev"
+


### PR DESCRIPTION
## Issue

Offline pods are now being set as offline and being used selected by the kubernetes service.
Related to [DPE-1225](https://warthogs.atlassian.net/browse/DPE-1225)

## Solution

Fix endpoint setting by parsing offline nodes and setting pod label accordingly.
+Lib bump.


[DPE-1225]: https://warthogs.atlassian.net/browse/DPE-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ