### PR TITLE
DPE-1656 Limit tests RAM usage by every unit/container to 1GB

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           provider: microk8s
           # This is needed until https://bugs.launchpad.net/juju/+bug/1977582 is fixed
-          bootstrap-options: "--agent-version 2.9.29"
+          bootstrap-options: "--agent-version 2.9.29 --constraints mem=1G"
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## Issue
Often and strange tests crashes on GH runner while all is OK on localhost.

## Solution
GH Runners have 8GB RAM only. We are launching 1-2 MySQL clusters with three units each and allocating 50% for innodb_buffer_pull_size. OOM is an often trouble in this case.

Close: https://github.com/canonical/mysql-k8s-operator/issues/205