### PR TITLE
Add how-to documents (based on PostgreSQL how-to)

### DIFF
--- a/docs/how-to/h-configure-s3.md
+++ b/docs/how-to/h-configure-s3.md
@@ -1,0 +1,21 @@
+Charmed MySQL backup can be stored on any S3 compatible storage. The S3 access and configurations are managed with the [s3-integrator charm](https://charmhub.io/s3-integrator). Deploy and configure the s3-integrator charm:
+```
+juju deploy s3-integrator --channel=edge
+juju run-action s3-integrator/leader sync-s3-credentials access-key=<access-key-here> secret-key=<secret-key-here> --wait
+juju config s3-integrator \
+    path="/mysql-test" \
+    region="us-west-2" \
+    bucket="mysql-test-bucket-1" \
+    endpoint="https://s3.amazonaws.com"
+```
+The s3-integrator charm [accepts many configurations](https://charmhub.io/s3-integrator/configure) - enter whatever configurations are necessary for your s3 storage.
+
+To pass these configurations to Charmed MySQL, relate the two applications:
+```
+juju relate s3-integrator mysql-k8s
+```
+
+You can also update your configuration options after relating:
+```
+juju config s3-integrator endpoint=<endpoint>
+```

--- a/docs/how-to/h-create-and-list-backups.md
+++ b/docs/how-to/h-create-and-list-backups.md
@@ -1,0 +1,14 @@
+Creating and listing backups requires that you:
+* [Have a cluster with at least three-nodes deployed](https://discourse.charmhub.io/t/charmed-mysql-tutorial-managing-units/TODO)
+* Access to S3 storage
+* [Have configured settings for S3 storage](https://discourse.charmhub.io/t/configuring-settings-for-s3/TODO)
+
+Once you have a three-node cluster that has configurations set for S3 storage, check that Charmed MySQL is `active` and `idle` with `juju status`. Once Charmed MySQL is `active` and `idle`, you can create your first backup with the `create-backup` command:
+```
+juju run-action mysql-k8s/leader create-backup --wait
+```
+
+You can list your available, failed, and in progress backups by running the `list-backups` command:
+```
+juju run-action mysql-k8s/leader list-backups --wait
+```

--- a/docs/how-to/h-enable-encryption.md
+++ b/docs/how-to/h-enable-encryption.md
@@ -1,0 +1,53 @@
+# How to enable encryption
+
+Note: The TLS settings here are for self-signed-certificates which are not recommended for production clusters, the `tls-certificates-operator` charm offers a variety of configurations, read more on the TLS charm [here](https://charmhub.io/tls-certificates-operator)
+
+## Enable TLS
+
+```shell
+# deploy the TLS charm
+juju deploy tls-certificates-operator --channel=edge
+# add the necessary configurations for TLS
+juju config tls-certificates-operator generate-self-signed-certificates="true" ca-common-name="Test CA"
+# to enable TLS relate the two applications
+juju relate tls-certificates-operator mysql-k8s
+```
+
+## Manage keys
+
+Updates to private keys for certificate signing requests (CSR) can be made via the `set-tls-private-key` action. Note passing keys to external/internal keys should *only be done with* `base64 -w0` *not* `cat`. With three replicas this schema should be followed
+
+* Generate a shared internal key
+
+```shell
+openssl genrsa -out internal-key.pem 3072
+```
+
+* generate external keys for each unit
+
+```
+openssl genrsa -out external-key-0.pem 3072
+openssl genrsa -out external-key-1.pem 3072
+openssl genrsa -out external-key-2.pem 3072
+```
+
+* apply both private keys on each unit, shared internal key will be allied only on juju leader
+
+```
+juju run-action mysql-k8s/0 set-tls-private-key "external-key=$(base64 -w0 external-key-0.pem)"  "internal-key=$(base64 -w0 internal-key.pem)"  --wait
+juju run-action mysql-k8s/1 set-tls-private-key "external-key=$(base64 -w0 external-key-1.pem)"  "internal-key=$(base64 -w0 internal-key.pem)"  --wait
+juju run-action mysql-k8s/2 set-tls-private-key "external-key=$(base64 -w0 external-key-2.pem)"  "internal-key=$(base64 -w0 internal-key.pem)"  --wait
+```
+
+* updates can also be done with auto-generated keys with
+
+```
+juju run-action mysql-k8s/0 set-tls-private-key --wait
+juju run-action mysql-k8s/1 set-tls-private-key --wait
+juju run-action mysql-k8s/2 set-tls-private-key --wait
+```
+
+## Disable TLS remove the relation
+```shell
+juju remove-relation tls-certificates-operator mysql-k8s
+```

--- a/docs/how-to/h-manage-app.md
+++ b/docs/how-to/h-manage-app.md
@@ -1,0 +1,54 @@
+# How to manage related applications
+
+## New `mysql_client` interface:
+
+Relations to new applications are supported via the "[mysql_client](https://github.com/canonical/charm-relation-interfaces/blob/main/interfaces/mysql_client/v0/README.md)" interface. To create a relation:
+
+```shell
+juju relate mysql-k8s application
+```
+
+To remove a relation:
+
+```shell
+juju remove-relation mysql-k8s application
+```
+
+## Legacy `mysql` interface:
+
+We have also added support for the database legacy relation from the [original version](https://launchpad.net/TODO) of the charm via the `mysql` interface. Please note that these interface is deprecated.
+
+ ```shell
+juju relate mysql-k8s:mysql wordpress-k8s
+```
+
+Also extended permissions can be requested using `mysql-root` edpoint:
+```shell
+juju relate mysql-k8s:mysql-root wordpress-k8s
+```
+
+
+## Rotate applications password
+
+To rotate the passwords of users created for related applications, the relation should be removed and related again. That process will generate a new user and password for the application.
+
+```shell
+juju remove-relation application mysql-k8s
+juju add-relation application mysql-k8s
+```
+
+### Internal operator user
+
+The operator user is used internally by the Charmed MySQL Operator, the `set-password` action can be used to rotate its password.
+
+* To set a specific password for the operator user
+
+```shell
+juju run-action mysql-k8s/leader set-password password=<password> --wait
+```
+
+* To randomly generate a password for the operator user
+
+```shell
+juju run-action mysql-k8s/leader set-password --wait
+```

--- a/docs/how-to/h-manage-units.md
+++ b/docs/how-to/h-manage-units.md
@@ -1,0 +1,35 @@
+# How to deploy and manage units
+
+## Basic Usage
+
+To deploy a single unit of MySQL using its default configuration
+```shell
+juju deploy mysql-k8s --channel edge
+```
+
+It is customary to use MySQL with replication. Hence usually more than one unit (preferably an odd number to prohibit a "split-brain" scenario) is deployed. To deploy MySQL with multiple replicas, specify the number of desired units with the `-n` option.
+```shell
+juju deploy mysql-k8s --channel edge -n <number_of_replicas>
+```
+
+To retrieve primary replica one can use the action `get-primary` on any of the units running MySQL:
+```shell
+juju run-action mysql-k8s/leader get-primary --wait
+```
+
+Similarly, the primary replica is displayed as a status message in `juju status`, however one should note that this hook gets called on regular time intervals and the primary may be outdated if the status hook has not been called recently.
+
+Further we highly suggest configuring the status hook to run frequently. In addition to reporting the primary, secondaries, and other statuses, the status hook performs self healing in the case of a network cut. To change the frequency of the update status hook do:
+```shell
+juju model-config update-status-hook-interval=<time(s/m/h)>
+```
+Note that this hook executes a read query to MySQL. On a production level server this should be configured to occur at a frequency that doesn't overload the server with read requests. Similarly the hook should not be configured at too quick of a frequency as this can delay other hooks from running. You can read more about status hooks [here](https://juju.is/docs/sdk/update-status-event).
+
+## Replication
+
+Both scaling-up and scaling-down operations are performed using `juju scale-application`:
+```shell
+juju scale-application mysql-k8s <desired_num_of_units>
+```
+
+Warning: scaling-down to zero units will destroy your data!

--- a/docs/how-to/h-migrate-cluster-via-restore.md
+++ b/docs/how-to/h-migrate-cluster-via-restore.md
@@ -1,0 +1,33 @@
+This is a How-To for restoring a backup that was made from the a *different* cluster, (i.e. cluster migration via restore). To perform a basic restore please reference the [Restore How-To](/t/cluster-migration-via-restore/TODO)
+
+Restoring a backup from a previous cluster to a current cluster requires that you:
+- Have a single unit Charmed MySQL deployed and running
+- Access to S3 storage
+- [Have configured settings for S3 storage](/t/configuring-settings-for-s3/TODO)
+- Have the backups from the previous cluster in your S3-storage
+- Have the passwords from your previous cluster
+
+When you restore a backup from an old cluster, it will restore the password from the previous cluster to your current cluster. Set the password of your current cluster to the previous cluster’s password:
+```shell
+juju run-action mysql-k8s/leader set-password password=<previous cluster password> --wait
+```
+
+To view the available backups to restore you can enter the command `list-backups`:
+```shell
+juju run-action mysql-k8s/leader list-backups --wait
+```
+
+This shows a list of the available backups (it is up to you to identify which `backup-id` corresponds to the previous-cluster):
+```shell
+    backups: |-
+      backup-id             | backup-type  | backup-status
+      ----------------------------------------------------
+      YYYY-MM-DDTHH:MM:SSZ  | physical     | finished
+```
+
+To restore your current cluster to the state of the previous cluster, run the `restore` command and pass the correct `backup-id` to the command:
+ ```shell
+juju run-action mysql-k8s/leader restore backup-id=YYYY-MM-DDTHH:MM:SSZ --wait
+```
+
+Your restore will then be in progress, once it is complete your cluster will represent the state of the previous cluster.

--- a/docs/how-to/h-restore-backup.md
+++ b/docs/how-to/h-restore-backup.md
@@ -1,0 +1,28 @@
+This is a How-To for performing a basic restore (restoring a locally made backup).
+To restore a backup that was made from the a *different* cluster, (i.e. cluster migration via restore), please reference the [Cluster Migration via Restore How-To](/t/cluster-migration-via-restore/TODO):
+
+Restoring from a backup requires that you:
+- [Scale-down to the single MySQL unit (scale it up after the backup is restored).](/t/charmed-mysql-tutorial-managing-units/TODO)
+- Access to S3 storage
+- [Have configured settings for S3 storage](/t/configuring-settings-for-s3/TODO)
+- [Have existing backups in your S3-storage](/t/how-to-create-and-list-backups/TODO)
+
+To view the available backups to restore you can enter the command `list-backups`:
+```shell
+juju run-action mysql-k8s/leader list-backups --wait
+```
+
+This should show your available backups
+```shell
+    backups: |-
+      backup-id             | backup-type  | backup-status
+      ----------------------------------------------------
+      YYYY-MM-DDTHH:MM:SSZ  | physical     | finished
+```
+
+To restore a backup from that list, run the `restore` command and pass the `backup-id` to restore:
+ ```shell
+juju run-action mysql-k8s/leader restore backup-id=YYYY-MM-DDTHH:MM:SSZ --wait
+```
+
+Your restore will then be in progress.


### PR DESCRIPTION
## Issue
To close the sprint epic we need to provide How-to documentation section.

## Solution
Prepare a common structure, the similar to MongoDB and PostgreSQL how-to.
