### PR TITLE
skip update when unit not ready

### DIFF
--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -87,6 +87,10 @@ class MySQLRelation(Object):
         if (relation_data := self.charm.app_peer_data.get("mysql_relation_data", "{}")) == "{}":
             return
 
+        if not self.charm.unit_peer_data.get("unit-initialized"):
+            # Skip update status for uninitialized unit
+            return
+
         container = self.charm.unit.get_container(CONTAINER_NAME)
         if not container.can_connect():
             return


### PR DESCRIPTION
## Issue

Replicas fail trying to get cluster primary before being added to the cluster on update_status hook for legacy mysql.
[DPE-1227](https://warthogs.atlassian.net/browse/DPE-1227) 

## Solution

Skip hook when not initialized.


[DPE-1227]: https://warthogs.atlassian.net/browse/DPE-1227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ