### PR TITLE
Use exactly match on 'pgrep mysqld' due to mysqld_exporter availability

### DIFF
--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -979,7 +979,7 @@ Swap:     1027600384  1027600384           0
 
         def get_mysqld_pid(self):
             try:
-                process = self.container.exec(["pgrep", "mysqld"])
+                process = self.container.exec(["pgrep", "-x", "mysqld"])
                 pid, _ = process.wait_output()
                 return pid
             except ExecError:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -312,6 +312,7 @@ async def get_process_pid(
         container_name,
         unit_name,
         "pgrep",
+        "-x",
         process,
     ]
     return_code, pid, _ = await ops_test.juju(*get_pid_commands)

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -564,7 +564,7 @@ async def ensure_process_not_running(
         container_name: The name of the container to ensure the process is not running
         process: The name of the process to ensure is not running
     """
-    get_pid_commands = ["ssh", "--container", container_name, unit_name, "pgrep", process]
+    get_pid_commands = ["ssh", "--container", container_name, unit_name, "pgrep", "-x", process]
     return_code, pid, _ = await ops_test.juju(*get_pid_commands)
 
     assert (


### PR DESCRIPTION
## Issue
The test is getting wrong pid due to wide match:
```
> ubuntu@juju-82de18-16:~$ pgrep -a mysqld
> 3774 /snap/charmed-mysql/24/bin/mysqld_exporter ...
> 3996 /bin/sh /snap/charmed-mysql/24/usr/bin/mysqld_safe ...
> 4866 /snap/charmed-mysql/24/usr/sbin/mysqld ...
> ubuntu@juju-82de18-16:~$

> ubuntu@juju-82de18-16:~$ pgrep -a -x mysqld
> 4866 /snap/charmed-mysql/24/usr/sbin/mysqld ...
> ubuntu@juju-82de18-16:~$
```
## Solution
Use "pgrep -x" for exact match.