### PR TITLE
Check if TLS configuration file exists before deleting it

### DIFF
--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -945,12 +945,13 @@ Swap:     1027600384  1027600384           0
         self.container.push(path, content, permissions=permission, user=owner, group=group)
 
     def remove_file(self, path: str) -> None:
-        """Remove a file from container workload.
+        """Remove a file (if it exists) from container workload.
 
         Args:
             path: Full filesystem path to remove
         """
-        self.container.remove_path(path)
+        if self.container.exists(path):
+            self.container.remove_path(path)
 
     def check_if_mysqld_process_stopped(self) -> bool:
         """Checks if the mysqld process is stopped on the container."""


### PR DESCRIPTION
## Issue
`juju remove-relation mysql-k8s tls-certificates-operator` causes uncaught exception ([DPE-1001](https://warthogs.atlassian.net/browse/DPE-1001))

## Solution
Check if TLS configuration file exists before deleting it

[DPE-1001]: https://warthogs.atlassian.net/browse/DPE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ