### PR TITLE
[DPE-2319] Update CI/CD to follow new discourse-gatekeeper logic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,3 +119,11 @@ jobs:
               "GCP_ACCESS_KEY": "${{ secrets.GCP_ACCESS_KEY }}",
               "GCP_SECRET_KEY": "${{ secrets.GCP_SECRET_KEY }}",
             }
+
+  sync-docs:
+    uses: ./.github/workflows/sync_docs.yaml
+    secrets: inherit
+    permissions:
+      contents: write  # Needed to update tags
+      pull-requests: write # Need to create PR
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,8 @@ jobs:
     secrets: inherit
     permissions:
       actions: write  # Needed to manage GitHub Actions cache
+      contents: write  # Needed to login to Discourse
+      pull-requests: write # Need to create PR
 
   build:
     name: Build charm

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -4,16 +4,17 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '53 0 * * *' # Daily at 00:53 UTC
+  # Triggered on push to branch "main" by .github/workflows/release.yaml
+  workflow_call:
 
 jobs:
-
   sync-docs:
     name: Open PR with docs changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Open PR with docs changes
-        uses: canonical/upload-charm-docs@main
+        uses: deusebio/discourse-gatekeeper@c8adb89ea1cbceca54d78da798658373615487ac
         id: docs-pr
         with:
           discourse_host: discourse.charmhub.io
@@ -26,4 +27,3 @@ jobs:
         run: echo '${{ steps.docs-pr.outputs.migrate }}'
       - name: Show reconcile output
         run: echo '${{ steps.docs-pr.outputs.reconcile }}'
-


### PR DESCRIPTION
## Issue

The sync discourse -> git didn't work in full. Fixing it here based on https://github.com/canonical/kafka-operator/pull/133/files

## Solution

The recent changes to discourse-gatekeeper requires new CI/CD logic.
