### PR TITLE
DPE-3027 Retry policy for is_mysqld_running 

### DIFF
--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -559,17 +559,9 @@ class MySQL(MySQLBase):
             )
             raise MySQLDeleteUsersWithLabelError(e.message)
 
-    @retry(
-        retry=retry_if_exception_type(ConnectionError),
-        stop=stop_after_attempt(10),
-        wait=wait_fixed(5),
-    )
     def is_mysqld_running(self) -> bool:
-        """Returns whether mysqld is running.
-
-        Retry every 5 seconds for 10 seconds if there is an issue obtaining a socket connection.
-        """
-        return self.container.exists(MYSQLD_SOCK_FILE)
+        """Returns whether server is connectable and mysqld is running."""
+        return self.is_server_connectable and self.container.exists(MYSQLD_SOCK_FILE)
 
     def is_server_connectable(self) -> bool:
         """Returns whether the server is connectable."""

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -19,7 +19,7 @@ from charms.mysql.v0.mysql import (
     MySQLStopMySQLDError,
 )
 from ops.model import Container
-from ops.pebble import ChangeError, ConnectionError, ExecError
+from ops.pebble import ChangeError, ExecError
 from tenacity import (
     retry,
     retry_if_exception_type,

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -561,7 +561,7 @@ class MySQL(MySQLBase):
 
     def is_mysqld_running(self) -> bool:
         """Returns whether server is connectable and mysqld is running."""
-        return self.is_server_connectable and self.container.exists(MYSQLD_SOCK_FILE)
+        return self.is_server_connectable() and self.container.exists(MYSQLD_SOCK_FILE)
 
     def is_server_connectable(self) -> bool:
         """Returns whether the server is connectable."""


### PR DESCRIPTION
## Issue
Charm deployment lands in an error state, mostly on GitHub Actions runners.
The error is caused by  `config-changed` hook failure when calling the `is_mysqld_running` method.

<details>
<summary>

Error snippet out of `kubectl logs mysql-k8s`

</summary>

```
unit-mysql-k8s-0: 16:48:16 ERROR unit.mysql-k8s/0.juju-log Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/./src/charm.py", line 786, in <module>
    main(MySQLOperatorCharm)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/main.py", line 436, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/main.py", line 144, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/framework.py", line 351, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/framework.py", line 853, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/framework.py", line 942, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/./src/charm.py", line 412, in _on_config_changed
    if not self._mysql.is_mysqld_running():
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/src/mysql_k8s_helpers.py", line 564, in is_mysqld_running
    return self.container.exists(MYSQLD_SOCK_FILE)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/model.py", line 2547, in exists
    self._pebble.list_files(str(path), itself=True)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/pebble.py", line 2219, in list_files
    resp = self._request('GET', '/v1/files', query)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/pebble.py", line 1655, in _request
    response = self._request_raw(method, path, query, headers, data)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/pebble.py", line 1704, in _request_raw
    raise ConnectionError(
ops.pebble.ConnectionError: Could not connect to Pebble: socket not found at '/charm/containers/mysql/pebble.socket' (container restarted?)
unit-mysql-k8s-0: 16:48:16 ERROR juju.worker.uniter.operation hook "config-changed" (via hook dispatching script: dispatch) failed: exit status 1
```

</details>

## Solution

Wrap `is_mysqld_running` method in `tenacity.retry` to implement retries on `ops.pebble.ConnectionError`
