### PR TITLE
DPE-2661 single unit upgrade fixes

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1189,18 +1189,6 @@ class MySQLBase(ABC):
             )
             raise MySQLCreateClusterError(e.message)
 
-    def drop_metadata_schema(self) -> None:
-        """Drops cluster metadata schema."""
-        drop_metadata_schema_command = [
-            f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
-            "dba.drop_metadata_schema({'force': True})",
-        ]
-        try:
-            self._run_mysqlsh_script("\n".join(drop_metadata_schema_command))
-        except MySQLClientError as e:
-            logger.exception("Failed to drop metadata schema")
-            raise
-
     def create_cluster_set(self) -> None:
         """Create a cluster set for the cluster on cluster primary.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -135,7 +135,7 @@ class MySQLOperatorCharm(MySQLCharmBase):
     def _mysql(self) -> MySQL:
         """Returns an instance of the MySQL object from mysql_k8s_helpers."""
         return MySQL(
-            self.get_unit_hostname(self.unit.name),
+            self._get_unit_fqdn(),
             self.app_peer_data["cluster-name"],
             self.app_peer_data["cluster-set-domain-name"],
             self.get_secret("app", ROOT_PASSWORD_KEY),


### PR DESCRIPTION
## Issue

1. mysqlsh will fail on same version check
1. single unit won't reconnect to a cluster (as it is the cluster)
1. `reboot_from_complete_outage` will not recognize unit as part of the cluster in it's metadata due to the `report_host` not being equal to the unit's fqdn (`hostname.mysql-k8s-endpoints != hostname.mysql-k8s-endpoints.model.svc.cluster.local`)

## Solution

1. modify mysqlsh version verification command to accommodate same versions correctly 
1. make usage of `reboot_from_complete_outage` for single unit deployment recovery
1. use fqdn for mysql's `report_host`

Merge after vm [PR#340](https://github.com/canonical/mysql-operator/pull/340)

Fixes #317 