### PR TITLE
[bugfix] defer reconciling pebble layer for exporter

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -382,6 +382,13 @@ class MySQLOperatorCharm(MySQLCharmBase):
         self, event: RelationCreatedEvent | RelationBrokenEvent
     ) -> None:
         """Handle a COS relation created or broken event."""
+        if not self.unit_peer_data.get("unit-initialized"):
+            # wait unit initialization to avoid messing
+            # with the pebble layer before the unit is initialized
+            logger.debug("Defer reconcile mysqld exporter")
+            event.defer()
+            return
+
         self.current_event = event
 
         container = self.unit.get_container(CONTAINER_NAME)


### PR DESCRIPTION
## Issue

COS relation creation/departure is reconciling the pebble layer, which will hinder the charm initialization in case it happens before other initial events (leader-election, pebble-ready).
This scenario will happens on relating with COS right from the deployment, e.g. in a bundle.

## Solution

Defer handler to run after initialization.