### PR TITLE
defer event for non-initialized units

### DIFF
--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -112,7 +112,9 @@ class MySQLRelation(Object):
         if not self.model.get_relation(LEGACY_MYSQL):
             return
 
-        if not self.charm._is_peer_data_set:
+        if not self.charm._is_peer_data_set or not self.charm.unit_peer_data.get(
+            "unit-initialized"
+        ):
             # Avoid running too early
             logger.info("Unit not ready to set `mysql` relation data. Deferring")
             event.defer()


### PR DESCRIPTION
## Issue

Secondaries process relation changed event while not fully deployed.

Related to [DPE-1640](https://warthogs.atlassian.net/browse/DPE-1640) / Issue #198 

## Solution

Defer event when unit is not initialized.
