### PR TITLE
DPE-2225 using allocable memory instead of `free`

### DIFF
--- a/lib/charms/mysql/v0/backups.py
+++ b/lib/charms/mysql/v0/backups.py
@@ -77,7 +77,7 @@ from charms.mysql.v0.s3_helpers import (
     list_backups_in_s3_path,
     upload_content_to_s3,
 )
-from ops.charm import ActionEvent, CharmBase
+from ops.charm import ActionEvent
 from ops.framework import Object
 from ops.jujuversion import JujuVersion
 from ops.model import ActiveStatus, BlockedStatus

--- a/lib/charms/mysql/v0/backups.py
+++ b/lib/charms/mysql/v0/backups.py
@@ -49,6 +49,7 @@ import datetime
 import logging
 import pathlib
 from typing import Dict, List, Optional, Tuple
+import typing
 
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.mysql.v0.mysql import (
@@ -98,10 +99,14 @@ LIBAPI = 0
 LIBPATCH = 6
 
 
+if typing.TYPE_CHECKING:
+    from charm import MySQLOperatorCharm
+
+
 class MySQLBackups(Object):
     """Encapsulation of backups for MySQL."""
 
-    def __init__(self, charm: CharmBase, s3_integrator: S3Requirer) -> None:
+    def __init__(self, charm: "MySQLOperatorCharm", s3_integrator: S3Requirer) -> None:
         super().__init__(charm, MYSQL_BACKUPS)
 
         self.charm = charm
@@ -251,7 +256,7 @@ Stderr:
         can_unit_perform_backup, validation_message = self._can_unit_perform_backup()
         if not can_unit_perform_backup:
             logger.error(f"Backup failed: {validation_message}")
-            event.fail(validation_message)
+            event.fail(validation_message or "")
             return
 
         # Test uploading metadata to S3 to test credentials before backup
@@ -272,14 +277,14 @@ Juju Version: {str(juju_version)}
         success, error_message = self._pre_backup()
         if not success:
             logger.error(f"Backup failed: {error_message}")
-            event.fail(error_message)
+            event.fail(error_message or "")
             return
 
         # Perform the backup
         success, error_message = self._backup(backup_path, s3_parameters)
         if not success:
             logger.error(f"Backup failed: {error_message}")
-            event.fail(error_message)
+            event.fail(error_message or "")
 
             success, error_message = self._post_backup()
             if not success:
@@ -297,7 +302,7 @@ Juju Version: {str(juju_version)}
             self.charm.unit.status = BlockedStatus(
                 "Failed to create backup; instance in bad state"
             )
-            event.fail(error_message)
+            event.fail(error_message or "")
             return
 
         logger.info(f"Backup succeeded: with backup-id {datetime_backup_requested}")

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1418,7 +1418,7 @@ class MySQLBase(ABC):
 
         # output is like:
         # 'MEMBER_STATE\tMEMBER_ROLE\tMEMBER_ID\t@@server_uuid\nONLINE\tPRIMARY\t<uuid>\t<uuid>\n'
-        lines = output.lower().split("\n")
+        lines = output.strip().lower().split("\n")
         if len(lines) < 2:
             raise MySQLGetMemberStateError("No member state retrieved")
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -96,9 +96,9 @@ LIBPATCH = 37
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
 
-BYTES_1GB = 1073741824  # 1 gibibyte
-BYTES_1Gb = 1000000000  # 1 gigabyte
-BYTES_1MB = 1048576     # 1 mebibyte
+BYTES_1GiB = 1073741824  # 1 gibibyte
+BYTES_1GB = 1000000000  # 1 gigabyte
+BYTES_1MiB = 1048576     # 1 mebibyte
 
 class Error(Exception):
     """Base class for exceptions in this module."""
@@ -1527,9 +1527,9 @@ class MySQLBase(ABC):
         # Reference: based off xtradb-cluster-operator
         # https://github.com/percona/percona-xtradb-cluster-operator/blob/main/pkg/pxc/app/config/autotune.go#L31-L54
 
-        chunk_size_min = BYTES_1MB
-        chunk_size_default = 128 * BYTES_1MB
-        group_replication_message_cache = BYTES_1GB
+        chunk_size_min = BYTES_1MiB
+        chunk_size_default = 128 * BYTES_1MiB
+        group_replication_message_cache = BYTES_1GiB
 
         try:
             innodb_buffer_pool_chunk_size = None
@@ -1537,14 +1537,14 @@ class MySQLBase(ABC):
 
             pool_size = int(total_memory * 0.75) - group_replication_message_cache
 
-            if total_memory - pool_size < BYTES_1Gb:
+            if total_memory - pool_size < BYTES_1GB:
                 pool_size = int(total_memory * 0.5) - group_replication_message_cache
 
             if pool_size % chunk_size_default != 0:
                 # round pool_size to be a multiple of chunk_size_default
                 pool_size += chunk_size_default - (pool_size % chunk_size_default)
 
-            if pool_size > BYTES_1GB:
+            if pool_size > BYTES_1GiB:
                 chunk_size = int(pool_size / 8)
 
                 if chunk_size % chunk_size_min != 0:
@@ -1565,7 +1565,7 @@ class MySQLBase(ABC):
         # Reference: based off xtradb-cluster-operator
         # https://github.com/percona/percona-xtradb-cluster-operator/blob/main/pkg/pxc/app/config/autotune.go#L61-L70
 
-        bytes_per_connection = 12 * BYTES_1MB  # 12 Megabytes
+        bytes_per_connection = 12 * BYTES_1MiB
         total_memory = 0
 
         try:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1800,7 +1800,7 @@ Swap:     1027600384  1027600384           0
     ) -> Tuple[str, str]:
         """Prepare the backup in the provided dir for restore."""
         try:
-            innodb_buffer_pool_size, _ = self.get_innodb_buffer_pool_parameters()
+            innodb_buffer_pool_size, _, _ = self.get_innodb_buffer_pool_parameters()
         except MySQLGetAutoTunningParametersError as e:
             raise MySQLPrepareBackupForRestoreError(e)
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -519,7 +519,7 @@ class MySQLBase(ABC):
         password: str,
         hostname: str,
         *,
-        unit_name: str = None,
+        unit_name: Optional[str] = None,
         create_database: bool = True,
     ) -> None:
         """Create an application database and a user scoped to the created database.
@@ -1252,7 +1252,9 @@ class MySQLBase(ABC):
 
         return (member_addresses, "<MEMBER_ADDRESSES>" in output)
 
-    def get_cluster_primary_address(self, connect_instance_address: str = None) -> Optional[str]:
+    def get_cluster_primary_address(
+        self, connect_instance_address: Optional[str] = None
+    ) -> Optional[str]:
         """Get the cluster primary's address.
 
         Keyword args:
@@ -1617,8 +1619,8 @@ Swap:     1027600384  1027600384           0
         mysqld_socket_file: str,
         tmp_base_directory: str,
         defaults_config_file: str,
-        user: str = None,
-        group: str = None,
+        user: Optional[str] = None,
+        group: Optional[str] = None,
     ) -> Tuple[str, str]:
         """Executes commands to create a backup with the given args."""
         nproc_command = "nproc".split()
@@ -1694,8 +1696,8 @@ Swap:     1027600384  1027600384           0
     def delete_temp_backup_directory(
         self,
         tmp_base_directory: str,
-        user: str = None,
-        group: str = None,
+        user: Optional[str] = None,
+        group: Optional[str] = None,
     ) -> None:
         """Delete the temp backup directory."""
         delete_temp_dir_command = f"find {tmp_base_directory} -wholename {tmp_base_directory}/xtra_backup_* -delete".split()
@@ -1918,8 +1920,8 @@ Swap:     1027600384  1027600384           0
         self,
         commands: List[str],
         bash: bool = False,
-        user: str = None,
-        group: str = None,
+        user: Optional[str] = None,
+        group: Optional[str] = None,
         env: Dict = {},
     ) -> Tuple[str, str]:
         """Execute commands on the server where MySQL is running."""
@@ -2024,7 +2026,11 @@ Swap:     1027600384  1027600384           0
 
     @abstractmethod
     def _run_mysqlcli_script(
-        self, script: str, user: str = "root", password: str = None, timeout: Optional[int] = None
+        self,
+        script: str,
+        user: str = "root",
+        password: Optional[str] = None,
+        timeout: Optional[int] = None,
     ) -> str:
         """Execute a MySQL CLI script.
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -91,7 +91,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 36
+LIBPATCH = 37
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1413,11 +1413,15 @@ class MySQLBase(ABC):
             )
             raise MySQLGetMemberStateError(e.message)
 
+        # output is like:
+        # 'MEMBER_STATE\tMEMBER_ROLE\tMEMBER_ID\t@@server_uuid\nONLINE\tPRIMARY\t<uuid>\t<uuid>\n'
         lines = output.lower().split("\n")
         if len(lines) < 2:
             raise MySQLGetMemberStateError("No member state retrieved")
 
         for line in lines[1:]:
+            # results will be like:
+            # ['online', 'primary', 'a6c00302-1c07-11ee-bca1-...', 'a6c00302-1c07-11ee-bca1-...']
             results = line.split("\t")
             if results[2] == results[3]:
                 # filter server uuid

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1420,6 +1420,12 @@ class MySQLBase(ABC):
         if len(lines) < 2:
             raise MySQLGetMemberStateError("No member state retrieved")
 
+        if len(lines) == 2:
+            # Instance just know it own state
+            # sometimes member_id is not populated
+            results = lines[1].split("\t")
+            return results[0], results[1] or "unknown"
+
         for line in lines[1:]:
             # results will be like:
             # ['online', 'primary', 'a6c00302-1c07-11ee-bca1-...', 'a6c00302-1c07-11ee-bca1-...']
@@ -1427,12 +1433,6 @@ class MySQLBase(ABC):
             if results[2] == results[3]:
                 # filter server uuid
                 return results[0], results[1] or "unknown"
-
-        if len(lines) == 2:
-            # Instance just know it own state
-            # sometimes member_id is not populated
-            results = lines[1].split("\t")
-            return results[0], results[1] or "unknown"
 
         raise MySQLGetMemberStateError("No member state retrieved")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -310,6 +310,7 @@ class MySQLOperatorCharm(CharmBase):
                 (
                     innodb_buffer_pool_size,
                     innodb_buffer_pool_chunk_size,
+                    group_replication_message_cache_size,
                 ) = self._mysql.get_innodb_buffer_pool_parameters()
                 group_replication_message_cache_size = None
                 max_connections = self._mysql.get_max_connections()

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,6 +13,7 @@ from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from charms.mysql.v0.backups import MySQLBackups
 from charms.mysql.v0.mysql import (
+    BYTES_1MB,
     MySQLAddInstanceToClusterError,
     MySQLConfigureInstanceError,
     MySQLConfigureMySQLUsersError,
@@ -300,14 +301,16 @@ class MySQLOperatorCharm(CharmBase):
             return True
 
         if profile == "testing":
-            innodb_buffer_pool_size = 20971520
-            innodb_buffer_pool_chunk_size = 1048576
+            innodb_buffer_pool_size = 20 * BYTES_1MB
+            innodb_buffer_pool_chunk_size = 1 * BYTES_1MB
+            group_replication_message_cache_size = 128 * BYTES_1MB
         else:
             try:
                 (
                     innodb_buffer_pool_size,
                     innodb_buffer_pool_chunk_size,
                 ) = self._mysql.get_innodb_buffer_pool_parameters()
+                group_replication_message_cache_size = None
             except MySQLGetInnoDBBufferPoolParametersError:
                 self.unit.status = BlockedStatus("Error computing innodb_buffer_pool_size")
                 return False
@@ -317,6 +320,7 @@ class MySQLOperatorCharm(CharmBase):
                 report_host=self._get_unit_fqdn(self.unit.name),
                 innodb_buffer_pool_size=innodb_buffer_pool_size,
                 innodb_buffer_pool_chunk_size=innodb_buffer_pool_chunk_size,
+                gr_message_cache_size=group_replication_message_cache_size,
             )
         except MySQLCreateCustomConfigFileError:
             self.unit.status = BlockedStatus("Failed to copy custom mysql config file")

--- a/src/charm.py
+++ b/src/charm.py
@@ -13,7 +13,7 @@ from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from charms.mysql.v0.backups import MySQLBackups
 from charms.mysql.v0.mysql import (
-    BYTES_1MB,
+    BYTES_1MiB,
     MySQLAddInstanceToClusterError,
     MySQLConfigureInstanceError,
     MySQLConfigureMySQLUsersError,
@@ -301,9 +301,9 @@ class MySQLOperatorCharm(CharmBase):
             return True
 
         if profile == "testing":
-            innodb_buffer_pool_size = 20 * BYTES_1MB
-            innodb_buffer_pool_chunk_size = 1 * BYTES_1MB
-            group_replication_message_cache_size = 128 * BYTES_1MB
+            innodb_buffer_pool_size = 20 * BYTES_1MiB
+            innodb_buffer_pool_chunk_size = 1 * BYTES_1MiB
+            group_replication_message_cache_size = 128 * BYTES_1MiB
             max_connections = 20
         else:
             try:

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -302,7 +302,6 @@ class MySQL(MySQLBase):
         if innodb_buffer_pool_chunk_size:
             content.append(f"innodb_buffer_pool_chunk_size = {innodb_buffer_pool_chunk_size}")
 
-        # TODO: Enable after GR is enabled
         if gr_message_cache_size:
             content.append(f"loose-group_replication_message_cache_size = {gr_message_cache_size}")
 

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -609,8 +609,8 @@ class MySQL(MySQLBase):
         self,
         commands: List[str],
         bash: bool = False,
-        user: str = None,
-        group: str = None,
+        user: Optional[str] = None,
+        group: Optional[str] = None,
         env: Dict = {},
     ) -> Tuple[str, str]:
         """Execute commands on the server where MySQL is running."""
@@ -625,7 +625,7 @@ class MySQL(MySQLBase):
                 environment=env,
             )
             stdout, stderr = process.wait_output()
-            return (stdout, stderr)
+            return (stdout, stderr or "")
         except ExecError as e:
             logger.debug(f"Failed command: {commands=}, {user=}, {group=}")
             raise MySQLExecError(e.stderr)

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -303,8 +303,8 @@ class MySQL(MySQLBase):
             content.append(f"innodb_buffer_pool_chunk_size = {innodb_buffer_pool_chunk_size}")
 
         # TODO: Enable after GR is enabled
-        # if gr_message_cache_size:
-        #    content.append(f"group_replication_message_cache_size = {gr_message_cache_size}")
+        if gr_message_cache_size:
+            content.append(f"loose-group_replication_message_cache_size = {gr_message_cache_size}")
 
         try:
             content.append("")

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -305,8 +305,8 @@ class MySQL(MySQLBase):
         if gr_message_cache_size:
             content.append(f"loose-group_replication_message_cache_size = {gr_message_cache_size}")
 
+        content.append("")
         try:
-            content.append("")
             self.container.push(MYSQLD_CONFIG_FILE, source="\n".join(content))
         except Exception:
             raise MySQLCreateCustomConfigFileError()

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -5,7 +5,7 @@ import itertools
 import json
 import secrets
 import string
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import mysql.connector
 import yaml
@@ -70,7 +70,7 @@ async def get_primary_unit(
     ops_test: OpsTest,
     unit: Unit,
     app_name: str,
-) -> str:
+) -> Optional[Unit]:
     """Helper to retrieve the primary unit.
 
     Args:

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -344,6 +344,10 @@ async def test_network_cut_affecting_an_instance(
         await ops_test.model.block_until(
             lambda: primary.workload_status == "maintenance", timeout=TIMEOUT
         )
+        logger.info("Wait until returning instance become active")
+        await ops_test.model.block_until(
+            lambda: primary.workload_status == "active", timeout=TIMEOUT
+        )
 
     logger.info("Wait until all units are online")
     await wait_until_units_in_status(ops_test, mysql_units, mysql_units[0], "online")

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -307,6 +307,8 @@ async def test_network_cut_affecting_an_instance(
     mysql_units = ops_test.model.applications[mysql_application_name].units
     primary = await get_primary_unit(ops_test, mysql_units[0], mysql_application_name)
 
+    assert primary is not None, "No primary unit found"
+
     logger.info(
         f"Creating networkchaos policy to isolate instance {primary.name} from the cluster"
     )
@@ -336,6 +338,12 @@ async def test_network_cut_affecting_an_instance(
 
     logger.info("Remove networkchaos policy isolating instance from cluster")
     remove_instance_isolation(ops_test)
+
+    async with ops_test.fast_forward():
+        logger.info("Wait until returning instance enters recovery")
+        await ops_test.model.block_until(
+            lambda: primary.workload_status == "maintenance", timeout=TIMEOUT
+        )
 
     logger.info("Wait until all units are online")
     await wait_until_units_in_status(ops_test, mysql_units, mysql_units[0], "online")

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -342,7 +342,7 @@ async def test_network_cut_affecting_an_instance(
     async with ops_test.fast_forward():
         logger.info("Wait until returning instance enters recovery")
         await ops_test.model.block_until(
-            lambda: primary.workload_status == "maintenance", timeout=TIMEOUT
+            lambda: primary.workload_status != "active", timeout=TIMEOUT
         )
         logger.info("Wait until returning instance become active")
         await ops_test.model.block_until(

--- a/tests/integration/relations/test_mysql_root.py
+++ b/tests/integration/relations/test_mysql_root.py
@@ -33,6 +33,7 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest) -> None:
         config = {
             "mysql-root-interface-user": "keystone",
             "mysql-root-interface-database": "keystone",
+            "profile": "testing",
         }
 
         osm_pol_resources = {
@@ -47,6 +48,7 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest) -> None:
                 config=config,
                 num_units=3,
                 series="jammy",
+                trust=True,
             ),
             # Deploy the osm-keystone charm
             # (using ops_test.juju instead of ops_test.deploy as the latter does

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -309,6 +309,7 @@ async def test_custom_variables(ops_test: OpsTest) -> None:
     custom_vars["max_connections"] = 20
     custom_vars["innodb_buffer_pool_size"] = 20971520
     custom_vars["innodb_buffer_pool_chunk_size"] = 1048576
+    custom_vars["group_replication_message_cache_size"] = 134217728
 
     for unit in application.units:
         for k, v in custom_vars.items():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -95,7 +95,8 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.is_instance_in_cluster")
     @patch("mysql_k8s_helpers.MySQL.get_member_state", return_value=("online", "primary"))
     @patch(
-        "mysql_k8s_helpers.MySQL.get_innodb_buffer_pool_parameters", return_value=(123456, None)
+        "mysql_k8s_helpers.MySQL.get_innodb_buffer_pool_parameters",
+        return_value=(123456, None, None),
     )
     @patch("mysql_k8s_helpers.MySQL.get_max_connections", return_value=(120, None))
     def test_mysql_pebble_ready(
@@ -157,7 +158,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader()
         self.charm.on.config_changed.emit()
         self.charm._mysql = _mysql_mock
-        _mysql_mock.get_innodb_buffer_pool_parameters.return_value = (123456, None)
+        _mysql_mock.get_innodb_buffer_pool_parameters.return_value = (123456, None, None)
         _mysql_mock.initialise_mysqld.side_effect = MySQLInitialiseMySQLDError
         # Trigger pebble ready after leader election
         self.harness.container_pebble_ready("mysql")


### PR DESCRIPTION
## Issue

Mysqld should not use node total memory for parameters auto tuning.

## Solution

* Use k8s allocable memory as baseline for usable memory.
* consider `group_replication_message_cache_size` for calculating available pool size
* use smaller possible `group_replication_message_cache_size` when using `testing` profile

Extra: [The commit](https://github.com/canonical/mysql-k8s-operator/pull/256/commits/a1fb0332c24d9461f9ddead70e24bdb591b4ad30) address [DPE-2274](https://warthogs.atlassian.net/browse/DPE-2274) 

closes #254 

[DPE-2274]: https://warthogs.atlassian.net/browse/DPE-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ