### PR TITLE
Update juju pin to 2.9.43.0 and pin macaroonbakery to 1.3.1 in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -193,7 +193,9 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
-    juju==2.9.38.1
+    juju==2.9.43.0
+; Force compatible mysql-connector-python version <8.1.0: https://github.com/juju/python-libjuju/issues/914
+    macaroonbakery==1.3.1
     mysql-connector-python
     pytest
     pdbpp

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,9 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
-    juju==2.9.38.1
+    juju==2.9.43.0
+; Force compatible mysql-connector-python version <8.1.0: https://github.com/juju/python-libjuju/issues/914
+    macaroonbakery==1.3.1
     lightkube
     mysql-connector-python
     pytest
@@ -92,7 +94,9 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
-    juju==2.9.38.1
+    juju==2.9.43.0
+; Force compatible mysql-connector-python version <8.1.0: https://github.com/juju/python-libjuju/issues/914
+    macaroonbakery==1.3.1
     lightkube
     mysql-connector-python
     pytest
@@ -108,7 +112,9 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
-    juju==2.9.38.1
+    juju==2.9.43.0
+; Force compatible mysql-connector-python version <8.1.0: https://github.com/juju/python-libjuju/issues/914
+    macaroonbakery==1.3.1
     lightkube
     mysql-connector-python
     pytest
@@ -124,7 +130,9 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
-    juju==2.9.38.1
+    juju==2.9.43.0
+; Force compatible mysql-connector-python version <8.1.0: https://github.com/juju/python-libjuju/issues/914
+    macaroonbakery==1.3.1
     lightkube
     mysql-connector-python
     pytest
@@ -140,7 +148,9 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
-    juju==2.9.38.1
+    juju==2.9.43.0
+; Force compatible mysql-connector-python version <8.1.0: https://github.com/juju/python-libjuju/issues/914
+    macaroonbakery==1.3.1
     kubernetes
     lightkube
     mysql-connector-python
@@ -157,7 +167,9 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
-    juju==2.9.38.1
+    juju==2.9.43.0
+; Force compatible mysql-connector-python version <8.1.0: https://github.com/juju/python-libjuju/issues/914
+    macaroonbakery==1.3.1
     lightkube
     mysql-connector-python
     pytest
@@ -177,7 +189,9 @@ pass_env =
     GCP_ACCESS_KEY
     GCP_SECRET_KEY
 deps =
-    juju==2.9.38.1
+    juju==2.9.43.0
+; Force compatible mysql-connector-python version <8.1.0: https://github.com/juju/python-libjuju/issues/914
+    macaroonbakery==1.3.1
     lightkube
     mysql-connector-python
     pytest


### PR DESCRIPTION
## Issue
- We are unable to run tests due to https://github.com/juju/python-libjuju/issues/914

## Solution
Pin macaroonbakery to 1.3.1
Update pin of juju to 2.9.43.0