### PR TITLE
avoid flaky planned units

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -567,7 +567,7 @@ class MySQLOperatorCharm(CharmBase):
         if not self.unit.is_leader():
             return
 
-        planned_units = self.app.planned_units()
+        current_units = 1 + len(self.peers.units)
 
         cluster_status = self._mysql.get_cluster_status()
         if not cluster_status:
@@ -577,7 +577,7 @@ class MySQLOperatorCharm(CharmBase):
         addresses_of_units_to_remove = [
             member["address"]
             for unit_name, member in cluster_status["defaultreplicaset"]["topology"].items()
-            if int(unit_name.split("-")[-1]) >= planned_units
+            if int(unit_name.split("-")[-1]) >= current_units
         ]
 
         if not addresses_of_units_to_remove:


### PR DESCRIPTION
## Issue

planned units is flaky
This is related to [DPE-915](https://warthogs.atlassian.net/browse/DPE-915), since enables correctly removal of departing unit.
Unit departed still refuses to go away in `terminated` state, but it's possible to scale up over the `terminated` unit(s).

## Solution

using peer databag units mapping instead

[DPE-915]: https://warthogs.atlassian.net/browse/DPE-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ