### PR TITLE
fix(tests): ensure that the latest version of the secret is used

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -90,7 +90,7 @@ class TestCharm(unittest.TestCase):
         # Test leader election setting of secret data
         self.harness.set_leader()
 
-        secret_data = self.harness.model.get_secret(label="mysql-k8s.app").get_content()
+        secret_data = self.harness.model.get_secret(label="mysql-k8s.app").peek_content()
 
         # Test passwords in content and length
         required_passwords = ["root-password", "server-config-password", "cluster-admin-password"]


### PR DESCRIPTION
## Issue

As of [Juju 3.1.7](https://bugs.launchpad.net/juju/+bug/2037120) (and 3.3.1, and all versions from 3.4.0 onwards) the behaviour of accessing secret content in Juju has changed:

* In Juju <= 3.1.6 the secret owner would always refresh when getting the secret content, and they cannot explicitly do a refresh
* In Juju >=3.1.7 the secret owner has the same behaviour as all other secret users: they get the tracked revision unless they use peek or refresh (and they can use refresh now)

This change is already present in `ops`, to prepare charms for the upcoming Juju change. This change means that one of the tests (`test_on_leader_elected_secrets`) fails in recent versions of `ops`, because it gets the original secret content, and not the updated content.

## Solution

The secret owner is able to use `peek` (in old and new ops/Juju) so the safe change is to always use peek.