### PR TITLE
Fix issues causing test backups to fail upon release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,7 @@ jobs:
     needs:
       - lib-check
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   release-to-charmhub:
     name: Release to CharmHub

--- a/tests/integration/test_backups.py
+++ b/tests/integration/test_backups.py
@@ -69,7 +69,7 @@ def clean_backups_from_buckets() -> None:
 
     logger.info("Cleaning backups from cloud buckets")
     for cloud_name, config in CLOUD_CONFIGS.items():
-        backup = backups_by_cloud[cloud_name]
+        backup = backups_by_cloud.get(cloud_name)
 
         if not backup:
             continue


### PR DESCRIPTION
## Issue
1. We are not inheriting secrets in a reusable workflow (`release.yaml`)
2. We are incorrectly assuming that a key exists in a fixture

## Solution
1. Inherit secrets
2. Use `.get()` when retrieving the key in the fixture