### PR TITLE
DPE-2064 fix datadir permissions via chmod

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -332,6 +332,7 @@ class MySQLOperatorCharm(CharmBase):
             # Run mysqld for the first time to
             # bootstrap the data directory and users
             logger.debug("Initializing instance")
+            self._mysql.fix_data_dir()
             self._mysql.initialise_mysqld()
 
             # Add the pebble layer

--- a/src/charm.py
+++ b/src/charm.py
@@ -332,7 +332,7 @@ class MySQLOperatorCharm(CharmBase):
             # Run mysqld for the first time to
             # bootstrap the data directory and users
             logger.debug("Initializing instance")
-            self._mysql.fix_data_dir()
+            self._mysql.fix_data_dir(container)
             self._mysql.initialise_mysqld()
 
             # Add the pebble layer

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -189,6 +189,7 @@ class MySQL(MySQLBase):
         assert len(paths) == 1, "list_files doesn't return only directory itself"
         logger.debug(f"Data directory ownership: {paths[0].user}:{paths[0].group}")
         if paths[0].user != MYSQL_SYSTEM_USER or paths[0].group != MYSQL_SYSTEM_GROUP:
+            logger.debug(f"Changing ownership to {MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP}")
             try:
                 container.exec(
                     f"chown -R {MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP} {MYSQL_DATA_DIR}".split(
@@ -196,11 +197,8 @@ class MySQL(MySQLBase):
                     )
                 )
             except ExecError as e:
-                logger.error("Exited with code %d. Stderr:", e.exit_code)
-                if e.stderr:
-                    for line in e.stderr.splitlines():
-                        logger.error("  %s", line)
-                raise MySQLInitialiseMySQLDError(e.stderr if e.stderr else "")
+                logger.error(f"Exited with code {e.exit_code}. Stderr:\n{e.stderr}")
+                raise MySQLInitialiseMySQLDError(e.stderr or "")
 
     def initialise_mysqld(self) -> None:
         """Execute instance first run.

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -191,7 +191,7 @@ class MySQL(MySQLBase):
         if paths[0].user != MYSQL_SYSTEM_USER or paths[0].group != MYSQL_SYSTEM_GROUP:
             try:
                 container.exec(
-                    f"chown -o {MYSQL_SYSTEM_USER} -g {MYSQL_SYSTEM_GROUP} -R {MYSQL_DATA_DIR}".split(
+                    f"chown -R {MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP} {MYSQL_DATA_DIR}".split(
                         " "
                     )
                 )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -88,6 +88,7 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.create_cluster")
     @patch("mysql_k8s_helpers.MySQL.create_custom_config_file")
     @patch("mysql_k8s_helpers.MySQL.initialise_mysqld")
+    @patch("mysql_k8s_helpers.MySQL.fix_data_dir")
     @patch("mysql_k8s_helpers.MySQL.is_instance_in_cluster")
     @patch("mysql_k8s_helpers.MySQL.get_member_state", return_value=("online", "primary"))
     @patch(
@@ -99,6 +100,7 @@ class TestCharm(unittest.TestCase):
         _get_member_state,
         _is_instance_in_cluster,
         _initialise_mysqld,
+        _fix_data_dir,
         _create_custom_config_file,
         _create_cluster,
         _configure_instance,


### PR DESCRIPTION
## Issue
The charm `mysql-k8s` cannot be deployed to AWS EKS, GKE, Charmed Kubernetes with an error:
```
ERROR unit.katib-db/0.juju-log   mysqld: Can't create/write to file '/var/lib/mysql/is_writable' (OS errno 13 - Permission denied)
```

Fixes https://github.com/canonical/mysql-k8s-operator/issues/237, https://github.com/canonical/mysql-k8s-operator/issues/239,  [DPE-1919](https://warthogs.atlassian.net/browse/DPE-1919), [DPE-2064](https://warthogs.atlassian.net/browse/DPE-2064), [DPE-2066](https://warthogs.atlassian.net/browse/DPE-2066).

## Solution

Set the proper owner for the DB Data folder (to be accessible by database).
See more details in [DPE-1919](https://warthogs.atlassian.net/browse/DPE-1919?focusedCommentId=254368).


[DPE-1919]: https://warthogs.atlassian.net/browse/DPE-1919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-2064]: https://warthogs.atlassian.net/browse/DPE-2064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-2066]: https://warthogs.atlassian.net/browse/DPE-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-1919]: https://warthogs.atlassian.net/browse/DPE-1919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ