### PR TITLE
Pin charmcraft to 2.3.0 in release.yaml to fix build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,8 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v4.2.0
+    with:
+      charmcraft-snap-revision: 1349  # version 2.3.0
 
   release:
     name: Release charm


### PR DESCRIPTION
charmcraft pinned to 2.3.0 in integration test build but not release build

https://github.com/canonical/charmcraft/issues/1179