### PR TITLE
Re-throw the exception when checking mysqlsh connection

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -2550,18 +2550,13 @@ class MySQLBase(ABC):
             logger.exception("Failed to kill external sessions")
             raise MySQLKillSessionError
 
-    def check_mysqlsh_connection(self) -> bool:
+    def check_mysqlsh_connection(self) -> None:
         """Checks if it is possible to connect to the server with mysqlsh."""
         connect_commands = (
             f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
             'session.run_sql("SELECT 1")',
         )
-
-        try:
-            self._run_mysqlsh_script("\n".join(connect_commands))
-            return True
-        except MySQLClientError:
-            return False
+        self._run_mysqlsh_script("\n".join(connect_commands))
 
     def get_pid_of_port_3306(self) -> Optional[str]:
         """Retrieves the PID of the process that is bound to port 3306."""

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -235,7 +235,7 @@ class MySQL(MySQLBase):
 
         if check_port:
             try:
-                self.check_mysqlsh_connection():
+                self.check_mysqlsh_connection()
             except MySQLClientError as e:
                 raise MySQLServiceNotRunningError("Connection with mysqlsh not possible") from e
 

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -233,8 +233,11 @@ class MySQL(MySQLBase):
         if not self.container.exists(MYSQLD_SOCK_FILE):
             raise MySQLServiceNotRunningError()
 
-        if check_port and not self.check_mysqlsh_connection():
-            raise MySQLServiceNotRunningError("Connection with mysqlsh not possible")
+        if check_port:
+            try:
+                self.check_mysqlsh_connection():
+            except MySQLClientError as e:
+                raise MySQLServiceNotRunningError("Connection with mysqlsh not possible") from e
 
         logger.debug("MySQL connection possible")
 


### PR DESCRIPTION
## Issue

When connection to `mysqlsh` is checked, any `MySQLClientError` is _swallowed_.  This does not help with debuggability.

## Solution

Change the API from returning a `bool` to returning nothing, but promising the faithfully throw an exception while checking `mysqlsh` connection if one occurred, _without_ losing any information that can help with debugging.  The call-site can then do the same, better here with a higher-level error, but again, without losing any details of the original error.