### PR TITLE
tests: simplify the way that the check is done for Juju secret functionality

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,6 @@ jobs:
   unit-test:
     strategy:
       fail-fast: false
-      matrix:
-        juju-version:  ["2.9", "3.1"]
     name: Unit test charm
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -35,10 +33,6 @@ jobs:
           pipx install poetry
       - name: Run tests
         run: tox run -e unit
-        env:
-          # This env var is only to indicate Juju version to "simulate" in the unit tests
-          # No libjuju is being actually used in unit testing
-          LIBJUJU_VERSION_SPECIFIER: ${{ matrix.juju-version }}
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import os
 from unittest.mock import PropertyMock
 
 import pytest
@@ -9,38 +8,17 @@ from ops import JujuVersion
 from pytest_mock import MockerFixture
 
 
-@pytest.fixture(autouse=True)
-def juju_has_secrets(mocker: MockerFixture):
-    """This fixture will force the usage of secrets whenever run on Juju 3.x.
-
-    NOTE: This is needed, as normally JujuVersion is set to 0.0.0 in tests
-    (i.e. not the real juju version)
-    """
-    juju_version = os.environ["LIBJUJU_VERSION_SPECIFIER"].split("/")[0]
-    if juju_version < "3":
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = False
-        return False
-    else:
-        mocker.patch.object(
-            JujuVersion, "has_secrets", new_callable=PropertyMock
-        ).return_value = True
-        return True
+@pytest.fixture
+def with_juju_secrets(mocker: MockerFixture):
+    """Ensure that JujuVersion.has_secrets returns True."""
+    mocker.patch.object(
+        JujuVersion, "has_secrets", new_callable=PropertyMock
+    ).return_value = True
 
 
 @pytest.fixture
-def only_with_juju_secrets(juju_has_secrets):
-    """Pretty way to skip Juju 3 tests."""
-    if not juju_has_secrets:
-        pytest.skip("Secrets test only applies on Juju 3.x")
-
-
-@pytest.fixture
-def only_without_juju_secrets(juju_has_secrets):
-    """Pretty way to skip Juju 2-specific tests.
-
-    Typically: to save CI time, when the same check were executed in a Juju 3-specific way already
-    """
-    if juju_has_secrets:
-        pytest.skip("Skipping legacy secrets tests")
+def without_juju_secrets(mocker: MockerFixture):
+    """Ensure that JujuVersion.has_secrets returns False."""
+    mocker.patch.object(
+        JujuVersion, "has_secrets", new_callable=PropertyMock
+    ).return_value = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,14 +11,10 @@ from pytest_mock import MockerFixture
 @pytest.fixture
 def with_juju_secrets(mocker: MockerFixture):
     """Ensure that JujuVersion.has_secrets returns True."""
-    mocker.patch.object(
-        JujuVersion, "has_secrets", new_callable=PropertyMock
-    ).return_value = True
+    mocker.patch.object(JujuVersion, "has_secrets", new_callable=PropertyMock).return_value = True
 
 
 @pytest.fixture
 def without_juju_secrets(mocker: MockerFixture):
     """Ensure that JujuVersion.has_secrets returns False."""
-    mocker.patch.object(
-        JujuVersion, "has_secrets", new_callable=PropertyMock
-    ).return_value = False
+    mocker.patch.object(JujuVersion, "has_secrets", new_callable=PropertyMock).return_value = False

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -69,7 +69,7 @@ class TestCharm(unittest.TestCase):
         # Comparing output dicts
         self.assertEqual(self.charm._pebble_layer.to_dict(), self.layer_dict())
 
-    @pytest.mark.usefixtures("only_without_juju_secrets")
+    @pytest.mark.usefixtures("without_juju_secrets")
     def test_on_leader_elected(self):
         # Test leader election setting of
         # peer relation data
@@ -82,7 +82,7 @@ class TestCharm(unittest.TestCase):
                 peer_data[password].isalnum() and len(peer_data[password]) == PASSWORD_LENGTH
             )
 
-    @pytest.mark.usefixtures("only_with_juju_secrets")
+    @pytest.mark.usefixtures("with_juju_secrets")
     def test_on_leader_elected_secrets(self):
         # Test leader election setting of secret data
         self.harness.set_leader()
@@ -234,7 +234,7 @@ class TestCharm(unittest.TestCase):
         )
         assert self.charm.get_secret("unit", "password") == "test-password"
 
-    @pytest.mark.usefixtures("only_without_juju_secrets")
+    @pytest.mark.usefixtures("without_juju_secrets")
     @patch("charm.MySQLOperatorCharm._on_leader_elected")
     def test_set_secret_databag(self, _):
         self.harness.set_leader()
@@ -259,7 +259,7 @@ class TestCharm(unittest.TestCase):
             == "test-password"
         )
 
-    @pytest.mark.usefixtures("only_with_juju_secrets")
+    @pytest.mark.usefixtures("with_juju_secrets")
     @patch("charm.MySQLOperatorCharm._on_leader_elected")
     def test_set_secret(self, _):
         self.harness.set_leader()

--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,6 @@ commands =
 
 [testenv:unit]
 description = Run unit tests
-pass_env =
-    LIBJUJU_VERSION_SPECIFIER
 commands_pre =
     poetry install --only main,charm-libs,unit
 commands =
@@ -76,7 +74,6 @@ pass_env =
     CI
     GITHUB_OUTPUT
     SECRETS_FROM_GITHUB
-    LIBJUJU_VERSION_SPECIFIER
 allowlist_externals =
     {[testenv:pack-wrapper]allowlist_externals}
 commands_pre =


### PR DESCRIPTION
## Issue

Since #313, running `tox -e unit` no longer works out of the box.

<details>

<summary>Example pytest run (4 tests fail, but this is one example)</summary>

```
tameyer@tam-canoncial-1:~/code/mysql-k8s-operator$ tox -e unit -- -x
unit: commands_pre[0]> poetry install --only main,charm-libs,unit
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: charm (0.1.0)
unit: commands[0]> poetry run coverage run --source=/home/tameyer/code/mysql-k8s-operator/src -m pytest -v --tb native -s -x /home/tameyer/code/mysql-k8s-operator/tests/unit
========================================================== test session starts ===========================================================
platform linux -- Python 3.10.12, pytest-7.4.0, pluggy-1.2.0 -- /home/tameyer/code/mysql-k8s-operator/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /home/tameyer/code/mysql-k8s-operator
configfile: pyproject.toml
plugins: anyio-3.7.1, mock-3.11.1
collected 44 items                                                                                                                       

tests/unit/test_charm.py::TestCharm::test_database_storage_detaching ERROR

================================================================= ERRORS =================================================================
______________________________________ ERROR at setup of TestCharm.test_database_storage_detaching _______________________________________
Traceback (most recent call last):
  File "/home/tameyer/code/mysql-k8s-operator/.tox/unit/lib/python3.10/site-packages/_pytest/runner.py", line 341, in from_call
    result: Optional[TResult] = func()
  File "/home/tameyer/code/mysql-k8s-operator/.tox/unit/lib/python3.10/site-packages/_pytest/runner.py", line 262, in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
[...]
    fixture_result = fixturefunc(**kwargs)
  File "/home/tameyer/code/mysql-k8s-operator/tests/conftest.py", line 19, in juju_has_secrets
    juju_version = os.environ["LIBJUJU_VERSION_SPECIFIER"].split("/")[0]
  File "/usr/lib/python3.10/os.py", line 680, in __getitem__
    raise KeyError(key) from None
KeyError: 'LIBJUJU_VERSION_SPECIFIER'
======================================================== short test summary info =========================================================
ERROR tests/unit/test_charm.py::TestCharm::test_database_storage_detaching - KeyError: 'LIBJUJU_VERSION_SPECIFIER'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================ 1 error in 0.31s ============================================================
unit: exit 1 (0.84 seconds) /home/tameyer/code/mysql-k8s-operator> poetry run coverage run --source=/home/tameyer/code/mysql-k8s-operator/src -m pytest -v --tb native -s -x /home/tameyer/code/mysql-k8s-operator/tests/unit pid=1204072
  unit: FAIL code 1 (1.35=setup[0.02]+cmd[0.50,0.84] seconds)
  evaluation failed :( (1.38 seconds)
```
</details>

This is because an environment variable is required, `LIBJUJU_VERSION_SPECIFIER`, that is used in fixtures for a few tests that mock whether `JujuVersion.has_secrets()` returns True or False, based on the version specified.

## Solution

`tox -e unit` could run, instead of `os.environ["LIBJUJU_VERSION_SPECIFIER"]`  (e.g.) `os.environ.get("LIBJUJU_VERSION_SPECIFIER", "3.3.3")`.

However, it seems like it would be simpler to avoid the complexity that this is adding (and also the need to run almost all of the tests twice in CI) by simply patching the specific `get_secrets()` check directly. I've left the `without_juju_secrets` fixture, even though that's the default, because it does indeed seem worth explicitly setting that rather than relying on the default for `JujuVersion.from_environ`. Outside of the 4 tests that explicitly use the fixture, all the other tests run under default values (which, at least for now, means the `JujuVersion` check would show that secrets are not available, even though `testing.Harness` would provide all the (simulated) functionality).

It does seem odd that the default `JujuVersion.from_dict` behaviour is to set the version to `0.0.0`. I've opened [canonical/operator:#1037](https://github.com/canonical/operator/issues/1037) to potentially address that.

I'm happy to rework this if you'd prefer a different approach, but are on board with having an out-of-the-box `tox` run again.