### PR TITLE
Wait for workload container reachability before pushing pebble config

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -359,6 +359,12 @@ class MySQLOperatorCharm(CharmBase):
             return
 
         container = event.workload
+        if not container.can_connect():
+            self.unit.status = WaitingStatus("Waiting for workload continer.")
+            logger.debug("Cannot connect workload continer, waiting...")
+            event.defer()
+            return
+
         if not self._prepare_configs(container):
             return
 


### PR DESCRIPTION
## Issue

Charm deployment may fail on overloaded GH runner:

> _____________________ test_no_replication_across_clusters ______________________
> Traceback (most recent call last):
>   File "/home/runner/work/mysql-k8s-operator/mysql-k8s-operator/tests/integration/high_availability/test_replication.py", line 65, in test_no_replication_across_clusters
>     await deploy_and_scale_mysql(
>   File "/home/runner/work/mysql-k8s-operator/mysql-k8s-operator/tests/integration/high_availability/high_availability_helpers.py", line 165, in deploy_and_scale_mysql
>     await ops_test.model.wait_for_idle(
>   File "/home/runner/work/mysql-k8s-operator/mysql-k8s-operator/.tox/integration-replication/lib/python3.10/site-packages/juju/model.py", line 2522, in wait_for_idle
>     _raise_for_status(errors, "error")
>   File "/home/runner/work/mysql-k8s-operator/mysql-k8s-operator/.tox/integration-replication/lib/python3.10/site-packages/juju/model.py", line 2465, in _raise_for_status
>     raise error_type("{}{} in {}: {}".format(
> juju.errors.JujuUnitError: Unit in error: another-mysql/1

Traceback:
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/./src/charm.py", line 667, in <module>
>     main(MySQLOperatorCharm)
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/main.py", line 433, in main
>     framework.reemit()
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/framework.py", line 834, in reemit
>     self._reemit()
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/framework.py", line 899, in _reemit
>     custom_handler(event)
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/./src/charm.py", line 384, in _on_mysql_pebble_ready
>     if not self._configure_instance(container):
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/./src/charm.py", line 286, in _configure_instance
>     self._mysql.initialise_mysqld()
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/src/mysql_k8s_helpers.py", line 178, in initialise_mysqld
>     process.wait_output()
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/pebble.py", line 1232, in wait_output
>     exit_code = self._wait()  # type: int
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/pebble.py", line 1178, in _wait
>     change = self._client.wait_change(self._change_id, timeout=timeout)
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/pebble.py", line 1673, in wait_change
>     return self._wait_change_using_wait(change_id, timeout)
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/pebble.py", line 1694, in _wait_change_using_wait
>     return self._wait_change(change_id, this_timeout)
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/pebble.py", line 1709, in _wait_change
>     resp = self._request('GET', '/v1/changes/{}/wait'.format(change_id), query)
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/pebble.py", line 1444, in _request
>     response = self._request_raw(method, path, query, headers, data)
>   File "/var/lib/juju/agents/unit-another-mysql-1/charm/venv/ops/pebble.py", line 1490, in _request_raw
>     raise ConnectionError(e.reason)
> ops.pebble.ConnectionError: [Errno 2] No such file or directory# Please enter the commit message for your changes. Lines starting
> # with '#' will be ignored, and an empty message aborts the commit.

## Solution
Make sure charm code can connect workload container before pushing pebble plan to launch mysql.