### PR TITLE
DPE-2068 use kill-delay

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ boto3==1.26.117
 cryptography==38.0.2
 jsonschema==4.16.0
 lightkube==0.12.0
-ops >= 2.0.0
+ops >= 2.5.0
 tenacity==8.0.1
 urllib3==1.26.15

--- a/src/charm.py
+++ b/src/charm.py
@@ -204,7 +204,7 @@ class MySQLOperatorCharm(CharmBase):
                         "startup": "enabled",
                         "user": MYSQL_SYSTEM_USER,
                         "group": MYSQL_SYSTEM_GROUP,
-                        "kill-delay": "2h",
+                        "kill-delay": "24h",
                     },
                     MYSQLD_EXPORTER_SERVICE: {
                         "override": "replace",

--- a/src/charm.py
+++ b/src/charm.py
@@ -204,6 +204,7 @@ class MySQLOperatorCharm(CharmBase):
                         "startup": "enabled",
                         "user": MYSQL_SYSTEM_USER,
                         "group": MYSQL_SYSTEM_GROUP,
+                        "kill-delay": "2h",
                     },
                     MYSQLD_EXPORTER_SERVICE: {
                         "override": "replace",
@@ -472,7 +473,6 @@ class MySQLOperatorCharm(CharmBase):
             # Add the pebble layer
             logger.debug("Adding pebble layer")
             container.add_layer(MYSQLD_SAFE_SERVICE, self._pebble_layer, combine=False)
-            self._mysql.safe_stop_mysqld_safe()
             container.restart(MYSQLD_SAFE_SERVICE)
 
             logger.debug("Waiting for instance to be ready")

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -6,7 +6,6 @@
 
 import json
 import logging
-from time import sleep
 from typing import Dict, List, Optional, Tuple
 
 from charms.mysql.v0.mysql import (
@@ -751,31 +750,6 @@ class MySQL(MySQLBase):
             return True
         except ExecError as e:
             raise MySQLClientError(e.stderr)
-
-    def safe_stop_mysqld_safe(self):
-        """Safely stop mysqld.
-
-        TODO: remove when https://github.com/canonical/pebble/pull/190 is merged/released
-        """
-
-        def get_mysqld_safe_pid(self):
-            try:
-                process = self.container.exec(["pgrep", "-x", MYSQLD_SAFE_SERVICE])
-                pid, _ = process.wait_output()
-                return pid
-            except ExecError:
-                return 0
-
-        logger.debug("Safe stopping mysqld safe")
-        pid = initial_pid = get_mysqld_safe_pid(self)
-        if pid == 0:
-            return
-        self.container.exec(["pkill", "-15", MYSQLD_SAFE_SERVICE])
-
-        # Wait for mysqld to stop
-        while initial_pid == pid:
-            pid = get_mysqld_safe_pid(self)
-            sleep(0.1)
 
     def _get_total_memory(self) -> int:
         """Get total memory of the container in bytes."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -83,7 +83,6 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.is_data_dir_initialised", return_value=False)
     @patch("mysql_k8s_helpers.MySQL.create_cluster_set")
     @patch("mysql_k8s_helpers.MySQL.initialize_juju_units_operations_table")
-    @patch("mysql_k8s_helpers.MySQL.safe_stop_mysqld_safe")
     @patch("mysql_k8s_helpers.MySQL.get_mysql_version", return_value="8.0.0")
     @patch("mysql_k8s_helpers.MySQL.wait_until_mysql_connection")
     @patch("mysql_k8s_helpers.MySQL.configure_mysql_users")
@@ -110,7 +109,6 @@ class TestCharm(unittest.TestCase):
         _configure_mysql_users,
         _wait_until_mysql_connection,
         _get_mysql_version,
-        _safe_stop_mysqld_safe,
         _initialize_juju_units_operations_table,
         _is_data_dir_initialised,
         _create_cluster_set,
@@ -133,8 +131,6 @@ class TestCharm(unittest.TestCase):
         # After configuration run, plan should be populated
         plan = self.harness.get_container_pebble_plan("mysql")
         self.assertEqual(plan.to_dict()["services"], self.layer_dict["services"])
-
-        _safe_stop_mysqld_safe.assert_called_once()
 
     @patch("charm.MySQLOperatorCharm._mysql", new_callable=PropertyMock)
     def test_mysql_pebble_ready_non_leader(self, _mysql_mock):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -41,6 +41,7 @@ class TestCharm(unittest.TestCase):
                     "startup": "enabled",
                     "user": "mysql",
                     "group": "mysql",
+                    "kill-delay": "24h",
                 },
                 "mysqld_exporter": {
                     "override": "replace",

--- a/tests/unit/test_mysql_k8s_helpers.py
+++ b/tests/unit/test_mysql_k8s_helpers.py
@@ -335,16 +335,3 @@ class TestMySQL(unittest.TestCase):
 
         with self.assertRaises(MySQLWaitUntilUnitRemovedFromClusterError):
             self.mysql._wait_until_unit_removed_from_cluster("mysql-0.mysql-endpoints")
-
-    @patch("ops.model.Container")
-    def test_safe_stop_mysqld_safe(self, _container):
-        """Test the successful execution of safe_stop_mysqld_safe."""
-        _container.exec.return_value = MagicMock()
-        _container.exec.return_value.wait_output.return_value = (
-            0,
-            b"stderr",
-        )
-        self.mysql.container = _container
-        self.mysql.safe_stop_mysqld_safe()
-
-        _container.exec.assert_called_once()


### PR DESCRIPTION
## Issue

Workaround for pebble fixed 5s delay `SIGKILL` after `SIGTERM`

**BLOCKED BY**: ~ops [PR#975](https://github.com/canonical/operator/pull/975)~ next ops release (2.5.0 maybe?)


## Solution

Use kill-delay