### PR TITLE
report host with fully qualified domain name

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -333,7 +333,7 @@ class MySQLOperatorCharm(CharmBase):
 
             try:
                 self._mysql.create_custom_config_file(
-                    report_host=self.get_unit_hostname(self.unit.name),
+                    report_host=self._get_unit_fqdn(self.unit.name),
                     innodb_buffer_pool_size=innodb_buffer_pool_size,
                     innodb_buffer_pool_chunk_size=innodb_buffer_pool_chunk_size,
                 )


### PR DESCRIPTION
## Issue

mysql-router can't connect to mysql cluster nodes on CMR, due nodes reporting self address without full domain, e.g. missing the `<model-name>.svc.cluster.local` and it silently fails to provide the read-only and read-write endpoints.
[DPE-1329](https://warthogs.atlassian.net/browse/DPE-1329)


## Solution

Make each cluster node report it's address with the fully qualified domain name.


[DPE-1329]: https://warthogs.atlassian.net/browse/DPE-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ