### PR TITLE
Fix/wait for service settled

### DIFF
--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -153,6 +153,9 @@ class MySQLProvider(Object):
             self.charm.k8s_helpers.create_endpoint_services(["primary", "replicas"])
 
             primary_endpoint = socket.getfqdn(f"{self.charm.app.name}-primary")
+            # wait for endpoints to be ready
+            self.charm.k8s_helpers.wait_service_ready((primary_endpoint, 3306))
+
             self.database.set_endpoints(relation_id, f"{primary_endpoint}:3306")
             replicas_endpoint = socket.getfqdn(f"{self.charm.app.name}-replicas")
             self.database.set_read_only_endpoints(relation_id, f"{replicas_endpoint}:3306")

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -51,6 +51,7 @@ class TestDatabase(unittest.TestCase):
     def tearDown(self) -> None:
         self.patcher.stop()
 
+    @patch("k8s_helpers.KubernetesHelpers.wait_service_ready")
     @patch("relations.mysql_provider.MySQLProvider._update_endpoints")
     @patch("k8s_helpers.KubernetesHelpers.create_endpoint_services")
     @patch("mysql_k8s_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")
@@ -65,6 +66,7 @@ class TestDatabase(unittest.TestCase):
         _get_mysql_version,
         _create_endpoint_services,
         _update_endpoints,
+        _wait_service_ready,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
@@ -109,6 +111,7 @@ class TestDatabase(unittest.TestCase):
         _get_mysql_version.assert_called_once()
         _create_endpoint_services.assert_called_once()
         _update_endpoints.assert_called_once()
+        _wait_service_ready.assert_called_once()
 
     @patch("k8s_helpers.KubernetesHelpers.delete_endpoint_services")
     @patch("mysql_k8s_helpers.MySQL.delete_user_for_relation")

--- a/tests/unit/test_k8s_helpers.py
+++ b/tests/unit/test_k8s_helpers.py
@@ -42,6 +42,7 @@ class TestK8sHelpers(unittest.TestCase):
                 metadata=ObjectMeta(
                     namespace=self.harness.charm.model.name,
                     name=f"{self.harness.charm.model.app.name}-role1",
+                    ownerReferences=self.mock_k8s_client.return_value.request.return_value.metadata.ownerReferences,
                 ),
                 spec=ServiceSpec(
                     selector={
@@ -83,3 +84,8 @@ class TestK8sHelpers(unittest.TestCase):
         self.assertEqual(
             self.k8s_helpers.get_resources_limits(container_name="mysql"), {"memory": "2Gi"}
         )
+
+    @patch("socket.socket")
+    def test_wait_service_ready(self, _socket):
+        _socket.return_value.connect_ex.return_value = 0
+        self.k8s_helpers.wait_service_ready(("test-service",3306))

--- a/tests/unit/test_k8s_helpers.py
+++ b/tests/unit/test_k8s_helpers.py
@@ -88,4 +88,4 @@ class TestK8sHelpers(unittest.TestCase):
     @patch("socket.socket")
     def test_wait_service_ready(self, _socket):
         _socket.return_value.connect_ex.return_value = 0
-        self.k8s_helpers.wait_service_ready(("test-service",3306))
+        self.k8s_helpers.wait_service_ready(("test-service", 3306))


### PR DESCRIPTION
## Issue

`mysql_client` interface relation being set before k8s service routes traffic to pods
[DPE-1704](https://warthogs.atlassian.net/browse/DPE-1704)

## Solution

Add test/wait step before setting relation data.
Tested with wordpress-k8s (issue #198 ) 