### PR TITLE
Check osm-zookeeper status in a special way

### DIFF
--- a/tests/integration/relations/test_osm_mysql.py
+++ b/tests/integration/relations/test_osm_mysql.py
@@ -100,7 +100,7 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest) -> None:
             timeout=1000,
         )
 
-        # osm-zookeeper is never `active` long enough (15 seconds is necessary).
+        # osm-zookeeper is never `active` long enough (15 seconds is necessary),
         # it constantly changes state `active`<>`maintenance`:
         # > osm-zookeeper/0 [idle] maintenance: Sending Zookeeper configuration
         await ops_test.model.wait_for_idle(
@@ -109,13 +109,7 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest) -> None:
             raise_on_blocked=True,
             timeout=1000,
         )
-        await ops_test.model.wait_for_idle(
-            apps=["osm-zookeeper"],
-            status="active",
-            idle_period=1,
-            raise_on_blocked=True,
-            timeout=1000,
-        )
+        ops_test.model.block_until(ops_test.model.applications["osm-zookeeper"].status == "active")
 
         await ops_test.model.relate("osm-keystone:db", f"{APP_NAME}:osm-mysql")
         await ops_test.model.block_until(

--- a/tests/integration/relations/test_osm_mysql.py
+++ b/tests/integration/relations/test_osm_mysql.py
@@ -100,9 +100,19 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest) -> None:
             timeout=1000,
         )
 
+        # osm-zookeeper is never `active` long enough (15 seconds is necessary).
+        # it constantly changes state `active`<>`maintenance`:
+        # > osm-zookeeper/0 [idle] maintenance: Sending Zookeeper configuration
         await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, "osm-kafka", "osm-zookeeper", "osm-mongodb"],
+            apps=[APP_NAME, "osm-kafka", "osm-mongodb"],
             status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+        )
+        await ops_test.model.wait_for_idle(
+            apps=["osm-zookeeper"],
+            status="active",
+            idle_period=1,
             raise_on_blocked=True,
             timeout=1000,
         )
@@ -111,11 +121,10 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest) -> None:
         await ops_test.model.block_until(
             lambda: is_relation_joined(ops_test, "db", "osm-mysql"), timeout=1000
         )
-
-        # osm-keystone is initially in blocked status
         await ops_test.model.wait_for_idle(
-            apps=[APP_NAME, "osm-keystone", "osm-kafka", "osm-zookeeper", "osm-mongodb"],
+            apps=[APP_NAME, "osm-keystone"],
             status="active",
+            # osm-keystone is initially in blocked status
             raise_on_blocked=False,
             timeout=1000,
         )


### PR DESCRIPTION
## Issue

The osm-zookeeper unit is constantly switching his status between `active` and `maintenance` (in integration tests):

> juju show-status-log osm-zookeeper/0
> Time                        Type       Status       Message
> ...
> 16 Feb 2023 11:30:18+01:00  workload   active       ready
> 16 Feb 2023 11:30:22+01:00  workload   maintenance  Sending Zookeeper configuration
> 16 Feb 2023 11:30:22+01:00  workload   active       ready
> 16 Feb 2023 11:30:30+01:00  workload   maintenance  Sending Zookeeper configuration
> 16 Feb 2023 11:30:31+01:00  workload   active       ready
> 16 Feb 2023 11:30:39+01:00  workload   maintenance  Sending Zookeeper configuration
> 16 Feb 2023 11:30:39+01:00  workload   active       ready
> 16 Feb 2023 11:30:49+01:00  workload   maintenance  Sending Zookeeper configuration
> 16 Feb 2023 11:30:49+01:00  workload   active       ready

As a result GH CI test might be unlucky to wait until timeouts: https://github.com/canonical/mysql-k8s-operator/actions/runs/4189712435/jobs/7262386481

> ...
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] maintenance: Sending Zookeeper configuration
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] active: ready
> INFO     juju.model:model.py:2530 Waiting for model:
>   osm-zookeeper/0 [idle] maintenance: Sending Zookeeper configuration
> ...

## Solution

We cannot blindly wait for osm-zookeeper active status.
As a proposal, let's switch from`wait_for_idle` (which is waiting `idle_period` (default to 15 seconds) before consider service is really `idle`) to `ops_test.model.block_until` which is immediately triggering back `active` when noticing it.

P.S. No need to re-check kafka/mongodb status after relation mysql-k8s and keystone.