### PR TITLE
DPE-915 fix storage re-use bug

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,12 +11,9 @@ bases:
         channel: "22.04"
 parts:
   charm:
-    charm-binary-python-packages:
-      - boto3==1.26.117
-      - cryptography==38.0.2
-      - jsonschema==4.16.0
-      - lightkube==0.12.0
-      - ops >= 2.0.0
-      - tenacity==8.0.1
-      - urllib3==1.26.15
+    build-packages:
+      - libffi-dev
+      - libssl-dev
+      - rustc
+      - cargo
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -472,7 +472,6 @@ class MySQLOperatorCharm(CharmBase):
     def _on_peer_relation_joined(self, _) -> None:
         """Handle the peer relation joined event."""
         # set some initial unit data
-        self.unit_peer_data.setdefault("instance-hostname", self._get_unit_fqdn(self.unit.name))
         self.unit_peer_data.setdefault("member-role", "unknown")
         self.unit_peer_data.setdefault("member-state", "waiting")
 

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -640,6 +640,19 @@ class MySQL(MySQLBase):
             logger.exception(error_message)
             raise MySQLStartMySQLDError(error_message)
 
+    def stop_group_replication(self) -> None:
+        """Stop Group replication if enabled on the instance."""
+        stop_gr_command = (
+            f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
+            "data = session.run_sql('SELECT 1 FROM performance_schema.replication_group_members')",
+            "if len(data.fetch_all()) > 0:",
+            "    session.run_sql('STOP GROUP_REPLICATION')",
+        )
+        try:
+            self._run_mysqlsh_script("\n".join(stop_gr_command))
+        except ExecError:
+            logger.debug("Failed to stop Group Replication for unit")
+
     def _execute_commands(
         self,
         commands: List[str],

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -825,3 +825,39 @@ class MySQL(MySQLBase):
         return 796917760
 
         return super()._get_total_memory()
+
+    def is_data_dir_initialised(self) -> bool:
+        """Check if data dir is initialised.
+
+        Returns:
+            A bool for an initialised and integral data dir.
+        """
+        try:
+            content = self.container.list_files(MYSQL_DATA_DIR)
+            content_set = {item.name for item in content}
+
+            # minimal expected content for an integral mysqld data-dir
+            expected_content = {
+                "#innodb_redo",
+                "#innodb_temp",
+                "auto.cnf",
+                "ca-key.pem",
+                "ca.pem",
+                "client-cert.pem",
+                "client-key.pem",
+                "ib_buffer_pool",
+                "mysql",
+                "mysql.ibd",
+                "performance_schema",
+                "private_key.pem",
+                "public_key.pem",
+                "server-cert.pem",
+                "server-key.pem",
+                "sys",
+                "undo_001",
+                "undo_002",
+            }
+
+            return expected_content <= content_set
+        except ExecError:
+            return False

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -285,3 +285,20 @@ async def test_exporter_endpoints(ops_test: OpsTest) -> None:
         assert "mysql_exporter_last_scrape_error 0" in resp.data.decode(
             "utf8"
         ), "Scrape error in mysql_exporter"
+
+
+@pytest.mark.abort_on_fail
+async def test_scale_up_after_scale_down(ops_test: OpsTest) -> None:
+    """Confirm storage reuse works."""
+    async with ops_test.fast_forward():
+        random_unit = ops_test.model.applications[APP_NAME].units[0]
+
+        await scale_application(ops_test, APP_NAME, 3)
+
+        cluster_status = await get_cluster_status(ops_test, random_unit)
+        online_member_addresses = [
+            member["address"]
+            for _, member in cluster_status["defaultreplicaset"]["topology"].items()
+            if member["status"] == "online"
+        ]
+        assert len(online_member_addresses) == 3

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,7 +6,7 @@
 import unittest
 from unittest.mock import PropertyMock, patch
 
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import MySQLOperatorCharm
@@ -80,6 +80,7 @@ class TestCharm(unittest.TestCase):
                 peer_data[password].isalnum() and len(peer_data[password]) == PASSWORD_LENGTH
             )
 
+    @patch("mysql_k8s_helpers.MySQL.is_data_dir_initialised", return_value=False)
     @patch("mysql_k8s_helpers.MySQL.initialize_juju_units_operations_table")
     @patch("mysql_k8s_helpers.MySQL.safe_stop_mysqld_safe")
     @patch("mysql_k8s_helpers.MySQL.get_mysql_version", return_value="8.0.0")
@@ -110,6 +111,7 @@ class TestCharm(unittest.TestCase):
         _get_mysql_version,
         _safe_stop_mysqld_safe,
         _initialize_juju_units_operations_table,
+        _is_data_dir_initialised,
     ):
         # Check if initial plan is empty
         self.harness.set_can_connect("mysql", True)
@@ -156,7 +158,7 @@ class TestCharm(unittest.TestCase):
         # Trigger pebble ready after leader election
         self.harness.container_pebble_ready("mysql")
 
-        self.assertTrue(isinstance(self.charm.unit.status, BlockedStatus))
+        self.assertFalse(isinstance(self.charm.unit.status, ActiveStatus))
 
     def test_on_config_changed(self):
         # Test config changed set of cluster name
@@ -168,7 +170,8 @@ class TestCharm(unittest.TestCase):
             self.charm.peers.data[self.charm.app]["cluster-name"], "not_valid_cluster_name"
         )
 
-    def test_mysql_property(self):
+    @patch("mysql_k8s_helpers.MySQL.is_data_dir_initialised", return_value=False)
+    def test_mysql_property(self, _):
         # Test mysql property instance of mysql_k8s_helpers.MySQL
         # set leader and populate peer relation data
         self.harness.set_leader()


### PR DESCRIPTION
## Issue

Failing to reuse previously storage on the charm.

## Solution

If data directory is populated with mysql typical data, the charm tries to use start mysqld and rejoin the unit to the cluster.

_Note 1: The `unit-configured` unit peer key, that indicate if a unit was already configured, was replaced with a method to check the mysql data directory directly._ 

_Note 2: case there's a `clusteradmin` password rotation before the scale up, joining the unit will fail, since the passwords will be out of sync. There's a backlog task (dpe-2186) to track this scenario._