### PR TITLE
Update peer interface name to follow naming conventions

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,7 +29,7 @@ resources:
     upstream-source: dataplatformoci/mysql-and-shell:latest
 peers:
   database-peers:
-    interface: mysql-peers
+    interface: mysql_peers
   restart:
     interface: rolling_op
 storage:


### PR DESCRIPTION
## Issue
The interface name is using `-`, but naming convention says `_`.
https://juju.is/docs/sdk/styleguide

## Solution
The endpoint name should use `-`, but interface name `_`.
