### PR TITLE
WIP: Update the upstream-source to the charmed-mysql rock

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: dataplatformoci/mysql-and-shell:latest
+    upstream-source: jardon/charmed-mysql:rock-fix
 peers:
   database-peers:
     interface: mysql_peers


### PR DESCRIPTION
## Issue
Our charm still relies on an image built with the Dockerfile, but we would like to switch to the ROCK based off the charmed-mysql snap

## Solution
Update the upstream source for the OCI in metadata.yaml