### PR TITLE
Remove unstable tags from self-healing tests and add resource constraints while running tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -25,4 +26,11 @@ def ops_test(ops_test: OpsTest) -> OpsTest:
             raise ValueError(f"Unable to find .charm file for {bases_index=} at {charm_path=}")
 
         ops_test.build_charm = build_charm
+
+    model_name = ops_test.model.info.name
+    subprocess.run(
+        f"juju set-model-constraints --model={model_name} cores=2 mem=1G".split(),
+        check=True,
+    )
+
     return ops_test

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -45,7 +45,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.unstable
 async def test_kill_db_process(ops_test: OpsTest, continuous_writes) -> None:
     """Test to send a SIGKILL to the primary db process and ensure that the cluster self heals."""
     mysql_application_name, _ = await high_availability_test_setup(ops_test)
@@ -103,7 +102,6 @@ async def test_kill_db_process(ops_test: OpsTest, continuous_writes) -> None:
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.unstable
 async def test_freeze_db_process(ops_test: OpsTest, continuous_writes) -> None:
     """Test to send a SIGSTOP to the primary db process and ensure that the cluster self heals."""
     mysql_application_name, _ = await high_availability_test_setup(ops_test)
@@ -205,7 +203,6 @@ async def test_freeze_db_process(ops_test: OpsTest, continuous_writes) -> None:
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.unstable
 async def test_graceful_crash_of_primary(ops_test: OpsTest, continuous_writes) -> None:
     """Test to send SIGTERM to primary instance and then verify recovery."""
     mysql_application_name, _ = await high_availability_test_setup(ops_test)
@@ -263,7 +260,6 @@ async def test_graceful_crash_of_primary(ops_test: OpsTest, continuous_writes) -
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.unstable
 async def test_network_cut_affecting_an_instance(
     ops_test: OpsTest, continuous_writes, chaos_mesh
 ) -> None:
@@ -322,7 +318,6 @@ async def test_network_cut_affecting_an_instance(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.unstable
 async def test_graceful_full_cluster_crash_test(
     ops_test: OpsTest, continuous_writes, restart_policy
 ) -> None:
@@ -404,7 +399,6 @@ async def test_graceful_full_cluster_crash_test(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.unstable
 async def test_single_unit_pod_delete(ops_test: OpsTest) -> None:
     """Delete the pod in a single unit deployment and write data to new pod."""
     mysql_application_name, _ = await high_availability_test_setup(ops_test)


### PR DESCRIPTION
[dpe-1656](https://warthogs.atlassian.net/browse/DPE-1656)

## Issue
We are not setting resource (mem, cpu) constraints when running tests. There is a mysqld config set (`innodb_buffer_pool_size`) that reserves a lot of the host machine's memory when constraints on pods/units are not set. This may lead to instability of self-healing tests. 

## Solution
1. Add constraints in the ops_test fixture by calling `juju set-model-constraints`
2. Remove `unstable` tags from the self healing tests so that they are run in CI
