### PR TITLE
Prevent starting logrotate dispatcher or flush mysql logs until unit initialized

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -2554,7 +2554,6 @@ class MySQLBase(ABC):
             f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
             'session.run_sql("SET sql_log_bin = 0")',
             f'session.run_sql("FLUSH {logs_type.value}")',
-            'session.run_sql("SET sql_log_bin = 1")',
         )
 
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -436,9 +436,6 @@ class MySQLOperatorCharm(MySQLCharmBase):
             # Configure instance as a cluster node
             self._mysql.configure_instance()
 
-            logger.info("Setting up the logrotate configurations")
-            self._mysql.setup_logrotate_config()
-
             if self.has_cos_relation:
                 if container.get_services(MYSQLD_EXPORTER_SERVICE)[
                     MYSQLD_EXPORTER_SERVICE
@@ -497,6 +494,9 @@ class MySQLOperatorCharm(MySQLCharmBase):
         except MySQLCreateCustomConfigFileError:
             logger.exception("Unable to write custom config file")
             raise
+
+        logger.info("Setting up the logrotate configurations")
+        self._mysql.setup_logrotate_config()
 
         self.unit_peer_data["unit-status"] = "alive"
         if self._mysql.is_data_dir_initialised():

--- a/src/log_rotate_manager.py
+++ b/src/log_rotate_manager.py
@@ -31,14 +31,17 @@ class LogRotateManager(Object):
 
     def start_log_rotate_manager(self):
         """Forks off a process that periodically dispatch a custom event to rotate logs."""
-        if not isinstance(self.charm.unit.status, ActiveStatus) or self.charm.peers is None:
+        if (
+            not isinstance(self.charm.unit.status, ActiveStatus)
+            or self.charm.peers is None
+            or self.charm.unit_peer_data.get("unit-initialized") != "True"
+        ):
             return
 
         if "log-rotate-manager-pid" in self.charm.unit_peer_data:
             pid = int(self.charm.unit_peer_data["log-rotate-manager-pid"])
             try:
-                # No-op if the process exists, else fork a new log rotate dispatcher process
-                os.kill(pid, 0)
+                os.kill(pid, 0)  # Check if the process exists
                 return
             except OSError:
                 pass

--- a/src/rotate_mysql_logs.py
+++ b/src/rotate_mysql_logs.py
@@ -43,6 +43,9 @@ class RotateMySQLLogs(Object):
 
     def _rotate_mysql_logs(self, _) -> None:
         """Rotate the mysql logs."""
+        if self.charm.peers is None or self.charm.unit_peer_data.get("unit-initialized") != "True":
+            return
+
         try:
             self.charm._mysql._execute_commands(["logrotate", "-f", LOG_ROTATE_CONFIG_FILE])
         except MySQLExecError:

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -108,7 +108,7 @@ async def ensure_n_online_mysql_members(
                 online_members = [
                     label
                     for label, member in cluster_status["defaultreplicaset"]["topology"].items()
-                    if member["status"] == "online" and not member.get("instanceerrors", [])
+                    if member["status"] == "online" and not member.get("instanceerrors")
                 ]
                 assert len(online_members) == number_online_members
                 return True


### PR DESCRIPTION
## Issue
When we scale up to more than one unit, it is possible that we start the log rotate dispatcher before the unit is fully initialized (and the logrotate config file is copied over the workload container).

```
unit-mysql-k8s-2: 18:00:00 ERROR unit.mysql-k8s/2.juju-log Failed to rotate mysql logs
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-mysql-k8s-2/charm/src/mysql_k8s_helpers.py", line 646, in _execute_commands
    stdout, stderr = process.wait_output()
  File "/var/lib/juju/agents/unit-mysql-k8s-2/charm/venv/ops/pebble.py", line 1359, in wait_output
    raise ExecError[AnyStr](self._command, exit_code, out_value, err_value)
ops.pebble.ExecError: non-zero exit code 1 executing ['logrotate', '-f', '/etc/logrotate.d/flush_mysql_logs'], stdout='', stderr='error: cannot stat /etc/logrotate.d/flush_mysql_logs: No such file or directory\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-mysql-k8s-2/charm/src/rotate_mysql_logs.py", line 47, in _rotate_mysql_logs
    self.charm._mysql._execute_commands(["logrotate", "-f", LOG_ROTATE_CONFIG_FILE])
  File "/var/lib/juju/agents/unit-mysql-k8s-2/charm/src/mysql_k8s_helpers.py", line 650, in _execute_commands
    raise MySQLExecError(e.stderr)
charms.mysql.v0.mysql.MySQLExecError: error: cannot stat /etc/logrotate.d/flush_mysql_logs: No such file or directory

unit-mysql-k8s-1: 18:00:00 DEBUG unit.mysql-k8s/1.juju-log Failed command: commands=['logrotate', '-f', '/etc/logrotate.d/flush_mysql_logs'], user=None, group=None
unit-mysql-k8s-1: 18:00:00 ERROR unit.mysql-k8s/1.juju-log Failed to rotate mysql logs
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-mysql-k8s-1/charm/src/mysql_k8s_helpers.py", line 646, in _execute_commands
    stdout, stderr = process.wait_output()
  File "/var/lib/juju/agents/unit-mysql-k8s-1/charm/venv/ops/pebble.py", line 1359, in wait_output
    raise ExecError[AnyStr](self._command, exit_code, out_value, err_value)
ops.pebble.ExecError: non-zero exit code 1 executing ['logrotate', '-f', '/etc/logrotate.d/flush_mysql_logs'], stdout='', stderr='error: cannot stat /etc/logrotate.d/flush_mysql_logs: No such file or directory\n'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-mysql-k8s-1/charm/src/rotate_mysql_logs.py", line 47, in _rotate_mysql_logs
    self.charm._mysql._execute_commands(["logrotate", "-f", LOG_ROTATE_CONFIG_FILE])
  File "/var/lib/juju/agents/unit-mysql-k8s-1/charm/src/mysql_k8s_helpers.py", line 650, in _execute_commands
    raise MySQLExecError(e.stderr)
charms.mysql.v0.mysql.MySQLExecError: error: cannot stat /etc/logrotate.d/flush_mysql_logs: No such file or directory

unit-mysql-k8s-0: 18:01:00 DEBUG unit.mysql-k8s/0.juju-log ops 2.7.0 up and running.
```

## Solution
Only start the log rotate dispatcher if the unit has been initialized and only flush mysql logs in the custom event handler if the unit has been initialized.