### PR TITLE
Update README to be up-2-date and describe supported relations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ this operator.
 - Generally, before developing enhancements to this charm, you should consider [opening an issue
   ](https://github.com/canonical/mysql-k8s-operator/issues) explaining your use case.
 - If you would like to chat with us about your use-cases or proposed implementation, you can reach
-  us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/charm-dev)
+  us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/data-platform)
   or [Discourse](https://discourse.charmhub.io/).
 - Familiarising yourself with the [Charmed Operator Framework](https://juju.is/docs/sdk) library
   will help you a lot when working on new features or bug fixes.
@@ -51,11 +51,13 @@ charmcraft pack
 ```bash
 # Create a model
 juju add-model dev
+
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
+
 # Deploy the charm
-juju deploy ./mysql-k8s_ubuntu-20.04-amd64.charm \
-    --resource mysql-image=ubuntu/mysql
+juju deploy ./mysql-k8s_ubuntu-22.04-amd64.charm \
+    --resource mysql-image=$(yq '(.resources.mysql-image.upstream-source)' metadata.yaml)
 ```
 
 ## Canonical Contributor Agreement

--- a/README.md
+++ b/README.md
@@ -1,49 +1,101 @@
-# MySQL k8s Charmed Operator
+# Charmed MySQL K8s operator
 
 ## Description
 
-The [MySQL](https://www.mysql.com/) operator provides an open-source relational database management system (RDBMS). This repository contains a Juju Charm for deploying MySQL on Kubernetes clusters.
-
-This charm is currently in development, with High Availability via Group Replication as a short-term goal.
+This repository contains a [Juju Charm](https://charmhub.io/mysql-k8s) for deploying [MySQL](https://www.mysql.com/) on ([Kubernetes](https://microk8s.io/)).
+To deploy on virtual machines, please use [Charmed MySQL VM operator](https://charmhub.io/mysql).
 
 ## Usage
 
-To deploy this charm using Juju 2.9.0 or later, run:
+To deploy this charm using Juju 2.9 or later, run:
 
 ```shell
 juju add-model mysql-k8s
 juju deploy mysql-k8s --trust
 ```
 
-**Note**: the `--trust` flag is required when relating using `mysql_client` interface.
+**Note:** the `--trust` flag is required when relating using `mysql_client` interface.
+**Note:** the above model must be created on K8s environment. Use [another](https://charmhub.io/mysql) charm for VMs!
 
 To confirm the deployment, you can run:
 
 ```shell
-juju status --color
+juju status --watch 1s
 ```
 
 Once MySQL starts up, it will be running on the default port (3306).
+Please follow the [tutorial guide](https://discourse.charmhub.io/t/charmed-mysql-k8s-tutorial-overview/9677) with detailed explanation how to access DB, configure cluster, change credentials and/or enable TLS.
 
 If required, you can remove the deployment completely by running:
 
 ```shell
-juju destroy-model -y mysql-k8s --destroy-storage
+juju destroy-model mysql-k8s --destroy-storage --yes
 ```
 
-Note: the `--destroy-storage` will delete any data persisted by MySQL.
+**Note:** the `--destroy-storage` will delete any data persisted by MySQL.
 
 ## Relations
 
-There are no relations implemented yet.
+The charm supports modern `mysql_client` and legacy `mysql` interfaces (in a backward compatible mode).
+
+**Note:** do NOT relate both of them simultaneously.
+
+
+### Modern relations
+
+This charm implements the [provides data platform library](https://charmhub.io/data-platform-libs/libraries/database_provides), with the modern `mysql_client` interface.
+To relate to it, use the [requires data-platform library](https://charmhub.io/data-platform-libs/libraries/database_requires).
+
+Adding a relation is accomplished with `juju relate` (or `juju integrate` for Juju 3.x). Example:
+
+```shell
+# Deploy Charmed MySQL cluster with 3 nodes
+juju deploy mysql-k8s -n 3 --trust
+
+# Deploy the relevant charms, e.g. mysql-test-app
+juju deploy mysql-test-app
+
+# Relate MySQL with your application
+juju relate mysql-k8s:database mysql-test-app:database
+
+# Check established relation (using mysql_client interface):
+juju status --relations
+
+# Example of the properly established relation:
+# > Relation provider      Requirer                 Interface     Type
+# > mysql-k8s:database     mysql-test-app:database  mysql_client  regular
+```
+
+**Note:** In order to relate with this charm, every table created by the related application must have a primary key. This is required by the [group replication plugin](https://dev.mysql.com/doc/refman/5.7/en/group-replication-requirements.html), enable in this charm.
+
+
+### Legacy relations
+
+**Note:** Legacy relations are deprecated and will be discontinued on future releases. Usage should be avoided.
+
+This charm supports legacy interface `mysql`. The `mysql` is a relation that's used from some k8s charms and can be used in cross-model relations.
+
+```shell
+juju deploy mysql-k8s --trust
+juju deploy mediawiki
+juju relate mysql-k8s:mysql mediawiki:db
+```
+
+**Note:** The endpoint `mysql-root` provides the same legacy interface `mysql` with MySQL root-level priviledges. It is NOT recommended to use it from security point of view.
 
 ## OCI Images
 
-This charm by default uses the latest version of the [ubuntu/mysql](https://hub.docker.com/r/ubuntu/mysql) image.
+This charm uses pinned and tested version of the [charmed-mysql](https://github.com/canonical/charmed-mysql-rock/pkgs/container/charmed-mysql) ROCK image.
 
 ## Contributing
 
 Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this
-charm following best practice guidelines, and
-[CONTRIBUTING.md](https://github.com/canonical/mysql-k8s-operator/blob/main/CONTRIBUTING.md) for developer
-guidance.
+charm following best practice guidelines, and [CONTRIBUTING.md](https://github.com/canonical/mysql-k8s-operator/blob/main/CONTRIBUTING.md) for developer guidance.
+
+## License
+The Charmed MySQL K8s Operator [is distributed](https://github.com/canonical/mysql-k8s-operator/blob/main/LICENSE) under the Apache Software License, version 2.0.
+It installs/operates/depends on [MySQL Community Edition](https://github.com/mysql/mysql-server), which [is licensed](https://github.com/mysql/mysql-server/blob/8.0/LICENSE) under the GPL License, version 2.
+
+## Trademark Notice
+MySQL is a trademark or registered trademark of Oracle America, Inc.
+Other trademarks are property of their respective owners.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Description
 
-This repository contains a [Juju Charm](https://charmhub.io/mysql-k8s) for deploying [MySQL](https://www.mysql.com/) on ([Kubernetes](https://microk8s.io/)).
+This repository contains a [Juju Charm](https://charmhub.io/mysql-k8s) for deploying [MySQL](https://www.mysql.com/) on [Kubernetes](https://microk8s.io/).
 
-To deploy on virtual machines, please use [Charmed MySQL VM operator](https://charmhub.io/mysql).
+To deploy on [virtual machines](https://ubuntu.com/lxd), please use [Charmed MySQL VM operator](https://charmhub.io/mysql).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,13 @@ juju status --relations
 
 **Note:** Legacy relations are deprecated and will be discontinued on future releases. Usage should be avoided.
 
-This charm supports legacy interface `mysql`. The `mysql` is a relation that's used from some k8s charms and can be used in cross-model relations.
+This charm supports legacy interface `mysql` (endpoint `mysql`). It was a popular interface used by some legacy charms (e.g. "[MariaDB](https://charmhub.io/mariadb)", "[OSM MariaDB](https://charmhub.io/charmed-osm-mariadb-k8s)", "[Percona Cluster](https://charmhub.io/percona-cluster)" and "[Mysql Innodb Cluster](https://charmhub.io/mysql-innodb-cluster)"), often in [cross-model relations](https://juju.is/docs/olm/cross-model-integration):
 
 ```shell
 juju deploy mysql-k8s --trust --channel 8.0
-juju deploy mediawiki
-juju relate mysql-k8s:mysql mediawiki:db
+juju config mysql-k8s mysql-interface-database=wordpress mysql-interface-user=wordpress
+juju deploy wordpress-k8s
+juju relate mysql-k8s:mysql wordpress-k8s:db
 ```
 
 **Note:** The endpoint `mysql-root` provides the same legacy interface `mysql` with MySQL root-level privileges. It is NOT recommended to use it from security point of view.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To deploy this charm using Juju 2.9 or later, run:
 
 ```shell
 juju add-model mysql-k8s
-juju deploy mysql-k8s --trust
+juju deploy mysql-k8s --trust --channel 8.0
 ```
 
 **Note:** the `--trust` flag is required when relating using `mysql_client` interface.
@@ -55,7 +55,7 @@ Adding a relation is accomplished with `juju relate` (or `juju integrate` for Ju
 
 ```shell
 # Deploy Charmed MySQL cluster with 3 nodes
-juju deploy mysql-k8s -n 3 --trust
+juju deploy mysql-k8s -n 3 --trust --channel 8.0
 
 # Deploy the relevant charms, e.g. mysql-test-app
 juju deploy mysql-test-app
@@ -81,7 +81,7 @@ juju status --relations
 This charm supports legacy interface `mysql`. The `mysql` is a relation that's used from some k8s charms and can be used in cross-model relations.
 
 ```shell
-juju deploy mysql-k8s --trust
+juju deploy mysql-k8s --trust --channel 8.0
 juju deploy mediawiki
 juju relate mysql-k8s:mysql mediawiki:db
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ juju status --relations
 # > mysql-k8s:database     mysql-test-app:database  mysql_client  regular
 ```
 
-**Note:** In order to relate with this charm, every table created by the related application must have a primary key. This is required by the [group replication plugin](https://dev.mysql.com/doc/refman/5.7/en/group-replication-requirements.html), enable in this charm.
+**Note:** In order to relate with this charm, every table created by the related application must have a primary key. This is required by the [group replication plugin](https://dev.mysql.com/doc/refman/5.7/en/group-replication-requirements.html) enabled in this charm.
 
 
 ### Legacy relations

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The charm supports modern `mysql_client` and legacy `mysql` interfaces (in a bac
 This charm implements the [provides data platform library](https://charmhub.io/data-platform-libs/libraries/database_provides), with the modern `mysql_client` interface.
 To relate to it, use the [requires data-platform library](https://charmhub.io/data-platform-libs/libraries/database_requires).
 
-Adding a relation is accomplished with `juju relate` (or `juju integrate` for Juju 3.x). Example:
+Adding a relation is accomplished with `juju relate` (or `juju integrate` for Juju 3.x) via endpoint `database`. Example:
 
 ```shell
 # Deploy Charmed MySQL cluster with 3 nodes

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Description
 
 This repository contains a [Juju Charm](https://charmhub.io/mysql-k8s) for deploying [MySQL](https://www.mysql.com/) on ([Kubernetes](https://microk8s.io/)).
+
 To deploy on virtual machines, please use [Charmed MySQL VM operator](https://charmhub.io/mysql).
 
 ## Usage
@@ -15,6 +16,7 @@ juju deploy mysql-k8s --trust
 ```
 
 **Note:** the `--trust` flag is required when relating using `mysql_client` interface.
+
 **Note:** the above model must be created on K8s environment. Use [another](https://charmhub.io/mysql) charm for VMs!
 
 To confirm the deployment, you can run:
@@ -24,7 +26,6 @@ juju status --watch 1s
 ```
 
 Once MySQL starts up, it will be running on the default port (3306).
-Please follow the [tutorial guide](https://discourse.charmhub.io/t/charmed-mysql-k8s-tutorial-overview/9677) with detailed explanation how to access DB, configure cluster, change credentials and/or enable TLS.
 
 If required, you can remove the deployment completely by running:
 
@@ -34,11 +35,15 @@ juju destroy-model mysql-k8s --destroy-storage --yes
 
 **Note:** the `--destroy-storage` will delete any data persisted by MySQL.
 
+## Documentation
+
+Please follow the [tutorial guide](https://discourse.charmhub.io/t/charmed-mysql-k8s-tutorial-overview/9677) with detailed explanation how to access DB, configure cluster, change credentials and/or enable TLS.
+
 ## Relations
 
 The charm supports modern `mysql_client` and legacy `mysql` interfaces (in a backward compatible mode).
 
-**Note:** do NOT relate both of them simultaneously.
+**Note:** do NOT relate both modern and legacy interfaces simultaneously.
 
 
 ### Modern relations
@@ -81,7 +86,7 @@ juju deploy mediawiki
 juju relate mysql-k8s:mysql mediawiki:db
 ```
 
-**Note:** The endpoint `mysql-root` provides the same legacy interface `mysql` with MySQL root-level priviledges. It is NOT recommended to use it from security point of view.
+**Note:** The endpoint `mysql-root` provides the same legacy interface `mysql` with MySQL root-level privileges. It is NOT recommended to use it from security point of view.
 
 ## OCI Images
 


### PR DESCRIPTION
## Issue
The README file was way outdated and had no interfaces description, causing issues like https://github.com/canonical/mysql-k8s-operator/issues/198

## Solution
Update README to match the one in mysql VM repo.

We should consider for the future:
 * name endpoints and interfaces identically/similar
 * sync amount of interfaces supported by VM and K8s
