### PR TITLE
DPE-1797 Implement log rotation of error, general and slowquery logs

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,4 +24,6 @@ parts:
       - pkg-config
       - rustc
       - cargo
+    prime:
+      - scripts
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -791,6 +791,8 @@ class MySQLBase(ABC):
 
         config = configparser.ConfigParser(interpolation=None)
 
+        # do not enable slow query logs, but specify a log file path in case
+        # the admin enables them manually
         config["mysqld"] = {
             "bind-address": "0.0.0.0",
             "mysqlx-bind-address": "0.0.0.0",
@@ -801,7 +803,6 @@ class MySQLBase(ABC):
             "log_error": f"{snap_common}/var/log/mysql/error.log",
             "general_log": "ON",
             "general_log_file": f"{snap_common}/var/log/mysql/general.log",
-            "slow_query_log": "ON",
             "slow_query_log_file": f"{snap_common}/var/log/mysql/slowquery.log",
         }
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -116,7 +116,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 49
+LIBPATCH = 50
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -2552,7 +2552,9 @@ class MySQLBase(ABC):
         """Flushes the specified logs_type logs."""
         flush_logs_commands = (
             f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
+            'session.run_sql("SET sql_log_bin = 0")',
             f'session.run_sql("FLUSH {logs_type.value}")',
+            'session.run_sql("SET sql_log_bin = 1")',
         )
 
         try:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -65,8 +65,10 @@ error handling on the subclass and in the charm code.
 
 """
 
+import configparser
 import dataclasses
 import enum
+import io
 import json
 import logging
 import re
@@ -114,7 +116,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 48
+LIBPATCH = 49
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -690,6 +692,17 @@ class MySQLMemberState(str, enum.Enum):
     UNKNOWN = "unknown"
 
 
+class MySQLTextLogs(str, enum.Enum):
+    """MySQL Text logs."""
+
+    # TODO: python 3.11 has new enum.StrEnum
+    #       that can remove str inheritance
+
+    ERROR = "ERROR LOGS"
+    GENERAL = "GENERAL LOGS"
+    SLOW = "SLOW LOGS"
+
+
 class MySQLBase(ABC):
     """Abstract class to encapsulate all operations related to the MySQL workload.
 
@@ -747,21 +760,23 @@ class MySQLBase(ABC):
         self,
         *,
         profile: str,
+        snap_common: str = "",
     ) -> str:
         """Render mysqld ini configuration file.
 
         Args:
             profile: profile to use for the configuration (testing, production)
+            snap_common: snap common directory (for log files locations in vm)
 
         Returns: mysqld ini file string content
         """
-        disable_memory_instruments = ""
+        performance_schema_instrument = ""
         if profile == "testing":
             innodb_buffer_pool_size = 20 * BYTES_1MiB
             innodb_buffer_pool_chunk_size = 1 * BYTES_1MiB
             group_replication_message_cache_size = 128 * BYTES_1MiB
             max_connections = 20
-            disable_memory_instruments = "performance-schema-instrument = 'memory/%=OFF'"
+            performance_schema_instrument = "'memory/%=OFF'"
         else:
             available_memory = self.get_available_memory()
             (
@@ -772,28 +787,36 @@ class MySQLBase(ABC):
             max_connections = self.get_max_connections(available_memory)
             if available_memory < 2 * BYTES_1GiB:
                 # disable memory instruments if we have less than 2GiB of RAM
-                disable_memory_instruments = "performance-schema-instrument = 'memory/%=OFF'"
+                performance_schema_instrument = "'memory/%=OFF'"
 
-        content = [
-            "[mysqld]",
-            "bind-address = 0.0.0.0",
-            "mysqlx-bind-address = 0.0.0.0",
-            f"report_host = {self.instance_address}",
-            f"max_connections = {max_connections}",
-            f"innodb_buffer_pool_size = {innodb_buffer_pool_size}",
-        ]
+        config = configparser.ConfigParser(interpolation=None)
+
+        config["mysqld"] = {
+            "bind-address": "0.0.0.0",
+            "mysqlx-bind-address": "0.0.0.0",
+            "report_host": self.instance_address,
+            "max_connections": str(max_connections),
+            "innodb_buffer_pool_size": str(innodb_buffer_pool_size),
+            "log_error_services": "log_filter_internal;log_sink_internal",
+            "log_error": f"{snap_common}/var/log/mysql/error.log",
+            "general_log": "ON",
+            "general_log_file": f"{snap_common}/var/log/mysql/general.log",
+            "slow_query_log": "ON",
+            "slow_query_log_file": f"{snap_common}/var/log/mysql/slowquery.log",
+        }
+
         if innodb_buffer_pool_chunk_size:
-            content.append(f"innodb_buffer_pool_chunk_size = {innodb_buffer_pool_chunk_size}")
-
-        if disable_memory_instruments:
-            content.append(disable_memory_instruments)
+            config["mysqld"]["innodb_buffer_pool_chunk_size"] = str(innodb_buffer_pool_chunk_size)
+        if performance_schema_instrument:
+            config["mysqld"]["performance-schema-instrument"] = performance_schema_instrument
         if group_replication_message_cache_size:
-            content.append(
-                f"loose-group_replication_message_cache_size = {group_replication_message_cache_size}"
+            config["mysqld"]["loose-group_replication_message_cache_size"] = str(
+                group_replication_message_cache_size
             )
 
-        content.append("\n")
-        return "\n".join(content)
+        with io.StringIO() as string_io:
+            config.write(string_io)
+            return string_io.getvalue()
 
     def configure_mysql_users(self):
         """Configure the MySQL users for the instance.
@@ -2523,6 +2546,18 @@ class MySQLBase(ABC):
             return stdout
         except MySQLExecError:
             return None
+
+    def flush_mysql_logs(self, logs_type: MySQLTextLogs) -> None:
+        """Flushes the specified logs_type logs."""
+        flush_logs_commands = (
+            f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
+            f'session.run_sql("FLUSH {logs_type.value}")',
+        )
+
+        try:
+            self._run_mysqlsh_script("\n".join(flush_logs_commands))
+        except MySQLClientError:
+            logger.exception(f"Failed to flush {logs_type} logs.")
 
     @abstractmethod
     def is_mysqld_running(self) -> bool:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,7 +32,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:3b6a4a63971acec3b71a0178cd093014a695ddf7c31d91d56ebb110eec6cdbe1
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:0f5fe7d7679b1881afde24ecfb9d14a9daade790ec787087aa5d8de1d7b00b21
 
 peers:
   database-peers:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2258,4 +2258,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e08e722e71c7f21baa7a60224c7f7e07dbb5f55d7d197507f0df11a35e40c978"
+content-hash = "840934d33987d81fcfac43ec243d3304f269d0c75980a4550d982dcbd5816cbb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ ops = "^2.5.0"
 lightkube = "^0.14.0"
 tenacity = "^8.2.2"
 boto3 = "^1.28.22"
+jinja2 = "^3.1.2"
 
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ ops = "^2.5.0"
 lightkube = "^0.14.0"
 tenacity = "^8.2.2"
 boto3 = "^1.28.22"
-jinja2 = "^3.1.2"
 
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py

--- a/scripts/log_rotate_dispatcher.py
+++ b/scripts/log_rotate_dispatcher.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Log rotate event dispatcher."""
+
+import shutil
+import subprocess
+import sys
+import time
+
+
+def dispatch(unit: str, charm_directory: str):
+    """Dispatch custom event to flush mysql logs."""
+    dispatch_sub_command = f"JUJU_DISPATCH_PATH=hooks/rotate_mysql_logs {charm_directory}/dispatch"
+
+    juju_run = shutil.which("juju-run")
+    juju_exec = shutil.which("juju-exec")
+    command = juju_exec if juju_exec else juju_run
+
+    subprocess.run([command, "-u", unit, dispatch_sub_command], check=True)
+
+
+def main():
+    """Main watch and dispatch loop.
+
+    Roughly every 60s at the top of the minute, dispatch the custom rotate_mysql_logs event.
+    """
+    unit, charm_directory = sys.argv[1:]
+
+    # wait till the top of the minute
+    time.sleep(60 - (time.time() % 60))
+    start_time = time.monotonic()
+
+    while True:
+        dispatch(unit, charm_directory)
+
+        # wait again till the top of the next minute
+        time.sleep(60.0 - ((time.monotonic() - start_time) % 60.0))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/log_rotate_dispatcher.py
+++ b/scripts/log_rotate_dispatcher.py
@@ -3,21 +3,30 @@
 
 """Log rotate event dispatcher."""
 
+import argparse
 import shutil
 import subprocess
-import sys
 import time
 
 
 def dispatch(unit: str, charm_directory: str):
     """Dispatch custom event to flush mysql logs."""
-    dispatch_sub_command = f"JUJU_DISPATCH_PATH=hooks/rotate_mysql_logs {charm_directory}/dispatch"
+    dispatch_sub_command = f"{charm_directory}/dispatch"
 
     juju_run = shutil.which("juju-run")
     juju_exec = shutil.which("juju-exec")
-    command = juju_exec if juju_exec else juju_run
+    command = juju_exec or juju_run
 
-    subprocess.run([command, "-u", unit, dispatch_sub_command], check=True)
+    subprocess.run(
+        [
+            command,
+            "-u",
+            unit,
+            "JUJU_DISPATCH_PATH=hooks/rotate_mysql_logs",
+            dispatch_sub_command,
+        ],
+        check=True,
+    )
 
 
 def main():
@@ -25,14 +34,17 @@ def main():
 
     Roughly every 60s at the top of the minute, dispatch the custom rotate_mysql_logs event.
     """
-    unit, charm_directory = sys.argv[1:]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("unit", help="name of unit")
+    parser.add_argument("charm_directory", help="base directory of the charm")
+    arguments = parser.parse_args()
 
     # wait till the top of the minute
     time.sleep(60 - (time.time() % 60))
     start_time = time.monotonic()
 
     while True:
-        dispatch(unit, charm_directory)
+        dispatch(arguments.unit, arguments.charm_directory)
 
         # wait again till the top of the next minute
         time.sleep(60.0 - ((time.monotonic() - start_time) % 60.0))

--- a/src/constants.py
+++ b/src/constants.py
@@ -48,3 +48,5 @@ GR_MAX_MEMBERS = 9
 SECRET_ID_KEY = "secret-id"
 # TODO: should be changed when adopting cos-agent
 COS_AGENT_RELATION_NAME = "metrics-endpoint"
+LOG_ROTATE_CONFIG_FILE = "/etc/logrotate.d/flush_mysql_logs"
+ROOT_SYSTEM_USER = "root"

--- a/src/log_rotate_manager.py
+++ b/src/log_rotate_manager.py
@@ -1,0 +1,83 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Log rotate manager."""
+
+import logging
+import os
+import signal
+import subprocess
+import typing
+
+from ops.framework import Object
+from ops.model import ActiveStatus
+
+if typing.TYPE_CHECKING:
+    from charm import MySQLOperatorCharm
+
+logger = logging.getLogger(__name__)
+
+# File path where log rotate manager exceptions will be stored
+LOG_FILE_PATH = "/var/log/log_rotate_manager.log"
+
+
+class LogRotateManager(Object):
+    """Manages log rotation for the charm.
+
+    Dispatches a custom event every 60s to rotate mysql logs in the workload container.
+    """
+
+    def __init__(self, charm: "MySQLOperatorCharm"):
+        super().__init__(charm, "log-rotate-manager")
+
+        self.charm = charm
+
+    def start_log_rotate_manager(self):
+        """Forks off a process that periodically dispatch a custom event to rotate logs."""
+        if not isinstance(self.charm.unit.status, ActiveStatus) or self.charm.peers is None:
+            return
+
+        if "log-rotate-manager-pid" in self.charm.unit_peer_data:
+            pid = int(self.charm.unit_peer_data["log-rotate-manager-pid"])
+            try:
+                os.kill(pid, 0)
+                return
+            except OSError:
+                pass
+
+        logger.info("Starting the log rotate manager")
+
+        # We need to trick Juju into thinking that we are not running
+        # in a hook context, as Juju will disallow use of juju-run.
+        new_env = os.environ.copy()
+        if "JUJU_CONTEXT_ID" in new_env:
+            new_env.pop("JUJU_CONTEXT_ID")
+
+        process = subprocess.Popen(
+            [
+                "/usr/bin/python3",
+                "scripts/log_rotate_dispatcher.py",
+                self.charm.unit.name,
+                self.charm.charm_dir,
+            ],
+            stdout=open(LOG_FILE_PATH, "a"),
+            stderr=subprocess.STDOUT,
+            env=new_env,
+        )
+
+        self.charm.unit_peer_data.update({"log-rotate-manager-pid": str(process.pid)})
+        logger.info(f"Started log rotate manager process with PID {process.pid}")
+
+    def stop_log_rotate_manager(self):
+        """Stop the log rotate manager process."""
+        if self.charm.peers is None or "log-rotate-manager-pid" not in self.charm.unit_peer_data:
+            return
+
+        log_rotate_manager_pid = int(self.charm.unit_peer_data["log-rotate-manager-pid"])
+
+        try:
+            os.kill(log_rotate_manager_pid, signal.SIGTERM)
+            logger.info(f"Stopped log rotate manager process with PID {log_rotate_manager_pid}")
+            del self.charm.unit_peer_data["log-rotate-manager-pid"]
+        except OSError:
+            pass

--- a/src/log_rotate_manager.py
+++ b/src/log_rotate_manager.py
@@ -17,9 +17,6 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# File path where log rotate manager exceptions will be stored
-LOG_FILE_PATH = "/var/log/log_rotate_manager.log"
-
 
 class LogRotateManager(Object):
     """Manages log rotation for the charm.
@@ -50,8 +47,7 @@ class LogRotateManager(Object):
         # We need to trick Juju into thinking that we are not running
         # in a hook context, as Juju will disallow use of juju-run.
         new_env = os.environ.copy()
-        if "JUJU_CONTEXT_ID" in new_env:
-            new_env.pop("JUJU_CONTEXT_ID")
+        new_env.pop("JUJU_CONTEXT_ID", None)
 
         process = subprocess.Popen(
             [
@@ -60,8 +56,8 @@ class LogRotateManager(Object):
                 self.charm.unit.name,
                 self.charm.charm_dir,
             ],
-            stdout=open(LOG_FILE_PATH, "a"),
-            stderr=subprocess.STDOUT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             env=new_env,
         )
 

--- a/src/log_rotate_manager.py
+++ b/src/log_rotate_manager.py
@@ -37,6 +37,7 @@ class LogRotateManager(Object):
         if "log-rotate-manager-pid" in self.charm.unit_peer_data:
             pid = int(self.charm.unit_peer_data["log-rotate-manager-pid"])
             try:
+                # No-op if the process exists, else fork a new log rotate dispatcher process
                 os.kill(pid, 0)
                 return
             except OSError:
@@ -49,6 +50,8 @@ class LogRotateManager(Object):
         new_env = os.environ.copy()
         new_env.pop("JUJU_CONTEXT_ID", None)
 
+        # Use Popen instead of run as the log rotate dispatcher is a long running
+        # process that shouldn't block the event handler
         process = subprocess.Popen(
             [
                 "/usr/bin/python3",

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -8,6 +8,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
+import jinja2
 from charms.mysql.v0.mysql import (
     Error,
     MySQLBase,
@@ -34,6 +35,7 @@ from constants import (
     CHARMED_MYSQL_XBSTREAM_LOCATION,
     CHARMED_MYSQL_XTRABACKUP_LOCATION,
     CONTAINER_NAME,
+    LOG_ROTATE_CONFIG_FILE,
     MYSQL_CLI_LOCATION,
     MYSQL_DATA_DIR,
     MYSQL_SYSTEM_GROUP,
@@ -45,6 +47,7 @@ from constants import (
     MYSQLD_SOCK_FILE,
     MYSQLSH_LOCATION,
     MYSQLSH_SCRIPT_FILE,
+    ROOT_SYSTEM_USER,
     XTRABACKUP_PLUGIN_DIR,
 )
 from k8s_helpers import KubernetesHelpers
@@ -237,6 +240,26 @@ class MySQL(MySQLBase):
             raise MySQLServiceNotRunningError("Connection with mysqlsh not possible")
 
         logger.debug("MySQL connection possible")
+
+    def setup_logrotate_config(self) -> None:
+        """Set up logrotate config in the workload container."""
+        logger.debug("Creating the logrotate config file")
+
+        with open("templates/logrotate.j2", "r") as file:
+            template = jinja2.Template(file.read())
+
+        rendered = template.render(
+            system_user=MYSQL_SYSTEM_USER,
+            system_group=MYSQL_SYSTEM_GROUP,
+        )
+
+        logger.debug("Writing the logrotate config file to the workload container")
+        self.write_content_to_file(
+            LOG_ROTATE_CONFIG_FILE,
+            rendered,
+            owner=ROOT_SYSTEM_USER,
+            group=ROOT_SYSTEM_USER,
+        )
 
     def configure_mysql_users(self) -> None:
         """Configure the MySQL users for the instance.

--- a/src/rotate_mysql_logs.py
+++ b/src/rotate_mysql_logs.py
@@ -1,0 +1,78 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Custom event for flushing mysql logs."""
+
+import logging
+import subprocess
+import tempfile
+import typing
+
+import jinja2
+from charms.mysql.v0.mysql import MySQLExecError, MySQLTextLogs
+from ops.charm import CharmEvents
+from ops.framework import EventBase, EventSource, Object
+
+from constants import LOG_ROTATE_CONFIG_FILE
+
+if typing.TYPE_CHECKING:
+    from charm import MySQLOperatorCharm
+
+logger = logging.getLogger(__name__)
+
+
+class RotateMySQLLogsEvent(EventBase):
+    """A custom event to rotate the mysql logs."""
+
+
+class RotateMySQLLogsCharmEvents(CharmEvents):
+    """A CharmEvent extension to rotate mysql logs.
+
+    Includes :class:`RotateMySQLLogsEvent` in those that can be handled.
+    """
+
+    rotate_mysql_logs = EventSource(RotateMySQLLogsEvent)
+
+
+class RotateMySQLLogs(Object):
+    """Encapsulates the rotation of mysql logs."""
+
+    def __init__(self, charm: "MySQLOperatorCharm"):
+        super().__init__(charm, "rotate-mysql-logs")
+
+        self.charm = charm
+
+        self.framework.observe(self.charm.on.rotate_mysql_logs, self._rotate_mysql_logs)
+
+    def _rotate_mysql_logs(self, _) -> None:
+        """Rotate the mysql logs."""
+        try:
+            self.charm._mysql._execute_commands(["logrotate", "-f", LOG_ROTATE_CONFIG_FILE])
+        except MySQLExecError:
+            logger.exception("Failed to rotate mysql logs")
+            return
+
+        self.charm._mysql.flush_mysql_logs(MySQLTextLogs.ERROR)
+        self.charm._mysql.flush_mysql_logs(MySQLTextLogs.GENERAL)
+        self.charm._mysql.flush_mysql_logs(MySQLTextLogs.SLOW)
+
+    def _setup_logrotate_dispatcher(self) -> None:
+        """Helper method to help set up a pebble plan for the log rotate dispatcher."""
+        with open("templates/logrotate.yaml.j2", "r") as file:
+            template = jinja2.Template(file.read())
+
+        rendered = template.render(
+            charm_directory=self.charm.charm_dir,
+            unit_name=self.charm.unit.name,
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w") as file:
+            file.write(rendered)
+            file.flush()
+
+            subprocess.run(
+                ["/charm/bin/pebble", "add", "logrotate", file.name],
+                check=True,
+            )
+
+        subprocess.run(["/charm/bin/pebble", "replan"], check=True)

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -1,0 +1,34 @@
+# Use system user
+su {{ system_user }} {{ system_group }}
+
+# Create dedicated subdirectory for rotated files
+createolddir 770 {{ system_user }} {{ system_group }}
+
+# Frequency of logs rotation
+hourly
+maxage 7
+rotate 10800
+
+# Naming of rotated files should be in the format:
+dateext
+dateformat -%V_%H%M
+
+# Settings to prevent misconfigurations and unwanted behaviours
+ifempty
+missingok
+nocompress
+nomail
+nosharedscripts
+nocopytruncate
+
+/var/log/mysql/error.log {
+    olddir archive_error
+}
+
+/var/log/mysql/general.log {
+    olddir archive_general
+}
+
+/var/log/mysql/slowquery.log {
+    olddir archive_slowquery
+}

--- a/templates/logrotate.yaml.j2
+++ b/templates/logrotate.yaml.j2
@@ -1,0 +1,6 @@
+summary: Layer for logrotate
+services:
+  logrotate:
+    override: replace
+    command: /usr/bin/python3 {{ charm_directory }}/scripts/log_rotate_dispatcher.py {{ unit_name }} {{ charm_directory }}
+    startup: enabled

--- a/templates/logrotate.yaml.j2
+++ b/templates/logrotate.yaml.j2
@@ -1,6 +1,0 @@
-summary: Layer for logrotate
-services:
-  logrotate:
-    override: replace
-    command: /usr/bin/python3 {{ charm_directory }}/scripts/log_rotate_dispatcher.py {{ unit_name }} {{ charm_directory }}
-    startup: enabled

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -653,12 +653,12 @@ async def stop_running_log_rotate_dispatcher(ops_test: OpsTest, unit_name: str):
         ops_test: The ops test object passed into every test case
         unit_name: The name of the unit to be tested
     """
-    # send TERM signal to mysql daemon, which trigger shutdown process
+    # send KILL signal to log rotate dispatcher, which trigger shutdown process
     await ops_test.juju(
         "ssh",
         unit_name,
         "pkill",
-        "-15",
+        "-9",
         "-f",
         "/usr/bin/python3 scripts/log_rotate_dispatcher.py",
     )
@@ -674,14 +674,14 @@ async def stop_running_flush_mysql_job(
         unit_name: The name of the unit to be tested
         container_name: The name of the container to be tested
     """
-    # send TERM signal to mysql daemon, which trigger shutdown process
+    # send KILL signal to log rotate process, which trigger shutdown process
     await ops_test.juju(
         "ssh",
         "--container",
         container_name,
         unit_name,
         "pkill",
-        "-15",
+        "-9",
         "-f",
         "logrotate -f /etc/logrotate.d/flush_mysql_logs",
     )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -5,6 +5,8 @@ import itertools
 import json
 import secrets
 import string
+import subprocess
+import tempfile
 from typing import Dict, List, Optional
 
 import mysql.connector
@@ -17,7 +19,7 @@ from mysql.connector.errors import (
     ProgrammingError,
 )
 from pytest_operator.plugin import OpsTest
-from tenacity import retry, stop_after_attempt, wait_fixed
+from tenacity import RetryError, Retrying, retry, stop_after_attempt, wait_fixed
 
 from constants import CONTAINER_NAME, MYSQLD_SAFE_SERVICE, SERVER_CONFIG_USERNAME
 
@@ -338,7 +340,7 @@ def is_connection_possible(credentials: Dict, **extra_opts) -> bool:
 
 async def get_process_pid(
     ops_test: OpsTest, unit_name: str, container_name: str, process: str
-) -> int:
+) -> Optional[int]:
     """Return the pid of a process running in a given unit.
 
     Args:
@@ -360,6 +362,9 @@ async def get_process_pid(
         process,
     ]
     return_code, pid, _ = await ops_test.juju(*get_pid_commands)
+
+    if return_code == 1:
+        return None
 
     assert (
         return_code == 0
@@ -411,7 +416,7 @@ async def unit_file_md5(ops_test: OpsTest, unit_name: str, file_path: str) -> st
     """
     try:
         _, md5sum_raw, _ = await ops_test.juju(
-            "ssh", "--container", "mysql", unit_name, "md5sum", file_path
+            "ssh", "--container", CONTAINER_NAME, unit_name, "md5sum", file_path
         )
 
         return md5sum_raw.strip().split()[0]
@@ -497,3 +502,230 @@ def get_unit_by_index(app_name: str, units: list, index: int):
     for unit in units:
         if unit.name == f"{app_name}/{index}":
             return unit
+
+
+async def delete_file_or_directory_in_unit(
+    ops_test: OpsTest, unit_name: str, path: str, container_name: str = CONTAINER_NAME
+) -> bool:
+    """Delete a file in the provided unit.
+
+    Args:
+        ops_test: The ops test framework
+        unit_name: The name unit on which to delete the file from
+        container_name: The name of the container where the file or directory is
+        path: The path of file or directory to delete
+
+    Returns:
+        boolean indicating success
+    """
+    if path.strip() in ["/", "."]:
+        return
+
+    try:
+        return_code, _, _ = await ops_test.juju(
+            "ssh",
+            "--container",
+            container_name,
+            unit_name,
+            "find",
+            path,
+            "-maxdepth",
+            "1",
+            "-delete",
+        )
+
+        return return_code == 0
+    except Exception:
+        return False
+
+
+async def write_content_to_file_in_unit(
+    ops_test: OpsTest, unit: Unit, path: str, content: str, container_name: str = CONTAINER_NAME
+) -> None:
+    """Write content to the file in the provided unit.
+
+    Args:
+        ops_test: The ops test framework
+        unit: THe unit in which to write to file in
+        path: The path at which to write the content to
+        content: The content to write to the file
+        container_name: The container where to write the file
+    """
+    pod_name = unit.name.replace("/", "-")
+
+    with tempfile.NamedTemporaryFile(mode="w") as temp_file:
+        temp_file.write(content)
+        temp_file.flush()
+
+        subprocess.run(
+            [
+                "kubectl",
+                "cp",
+                "-n",
+                ops_test.model.info.name,
+                "-c",
+                container_name,
+                temp_file.name,
+                f"{pod_name}:{path}",
+            ],
+            check=True,
+        )
+
+    # return_code, _, _ = await ops_test.juju(
+    #     "ssh", unit.name, "chown", f"{MYSQL_SYSTEM_USER}:root", path
+    # )
+    # assert return_code == 0
+
+
+async def read_contents_from_file_in_unit(
+    ops_test: OpsTest, unit: Unit, path: str, container_name: str = CONTAINER_NAME
+) -> str:
+    """Read contents from file in the provided unit.
+
+    Args:
+        ops_test: The ops test framework
+        unit: The unit in which to read file from
+        path: The path from which to read content from
+        container_name: The container where the file exists
+
+    Returns:
+        the contents of the file
+    """
+    pod_name = unit.name.replace("/", "-")
+
+    with tempfile.NamedTemporaryFile(mode="r+") as temp_file:
+        subprocess.run(
+            [
+                "kubectl",
+                "cp",
+                "-n",
+                ops_test.model.info.name,
+                "-c",
+                container_name,
+                f"{pod_name}:{path}",
+                temp_file.name,
+            ],
+            check=True,
+        )
+
+        temp_file.seek(0)
+
+        contents = ""
+        for line in temp_file:
+            contents += line
+            contents += "\n"
+
+    return contents
+
+
+async def ls_la_in_unit(
+    ops_test: OpsTest, unit_name: str, directory: str, container_name: str = CONTAINER_NAME
+) -> list[str]:
+    """Returns the output of ls -la in unit.
+
+    Args:
+        ops_test: The ops test framework
+        unit_name: The name of unit in which to run ls -la
+        path: The path from which to run ls -la
+        container_name: The container where to run ls -la
+
+    Returns:
+        a list of files returned by ls -la
+    """
+    return_code, output, _ = await ops_test.juju(
+        "ssh", "--container", container_name, unit_name, "ls", "-la", directory
+    )
+    assert return_code == 0
+
+    ls_output = output.split("\n")[1:]
+
+    return [
+        line.strip("\r")
+        for line in ls_output
+        if len(line.strip()) > 0 and line.split()[-1] not in [".", ".."]
+    ]
+
+
+async def stop_running_log_rotate_dispatcher(ops_test: OpsTest, unit_name: str):
+    """Stop running the log rotate dispatcher script.
+
+    Args:
+        ops_test: The ops test object passed into every test case
+        unit_name: The name of the unit to be tested
+    """
+    # send TERM signal to mysql daemon, which trigger shutdown process
+    await ops_test.juju(
+        "ssh",
+        unit_name,
+        "pkill",
+        "-15",
+        "-f",
+        "/usr/bin/python3 scripts/log_rotate_dispatcher.py",
+    )
+
+
+async def stop_running_flush_mysql_job(
+    ops_test: OpsTest, unit_name: str, container_name: str = CONTAINER_NAME
+) -> None:
+    """Stop running any logrotate jobs that may have been triggered by cron.
+
+    Args:
+        ops_test: The ops test object passed into every test case
+        unit_name: The name of the unit to be tested
+        container_name: The name of the container to be tested
+    """
+    # send TERM signal to mysql daemon, which trigger shutdown process
+    await ops_test.juju(
+        "ssh",
+        "--container",
+        container_name,
+        unit_name,
+        "pkill",
+        "-15",
+        "-f",
+        "logrotate -f /etc/logrotate.d/flush_mysql_logs",
+    )
+
+    # hold execution until process is stopped
+    try:
+        for attempt in Retrying(stop=stop_after_attempt(45), wait=wait_fixed(2)):
+            with attempt:
+                if await get_process_pid(ops_test, unit_name, container_name, "logrotate"):
+                    raise Exception
+    except RetryError:
+        raise Exception("Failed to stop the flush_mysql_logs logrotate process.")
+
+
+async def dispatch_custom_event_for_logrotate(ops_test: OpsTest, unit_name: str) -> None:
+    """Dispatch the custom event to run logrotate.
+
+    Args:
+        ops_test: The ops test object passed into every test case
+        unit_name: The name of the unit to be tested
+    """
+    _, juju_run, _ = await ops_test.juju(
+        "ssh",
+        unit_name,
+        "which",
+        "juju-run",
+    )
+
+    _, juju_exec, _ = await ops_test.juju(
+        "ssh",
+        unit_name,
+        "which",
+        "juju-exec",
+    )
+
+    dispatch_command = juju_exec.strip() or juju_run.strip()
+    unit_label = unit_name.replace("/", "-")
+
+    return_code, stdout, stderr = await ops_test.juju(
+        "ssh",
+        unit_name,
+        dispatch_command,
+        "JUJU_DISPATCH_PATH=hooks/rotate_mysql_logs",
+        f"/var/lib/juju/agents/unit-{unit_label}/charm/dispatch",
+    )
+
+    assert return_code == 0

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -571,11 +571,6 @@ async def write_content_to_file_in_unit(
             check=True,
         )
 
-    # return_code, _, _ = await ops_test.juju(
-    #     "ssh", unit.name, "chown", f"{MYSQL_SYSTEM_USER}:root", path
-    # )
-    # assert return_code == 0
-
 
 async def read_contents_from_file_in_unit(
     ops_test: OpsTest, unit: Unit, path: str, container_name: str = CONTAINER_NAME

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -108,7 +108,7 @@ async def ensure_n_online_mysql_members(
                 online_members = [
                     label
                     for label, member in cluster_status["defaultreplicaset"]["topology"].items()
-                    if member["status"] == "online"
+                    if member["status"] == "online" and not member.get("instanceerrors", [])
                 ]
                 assert len(online_members) == number_online_members
                 return True

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -368,6 +368,11 @@ async def test_network_cut_affecting_an_instance(
     assert isolated_primary_status == "online"
     assert isolated_primary_memberrole == "secondary"
 
+    logger.info("Ensure there are 3 online mysql members")
+    assert await ensure_n_online_mysql_members(
+        ops_test, 3
+    ), "The deployed mysql application does not have three online nodes"
+
     logger.info("Ensure all units have incrementing continuous writes")
     await ensure_all_units_continuous_writes_incrementing(ops_test)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,6 +15,8 @@ from constants import CLUSTER_ADMIN_USERNAME, PASSWORD_LENGTH, ROOT_USERNAME
 from utils import generate_random_password
 
 from .helpers import (
+    delete_file_or_directory_in_unit,
+    dispatch_custom_event_for_logrotate,
     execute_queries_on_unit,
     fetch_credentials,
     generate_random_string,
@@ -22,10 +24,15 @@ from .helpers import (
     get_primary_unit,
     get_server_config_credentials,
     get_unit_address,
+    ls_la_in_unit,
+    read_contents_from_file_in_unit,
     retrieve_database_variable_value,
     rotate_credentials,
     scale_application,
     start_mysqld_exporter,
+    stop_running_flush_mysql_job,
+    stop_running_log_rotate_dispatcher,
+    write_content_to_file_in_unit,
 )
 
 logger = logging.getLogger(__name__)
@@ -328,3 +335,91 @@ async def test_custom_variables(ops_test: OpsTest) -> None:
             logger.info(f"Checking that {k} is set to {v} on {unit.name}")
             value = await retrieve_database_variable_value(ops_test, unit, k)
             assert int(value) == v, f"Variable {k} is not set to {v}"
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_log_rotation(ops_test: OpsTest) -> None:
+    """Test the log rotation of text files."""
+    unit = ops_test.model.applications[APP_NAME].units[0]
+
+    logger.info("Extending update-status-hook-inteval to 60m")
+    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+
+    # Exclude slowquery log files as slowquery logs are not enabled by default
+    log_types = ["error", "general"]
+    log_files = ["error.log", "general.log"]
+    archive_directories = ["archive_error", "archive_general", "archive_slowquery"]
+
+    logger.info("Overwriting the log rotate dispatcher script")
+    unit_label = unit.name.replace("/", "-")
+    await write_content_to_file_in_unit(
+        ops_test,
+        unit,
+        f"/var/lib/juju/agents/unit-{unit_label}/charm/scripts/log_rotate_dispatcher.py",
+        "exit(0)\n",
+        container_name="charm",
+    )
+
+    logger.info("Stopping the log rotate dispatcher")
+    await stop_running_log_rotate_dispatcher(ops_test, unit.name)
+
+    logger.info("Stopping any running logrotate jobs")
+    await stop_running_flush_mysql_job(ops_test, unit.name)
+
+    logger.info("Removing existing archive directories")
+    for archive_directory in archive_directories:
+        await delete_file_or_directory_in_unit(
+            ops_test,
+            unit.name,
+            f"/var/log/mysql/{archive_directory}/",
+        )
+
+    logger.info("Writing some data to the text log files")
+    for log in log_types:
+        log_path = f"/var/log/mysql/{log}.log"
+        await write_content_to_file_in_unit(ops_test, unit, log_path, f"test {log} content\n")
+
+    logger.info("Ensuring only log files exist")
+    ls_la_output = await ls_la_in_unit(ops_test, unit.name, "/var/log/mysql/")
+
+    assert len(ls_la_output) == len(
+        log_files
+    ), f"❌ files other than log files exist {ls_la_output}"
+    directories = [line.split()[-1] for line in ls_la_output]
+    assert sorted(directories) == sorted(
+        log_files
+    ), f"❌ file other than logs files exist: {ls_la_output}"
+
+    logger.info("Dispatching custom event to rotate logs")
+    await dispatch_custom_event_for_logrotate(ops_test, unit.name)
+
+    logger.info("Ensuring log files and archive directories exist")
+    ls_la_output = await ls_la_in_unit(ops_test, unit.name, "/var/log/mysql/")
+
+    assert len(ls_la_output) == len(
+        log_files + archive_directories
+    ), f"❌ unexpected files/directories in log directory: {ls_la_output}"
+    directories = [line.split()[-1] for line in ls_la_output]
+    assert sorted(directories) == sorted(
+        log_files + archive_directories
+    ), f"❌ unexpected files/directories in log directory: {ls_la_output}"
+
+    logger.info("Ensuring log files were rotated")
+    # Exclude checking slowquery log rotation as slowquery logs are disabled by default
+    for log in set(log_types):
+        file_contents = await read_contents_from_file_in_unit(
+            ops_test, unit, f"/var/log/mysql/{log}.log"
+        )
+        assert f"test {log} content" not in file_contents, f"❌ log file {log}.log not rotated"
+
+        ls_la_output = await ls_la_in_unit(ops_test, unit.name, f"/var/log/mysql/archive_{log}/")
+        assert len(ls_la_output) == 1, f"❌ more than 1 file in archive directory: {ls_la_output}"
+
+        filename = ls_la_output[0].split()[-1]
+        file_contents = await read_contents_from_file_in_unit(
+            ops_test,
+            unit,
+            f"/var/log/mysql/archive_{log}/{filename}",
+        )
+        assert f"test {log} content" in file_contents, f"❌ log file {log}.log not rotated"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -98,8 +98,12 @@ class TestCharm(unittest.TestCase):
         return_value=(123456, None, None),
     )
     @patch("mysql_k8s_helpers.MySQL.get_max_connections", return_value=(120, None))
+    @patch("mysql_k8s_helpers.MySQL.setup_logrotate_config")
+    @patch("rotate_mysql_logs.RotateMySQLLogs._setup_logrotate_dispatcher")
     def test_mysql_pebble_ready(
         self,
+        _,
+        __,
         _get_max_connections,
         _get_innodb_buffer_pool_parameters,
         _get_member_state,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -99,11 +99,9 @@ class TestCharm(unittest.TestCase):
     )
     @patch("mysql_k8s_helpers.MySQL.get_max_connections", return_value=(120, None))
     @patch("mysql_k8s_helpers.MySQL.setup_logrotate_config")
-    @patch("rotate_mysql_logs.RotateMySQLLogs._setup_logrotate_dispatcher")
     def test_mysql_pebble_ready(
         self,
         _,
-        __,
         _get_max_connections,
         _get_innodb_buffer_pool_parameters,
         _get_member_state,

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ env_list = lint, unit
 [vars]
 src_path = {tox_root}/src
 tests_path = {tox_root}/tests
-all_path = {[vars]src_path} {[vars]tests_path}
+scripts_path = {tox_root}/scripts
+all_path = {[vars]src_path} {[vars]tests_path} {[vars]scripts_path}
 
 [testenv]
 set_env =


### PR DESCRIPTION
## Issue
1. We currently do not have general or slowquery logs enabled (discussion pending whether slowquery logs should be enabled)
2. We would like to rotate the error, general and slowquery logs

## Solution
1. Enable general and slowquery logs (may remove the enable-ment of slowquery logs pending discussion with mohamed)
2. Rotate the text logs. To do so, we copy the logrotate config upon instance configuration. Furthermore, we add to the charm container pebble layer a service that runs a script. This script tries its best to dispatch a custom event to rotate (by running logrotate with pebble exec) and flush logs at the top of every minute