### PR TITLE
[DPE-2837] Additional testing for external secrets

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -724,3 +724,14 @@ async def dispatch_custom_event_for_logrotate(ops_test: OpsTest, unit_name: str)
     )
 
     assert return_code == 0
+
+
+async def get_secret_data(ops_test: OpsTest, secret_uri: str) -> Dict[str, str]:
+    """Retrieving secret data."""
+    secret_id = secret_uri.split("/")[-1]
+
+    command = f"show-secret {secret_uri} --reveal --format=json"
+    _, stdout, _ = await ops_test.juju(*command.split())
+    data = json.loads(stdout)
+
+    return data[secret_id]["content"]["Data"]


### PR DESCRIPTION
## Issue

Currently this behavior is not tested.

https://github.com/canonical/mysql-operator/blob/main/src/relations/mysql_provider.py#L190

(I know it coz I broke it ;-)  With green pipelines... :-( )

## Solution

1. In case we consider this behavior not needed: REMOVE the code
2. In case we consider the behavior as imporatnt: gotta be tested.