### PR TITLE
Fix new units addition after failure.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -374,7 +374,6 @@ class MySQLOperatorCharm(CharmBase):
 
             return
 
-
         # First run setup
         if not self._configure_instance(container):
             self.unit.status = BlockedStatus("Unable to configure instance")


### PR DESCRIPTION
## Issue

Transient issue where adding new units to a cluster with a to-be recovered primary has not yet recovered.
As described [DPE-1224](https://warthogs.atlassian.net/browse/DPE-1224).

## Solution

Sets maintenance status for all cases (unit configured or not), which will defer new units joining the cluster until `Active Status` is reached.
Speed up recovery when restarting from a pre-configured attached storage.

### Noteworthy

During testing, sometimes the databag went missing and I could see [this bug in action](https://bugs.launchpad.net/juju/+bug/2011277)

[DPE-1224]: https://warthogs.atlassian.net/browse/DPE-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ