### PR TITLE
DPE-2426 Update upgrade dependencies for mysqld and charm to account for 8.0.34

### DIFF
--- a/src/dependency.json
+++ b/src/dependency.json
@@ -3,12 +3,12 @@
     "dependencies": {},
     "name": "mysql-k8s",
     "upgrade_supported": ">0",
-    "version": "1"
+    "version": "2"
   },
   "rock": {
     "dependencies": {},
     "name": "charmed-mysql",
     "upgrade_supported": ">8.0.31",
-    "version": "8.0.33"
+    "version": "8.0.34"
   }
 }

--- a/src/dependency.json
+++ b/src/dependency.json
@@ -3,7 +3,7 @@
     "dependencies": {},
     "name": "mysql-k8s",
     "upgrade_supported": ">0",
-    "version": "2"
+    "version": "1"
   },
   "rock": {
     "dependencies": {},


### PR DESCRIPTION
## Issue
Again, I merged in the changes to switch the ROCK to 8.0.34, but missed changes in upgrade dependencies

## Solution
Update the upgrade dependencies