### PR TITLE
Remove charmcraft beta channel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v11.0.0
     with:
       cache: true
-      charmcraft-snap-channel: beta
 
   integration-test:
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,8 +34,6 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v11.0.0
-    with:
-      charmcraft-snap-channel: beta
 
   release:
     name: Release charm


### PR DESCRIPTION
charmcraft 2.5.4 was released to stable
