### PR TITLE
Pin the charmed-mysql rock to a hash

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql:8.0.32-22.04_edge
+    upstream-source: ghcr.io/canonical/charmed-mysql:8.0.32-22.04_edge@sha256:924cb913733002e0936a36b6edab0bb8a4d72f1b92be0e0b7a933e797b7ef215
 peers:
   database-peers:
     interface: mysql_peers

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql:8.0.32-22.04_edge@sha256:924cb913733002e0936a36b6edab0bb8a4d72f1b92be0e0b7a933e797b7ef215
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:924cb913733002e0936a36b6edab0bb8a4d72f1b92be0e0b7a933e797b7ef215
 peers:
   database-peers:
     interface: mysql_peers


### PR DESCRIPTION
## Issue
We are using a ROCK label `charmed-mysql:8.0.32-22.04_edge` in the charm. However, a breaking a change in a new version of the ROCK can result in a broken charm. Additionally, it is possible for 2 nodes in the same cluster to have different versions of the ROCK (if a new version of the ROCK is released before a new node is added to the cluster).

## Solution
Pin the ROCK to a specific hash in the metadata file. We can add a renovate configuration to update this hash in a future PR (to automatically update and create a PR when there is a new version of the ROCK).