### PR TITLE
Fix 618fe32d: wait for coroutine 'Model.block_until'

### DIFF
--- a/tests/integration/relations/test_osm_mysql.py
+++ b/tests/integration/relations/test_osm_mysql.py
@@ -109,7 +109,9 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest) -> None:
             raise_on_blocked=True,
             timeout=1000,
         )
-        await ops_test.model.block_until(ops_test.model.applications["osm-zookeeper"].status == "active")
+        await ops_test.model.block_until(
+            ops_test.model.applications["osm-zookeeper"].status == "active"
+        )
 
         await ops_test.model.relate("osm-keystone:db", f"{APP_NAME}:osm-mysql")
         await ops_test.model.block_until(

--- a/tests/integration/relations/test_osm_mysql.py
+++ b/tests/integration/relations/test_osm_mysql.py
@@ -110,7 +110,8 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest) -> None:
             timeout=1000,
         )
         await ops_test.model.block_until(
-            ops_test.model.applications["osm-zookeeper"].status == "active"
+            lambda: ops_test.model.applications["osm-zookeeper"].status == "active",
+            timeout=1000,
         )
 
         await ops_test.model.relate("osm-keystone:db", f"{APP_NAME}:osm-mysql")

--- a/tests/integration/relations/test_osm_mysql.py
+++ b/tests/integration/relations/test_osm_mysql.py
@@ -109,7 +109,7 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest) -> None:
             raise_on_blocked=True,
             timeout=1000,
         )
-        ops_test.model.block_until(ops_test.model.applications["osm-zookeeper"].status == "active")
+        await ops_test.model.block_until(ops_test.model.applications["osm-zookeeper"].status == "active")
 
         await ops_test.model.relate("osm-keystone:db", f"{APP_NAME}:osm-mysql")
         await ops_test.model.block_until(


### PR DESCRIPTION
## Issue

Otherwise the test produces warning:
> =============================== warnings summary ===============================
> tests/integration/relations/test_osm_mysql.py::test_deploy_and_relate_osm_bundle
>   /home/runner/work/mysql-k8s-operator/mysql-k8s-operator/tests/integration/relations/test_osm_mysql.py:112: RuntimeWarning: coroutine 'Model.block_until' was never awaited
>     ops_test.model.block_until(ops_test.model.applications["osm-zookeeper"].status == "active")
>   Enable tracemalloc to get traceback where the object was allocated.
>  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.


## Solution

await for model.block_until(ops_test.model.applications["osm-zookeeper"]...f