### PR TITLE
DPE-2221 DPE-2224 Update mysql-image to the latest 8.0.33 rock

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,7 +32,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:017605f168fcc569d10372bb74b29ef9041256bd066013dec39e9ceee8c88539
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:753477ce39712221f008955b746fcf01a215785a215fe3de56f525380d14ad97
 
 peers:
   database-peers:


### PR DESCRIPTION
## Issue
We have built a new ROCK for charmed-mysql (with v8.0.33). This rock contains numerous updates including:
- proper licenses
- all packages installed from trusted sources
- bump to 8.0.33

## Solution
Use this new ROCK in the charm