### PR TITLE
DPE-2352 Start mysqld-exporter on COS relation and restart upon monitoring password change

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -88,6 +88,7 @@ from constants import (
     BACKUPS_USERNAME,
     CLUSTER_ADMIN_PASSWORD_KEY,
     CLUSTER_ADMIN_USERNAME,
+    COS_AGENT_RELATION_NAME,
     MONITORING_PASSWORD_KEY,
     MONITORING_USERNAME,
     PASSWORD_LENGTH,
@@ -110,7 +111,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 38
+LIBPATCH = 39
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -403,6 +404,12 @@ class MySQLCharmBase(CharmBase):
         self._mysql.update_user_password(username, new_password)
 
         self.set_secret("app", secret_key, new_password)
+
+        if (
+            username == MONITORING_USERNAME
+            and len(self.model.relations.get(COS_AGENT_RELATION_NAME, [])) > 0
+        ):
+            self._mysql.restart_mysql_exporter()
 
     def _get_cluster_status(self, event: ActionEvent) -> None:
         """Action used  to retrieve the cluster status."""
@@ -2293,6 +2300,11 @@ Swap:     1027600384  1027600384           0
     @abstractmethod
     def start_mysqld(self) -> None:
         """Starts the mysqld process."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def restart_mysql_exporter(self) -> None:
+        """Restart the mysqld exporter."""
         raise NotImplementedError
 
     @abstractmethod

--- a/src/constants.py
+++ b/src/constants.py
@@ -46,3 +46,5 @@ MYSQLD_EXPORTER_PORT = "9104"
 MYSQLD_EXPORTER_SERVICE = "mysqld_exporter"
 GR_MAX_MEMBERS = 9
 SECRET_ID_KEY = "secret-id"
+# TODO: should be changed when adopting cos-agent
+COS_AGENT_RELATION_NAME = "metrics-endpoint"

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -137,6 +137,7 @@ class MySQL(MySQLBase):
         backups_password: str,
         container: Container,
         k8s_helper: KubernetesHelpers,
+        charm,
     ):
         """Initialize the MySQL class.
 
@@ -172,6 +173,7 @@ class MySQL(MySQLBase):
         )
         self.container = container
         self.k8s_helper = k8s_helper
+        self.charm = charm
 
     def fix_data_dir(self, container: Container) -> None:
         """Ensure the data directory for mysql is writable for the "mysql" user.
@@ -590,6 +592,10 @@ class MySQL(MySQLBase):
             error_message = f"Failed to start service {MYSQLD_SAFE_SERVICE}"
             logger.exception(error_message)
             raise MySQLStartMySQLDError(error_message)
+
+    def restart_mysql_exporter(self) -> None:
+        """Restarts the mysqld exporter service in pebble."""
+        self.charm._reconcile_pebble_layer(self.container)
 
     def stop_group_replication(self) -> None:
         """Stop Group replication if enabled on the instance."""


### PR DESCRIPTION
## Issue
1. We are always running the mysqld-exporter, even if the relation with COS does not exist
2. We are not restarting mysqld-exporter when the password for the monitoring user changes

## Solution
1. Run `pwd` (or no-op) command in the mysql-exporter pebble service when no relation to COS exists. When a relation is formed, run the mysqld-exporter in the same pebble service (using pebble service override strategy)
2. Replan the pebble services upon monitoring user password changes (to run mysqld-exporter with the most up to date password) 
