### PR TITLE
add support for memory constrained deployment

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -63,6 +63,7 @@ from constants import (
     SERVER_CONFIG_PASSWORD_KEY,
     SERVER_CONFIG_USERNAME,
 )
+from k8s_helpers import KubernetesHelpers
 from mysql_k8s_helpers import (
     MySQL,
     MySQLCreateCustomConfigFileError,
@@ -98,6 +99,7 @@ class MySQLOperatorCharm(CharmBase):
         self.framework.observe(self.on.get_password_action, self._on_get_password)
         self.framework.observe(self.on.set_password_action, self._on_set_password)
 
+        self.k8s_helpers = KubernetesHelpers(self)
         self.mysql_relation = MySQLRelation(self)
         self.database_relation = MySQLProvider(self)
         self.osm_mysql_relation = MySQLOSMRelation(self)
@@ -152,6 +154,7 @@ class MySQLOperatorCharm(CharmBase):
             MONITORING_USERNAME,
             self.get_secret("app", MONITORING_PASSWORD_KEY),
             self.unit.get_container("mysql"),
+            self.k8s_helpers,
         )
 
     @property

--- a/src/k8s_helpers.py
+++ b/src/k8s_helpers.py
@@ -4,7 +4,7 @@
 """Kubernetes helpers."""
 
 import logging
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
@@ -115,4 +115,20 @@ class KubernetesHelpers:
                 logger.error("Kubernetes pod label creation failed: `juju trust` needed")
             else:
                 logger.exception("Kubernetes pod label creation failed: %s", e)
+            raise KubernetesClientError
+
+    def get_resources_limits(self, container_name: str) -> Dict:
+        """Return resources limits for a given container.
+
+        Args:
+            container_name: name of the container to get resources limits for
+        """
+        try:
+            pod = self.client.get(Pod, self.pod_name, namespace=self.namespace)
+
+            for container in pod.spec.containers:
+                if container.name == container_name:
+                    return container.resources.limits or {}
+            return {}
+        except ApiError:
             raise KubernetesClientError

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,6 +4,7 @@
 """A collection of utility functions that are used in the charm."""
 
 import hashlib
+import re
 import secrets
 import string
 
@@ -28,3 +29,45 @@ def generate_random_hash() -> str:
     """
     random_characters = generate_random_password(10)
     return hashlib.md5(random_characters.encode("utf-8")).hexdigest()
+
+
+def split_mem(mem_str) -> tuple:
+    """Split a memory string into a number and a unit.
+
+    Args:
+        mem_str: a string representing a memory value, e.g. "1Gi"
+    """
+    pattern = r"^(\d+)(\w+)$"
+    parts = re.match(pattern, mem_str)
+    if parts:
+        return parts.groups()
+    return None, "No unit found"
+
+
+def any_memory_to_bytes(mem_str) -> int:
+    """Convert a memory string to bytes.
+
+    Args:
+        mem_str: a string representing a memory value, e.g. "1Gi"
+    """
+    units = {
+        "KI": 1024,
+        "K": 10**3,
+        "MI": 1048576,
+        "M": 10**6,
+        "GI": 1073741824,
+        "G": 10**9,
+        "TI": 1099511627776,
+        "T": 10**12,
+    }
+    try:
+        num = int(mem_str)
+        return num
+    except ValueError:
+        memory, unit = split_mem(mem_str)
+        unit = unit.upper()
+        if unit not in units:
+            raise ValueError(f"Invalid memory definition in '{mem_str}'")
+
+        num = int(memory)
+        return int(num * units[unit])

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -150,6 +150,7 @@ async def deploy_and_scale_mysql(
 
     config = {"cluster-name": CLUSTER_NAME}
     resources = {"mysql-image": METADATA["resources"]["mysql-image"]["upstream-source"]}
+    constraints = {"memory": "728M"}
 
     async with ops_test.fast_forward():
         await ops_test.model.deploy(
@@ -160,6 +161,7 @@ async def deploy_and_scale_mysql(
             num_units=num_units,
             series="jammy",
             trust=True,
+            constraints=constraints,
         )
 
         await ops_test.model.wait_for_idle(

--- a/tests/unit/test_k8s_helpers.py
+++ b/tests/unit/test_k8s_helpers.py
@@ -71,3 +71,15 @@ class TestK8sHelpers(unittest.TestCase):
         _get.return_value = pod
         self.k8s_helpers.label_pod("role1")
         _patch.assert_called_once_with(Pod, pod.name, pod)
+
+    @patch("lightkube.Client.get")
+    def test_get_resources_limit(self, _get):
+        pod = MagicMock()
+        container = MagicMock()
+        container.resources.limits = {"memory": "2Gi"}
+        container.name = "mysql"
+        pod.spec.containers = [container]
+        _get.return_value = pod
+        self.assertEqual(
+            self.k8s_helpers.get_resources_limits(container_name="mysql"), {"memory": "2Gi"}
+        )

--- a/tests/unit/test_mysql_k8s_helpers.py
+++ b/tests/unit/test_mysql_k8s_helpers.py
@@ -56,6 +56,7 @@ class TestMySQL(unittest.TestCase):
             "monitoring",
             "monitoringpassword",
             None,
+            None,
         )
 
     @patch("ops.pebble.ExecProcess")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,26 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+
+from utils import any_memory_to_bytes, generate_random_password, split_mem
+
+
+class TestUtils(unittest.TestCase):
+    def test_foo(self):
+        self.assertTrue(True)
+
+    def test_generate_random_password(self):
+        password = generate_random_password(16)
+        self.assertEqual(len(password), 16)
+        self.assertTrue(password.isalnum())
+
+    def test_split_mem(self):
+        self.assertEqual(split_mem("1Gi"), ("1", "Gi"))
+        self.assertEqual(split_mem("1G"), ("1", "G"))
+        self.assertEqual(split_mem("1"), (None, "No unit found"))
+
+    def test_any_memory_to_bytes(self):
+        self.assertEqual(any_memory_to_bytes("1Gi"), 1073741824)
+        self.assertEqual(any_memory_to_bytes("1G"), 10**9)
+        self.assertEqual(any_memory_to_bytes("1024"), 1024)


### PR DESCRIPTION
## Issue

The charm does not respect resources limits.
 **Extra context**: the method to calculate memory limits is very grabby and uses host system memory as base.
Further tuning may be necessary on k8s as the k8s cluster node workload tends to be more diverse, requiring a somewhat less grabby calculation.

## Solution

Refactor method that retrieve total memory to check for resources limits.
Chore:
- moved KubernetesHelpers reference from relation provider to charm in order to refer the object broadly
- refactor/added unit tests



Refer to [DPE-1598](https://warthogs.atlassian.net/browse/DPE-1598)
Closes #192 

[DPE-1598]: https://warthogs.atlassian.net/browse/DPE-1598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ