### PR TITLE
DPE-2217 premptively switchover

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -683,6 +683,16 @@ class MySQLOperatorCharm(MySQLCharmBase):
         if not self._mysql.is_instance_in_cluster(self.unit_label):
             return
 
+        # Preemptively switch primary to unit 0
+        if (
+            self._mysql.get_primary_label() == self.unit_label
+            and self.unit.name.split("/")[1] != "0"
+        ):
+            logger.debug("Switching primary to unit 0")
+            self._mysql.set_cluster_primary(
+                new_primary_address=self._get_unit_fqdn(f"{self.app.name}/0")
+            )
+
         # The following operation uses locks to ensure that only one instance is removed
         # from the cluster at a time (to avoid split-brain or lack of majority issues)
         self._mysql.remove_instance(self.unit_label)

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ description = Run unit tests
 commands_pre =
     poetry install --only main,charm-libs,unit
 commands =
-    poetry run coverage run --source={[vars]src_path},{[vars]lib_path} \
+    poetry run coverage run --source={[vars]src_path} \
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     poetry run coverage report
 


### PR DESCRIPTION
## Issue

On scale down of primary, MySQL will reelect the primary after some delay.

## Solution

Minimize delay by preemptively setting primary to unit 0 (last one to be torn down) if primary is being removed.