### PR TITLE
DPE-3547 mitigations for container restart

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -122,7 +122,7 @@ BYTES_1MB = 1000000  # 1 megabyte
 BYTES_1MiB = 1048576  # 1 mebibyte
 RECOVERY_CHECK_TIME = 10  # seconds
 GET_MEMBER_STATE_TIME = 10  # seconds
-MIM_MAX_CONNECTIONS = 100
+MIN_MAX_CONNECTIONS = 100
 
 SECRET_INTERNAL_LABEL = "secret-id"
 SECRET_DELETED_LABEL = "None"
@@ -711,7 +711,7 @@ class MySQLBase(ABC):
             innodb_buffer_pool_size = 20 * BYTES_1MiB
             innodb_buffer_pool_chunk_size = 1 * BYTES_1MiB
             group_replication_message_cache_size = 128 * BYTES_1MiB
-            max_connections = MIM_MAX_CONNECTIONS
+            max_connections = MIN_MAX_CONNECTIONS
             performance_schema_instrument = "'memory/%=OFF'"
         else:
             available_memory = self.get_available_memory()
@@ -724,7 +724,7 @@ class MySQLBase(ABC):
                 innodb_buffer_pool_chunk_size,
                 group_replication_message_cache_size,
             ) = self.get_innodb_buffer_pool_parameters(available_memory)
-            max_connections = max(self.get_max_connections(available_memory), MIM_MAX_CONNECTIONS)
+            max_connections = max(self.get_max_connections(available_memory), MIN_MAX_CONNECTIONS)
             if available_memory < 2 * BYTES_1GiB:
                 # disable memory instruments if we have less than 2GiB of RAM
                 performance_schema_instrument = "'memory/%=OFF'"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1180,18 +1180,21 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "ops"
-version = "2.5.1"
+version = "2.10.0"
 description = "The Python library behind great charms"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ops-2.5.1-py3-none-any.whl", hash = "sha256:b7efc373031c52cb4ce61a455bcb990330bc1b81c01b1061626ed957bc58bbc1"},
-    {file = "ops-2.5.1.tar.gz", hash = "sha256:7f74552e48ee42af3ae87148767fd0cedef03e6d28248728f2258e05a0dfd86d"},
+    {file = "ops-2.10.0-py3-none-any.whl", hash = "sha256:25ecac7054e53b500d1ea6cccf47de4ed69d39de4eaf9a2bc05d49a12f8651bf"},
+    {file = "ops-2.10.0.tar.gz", hash = "sha256:7b0bf23c7ae20891d3fd7943830d75f1b38e7cafb216d5b727771d9c2f69d654"},
 ]
 
 [package.dependencies]
 PyYAML = "==6.*"
 websocket-client = "==1.*"
+
+[package.extras]
+docs = ["furo", "lxd-sphinx-extensions", "sphinx (==6.2.1)", "sphinx-copybutton", "sphinx-design", "sphinx-tabs"]
 
 [[package]]
 name = "packaging"
@@ -2337,4 +2340,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "475ea8a1e1f447f30981fb2916e387979f46c57d1ac1563824851de570556d70"
+content-hash = "21cb4c6fb393beb8f88f14701e1d178b4775f4be5ad28ced1cfc6f61b5007be0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = []
 
 [tool.poetry.dependencies]
 python = "^3.10"
-ops = "^2.5.0"
+ops = "^2.7.0"
 lightkube = "^0.14.0"
 tenacity = "^8.2.2"
 boto3 = "^1.28.22"

--- a/src/charm.py
+++ b/src/charm.py
@@ -481,8 +481,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         """
         if ops.JujuVersion.from_environ().supports_open_port_on_k8s:
             try:
-                self.unit.open_port("tcp", 3306)
-                self.unit.open_port("tcp", 33060)
+                self.unit.set_ports(3306, 33060)
             except ops.ModelError:
                 logger.exception("failed to open port")
 

--- a/src/k8s_helpers.py
+++ b/src/k8s_helpers.py
@@ -5,15 +5,15 @@
 
 import logging
 import socket
+import typing
 from typing import Dict, List, Optional, Tuple
 
-from lightkube import Client
+from lightkube.core.client import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import Node, Pod, Service
-from ops.charm import CharmBase
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from utils import any_memory_to_bytes
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 logging.getLogger("httpcore").setLevel(logging.ERROR)
 logging.getLogger("httpx").setLevel(logging.ERROR)
 
+if typing.TYPE_CHECKING:
+    from charm import MySQLOperatorCharm
+
 
 class KubernetesClientError(Exception):
     """Exception raised when client can't execute."""
@@ -32,7 +35,7 @@ class KubernetesClientError(Exception):
 class KubernetesHelpers:
     """Kubernetes helpers for service exposure."""
 
-    def __init__(self, charm: CharmBase):
+    def __init__(self, charm: "MySQLOperatorCharm"):
         """Initialize Kubernetes helpers.
 
         Args:
@@ -42,7 +45,7 @@ class KubernetesHelpers:
         self.namespace = charm.model.name
         self.app_name = charm.model.app.name
         self.cluster_name = charm.app_peer_data.get("cluster-name")
-        self.client = Client()
+        self.client = Client()  # type: ignore
 
     def create_endpoint_services(self, roles: List[str]) -> None:
         """Create kubernetes service for endpoints.

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -19,7 +19,7 @@ from charms.mysql.v0.mysql import (
     MySQLStopMySQLDError,
 )
 from ops.model import Container
-from ops.pebble import ChangeError, ExecError
+from ops.pebble import ChangeError, ExecError, PathError
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -194,14 +194,13 @@ class MySQL(MySQLBase):
             logger.debug(f"Changing ownership to {MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP}")
             try:
                 container.exec(
-                    f"chown -R {MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP} {MYSQL_DATA_DIR}".split(
-                        " "
-                    )
+                    ["chown", "-R", f"{MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP}", MYSQL_DATA_DIR]
                 )
             except ExecError as e:
                 logger.error(f"Exited with code {e.exit_code}. Stderr:\n{e.stderr}")
                 raise MySQLInitialiseMySQLDError(e.stderr or "")
 
+    @retry(reraise=True, stop=stop_after_delay(30), wait=wait_fixed(5))
     def initialise_mysqld(self) -> None:
         """Execute instance first run.
 
@@ -216,13 +215,11 @@ class MySQL(MySQLBase):
                 user=MYSQL_SYSTEM_USER,
                 group=MYSQL_SYSTEM_GROUP,
             )
-            process.wait_output()
-        except ExecError as e:
-            logger.error("Exited with code %d. Stderr:", e.exit_code)
-            if e.stderr:
-                for line in e.stderr.splitlines():
-                    logger.error("  %s", line)
-            raise MySQLInitialiseMySQLDError(e.stderr if e.stderr else "")
+            process.wait()
+        except (ExecError, ChangeError, PathError, TimeoutError):
+            logger.exception("Failed to initialise MySQL data directory")
+            self.reset_data_dir()
+            raise MySQLInitialiseMySQLDError
 
     @retry(reraise=True, stop=stop_after_delay(30), wait=wait_fixed(5))
     def wait_until_mysql_connection(self, check_port: bool = True) -> None:
@@ -752,6 +749,14 @@ class MySQL(MySQLBase):
         """
         if self.container.exists(path):
             self.container.remove_path(path)
+
+    def reset_data_dir(self) -> None:
+        """Remove all files from the data directory."""
+        content = self.container.list_files(MYSQL_DATA_DIR)
+        content_set = {item.name for item in content}
+        logger.debug("Resetting MySQL data directory.")
+        for item in content_set:
+            self.container.remove_path(f"{MYSQL_DATA_DIR}/{item}", recursive=True)
 
     def check_if_mysqld_process_stopped(self) -> bool:
         """Checks if the mysqld process is stopped on the container."""

--- a/src/rotate_mysql_logs.py
+++ b/src/rotate_mysql_logs.py
@@ -6,7 +6,7 @@
 import logging
 import typing
 
-from charms.mysql.v0.mysql import MySQLExecError, MySQLTextLogs
+from charms.mysql.v0.mysql import MySQLClientError, MySQLExecError, MySQLTextLogs
 from ops.charm import CharmEvents
 from ops.framework import EventBase, EventSource, Object
 
@@ -47,11 +47,9 @@ class RotateMySQLLogs(Object):
             return
 
         try:
+            self.charm._mysql.flush_mysql_logs(list(MySQLTextLogs))
             self.charm._mysql._execute_commands(["logrotate", "-f", LOG_ROTATE_CONFIG_FILE])
         except MySQLExecError:
-            logger.exception("Failed to rotate mysql logs")
-            return
-
-        self.charm._mysql.flush_mysql_logs(MySQLTextLogs.ERROR)
-        self.charm._mysql.flush_mysql_logs(MySQLTextLogs.GENERAL)
-        self.charm._mysql.flush_mysql_logs(MySQLTextLogs.SLOW)
+            logger.warning("Failed to rotate MySQL logs")
+        except MySQLClientError:
+            logger.warning("Failed to flush MySQL logs")

--- a/src/rotate_mysql_logs.py
+++ b/src/rotate_mysql_logs.py
@@ -47,8 +47,8 @@ class RotateMySQLLogs(Object):
             return
 
         try:
-            self.charm._mysql.flush_mysql_logs(list(MySQLTextLogs))
             self.charm._mysql._execute_commands(["logrotate", "-f", LOG_ROTATE_CONFIG_FILE])
+            self.charm._mysql.flush_mysql_logs(list(MySQLTextLogs))
         except MySQLExecError:
             logger.warning("Failed to rotate MySQL logs")
         except MySQLClientError:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -325,7 +325,7 @@ async def test_custom_variables(ops_test: OpsTest) -> None:
     application = ops_test.model.applications[APP_NAME]
 
     custom_vars = {}
-    custom_vars["max_connections"] = 20
+    custom_vars["max_connections"] = 100
     custom_vars["innodb_buffer_pool_size"] = 20971520
     custom_vars["innodb_buffer_pool_chunk_size"] = 1048576
     custom_vars["group_replication_message_cache_size"] = 134217728

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -93,7 +93,7 @@ class TestCharm(unittest.TestCase):
         secret_data = self.harness.model.get_secret(label="mysql-k8s.app").get_content()
 
         # Test passwords in content and length
-        required_passwords = ["root-password", "server-config-password", "cluster-admin-password"]
+        required_passwords = ["root-password"]
         for password in required_passwords:
             self.assertTrue(
                 secret_data[password].isalnum() and len(secret_data[password]) == PASSWORD_LENGTH
@@ -116,7 +116,7 @@ class TestCharm(unittest.TestCase):
         "mysql_k8s_helpers.MySQL.get_innodb_buffer_pool_parameters",
         return_value=(123456, None, None),
     )
-    @patch("mysql_k8s_helpers.MySQL.get_max_connections", return_value=(120, None))
+    @patch("mysql_k8s_helpers.MySQL.get_max_connections", return_value=120)
     @patch("mysql_k8s_helpers.MySQL.setup_logrotate_config")
     def test_mysql_pebble_ready(
         self,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,10 +11,24 @@ from ops.model import ActiveStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import MySQLOperatorCharm
-from constants import PASSWORD_LENGTH
+from constants import (
+    BACKUPS_PASSWORD_KEY,
+    CLUSTER_ADMIN_PASSWORD_KEY,
+    MONITORING_PASSWORD_KEY,
+    PASSWORD_LENGTH,
+    ROOT_PASSWORD_KEY,
+    SERVER_CONFIG_PASSWORD_KEY,
+)
 from mysql_k8s_helpers import MySQL, MySQLInitialiseMySQLDError
 
 APP_NAME = "mysql-k8s"
+REQUIRED_PASSWORD_KEYS = [
+    ROOT_PASSWORD_KEY,
+    MONITORING_PASSWORD_KEY,
+    CLUSTER_ADMIN_PASSWORD_KEY,
+    SERVER_CONFIG_PASSWORD_KEY,
+    BACKUPS_PASSWORD_KEY,
+]
 
 
 class TestCharm(unittest.TestCase):
@@ -80,8 +94,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader()
         peer_data = self.harness.get_relation_data(self.peer_relation_id, self.charm.app)
         # Test passwords in content and length
-        required_passwords = ["root-password", "server-config-password", "cluster-admin-password"]
-        for password in required_passwords:
+        for password in REQUIRED_PASSWORD_KEYS:
             self.assertTrue(
                 peer_data[password].isalnum() and len(peer_data[password]) == PASSWORD_LENGTH
             )
@@ -90,11 +103,11 @@ class TestCharm(unittest.TestCase):
         # Test leader election setting of secret data
         self.harness.set_leader()
 
-        secret_data = self.harness.model.get_secret(label="mysql-k8s.app").get_content()
+        # > 3.1.7 changed way last revision secret is accessed (peek)
+        secret_data = self.harness.model.get_secret(label="mysql-k8s.app").peek_content()
 
         # Test passwords in content and length
-        required_passwords = ["root-password"]
-        for password in required_passwords:
+        for password in REQUIRED_PASSWORD_KEYS:
             self.assertTrue(
                 secret_data[password].isalnum() and len(secret_data[password]) == PASSWORD_LENGTH
             )

--- a/tests/unit/test_mysql_k8s_helpers.py
+++ b/tests/unit/test_mysql_k8s_helpers.py
@@ -77,11 +77,12 @@ class TestMySQL(unittest.TestCase):
             group="mysql",
         )
 
-        _process.wait_output.assert_called_once()
+        _process.wait.assert_called_once()
 
     @patch("ops.model.Container")
     def test_initialise_mysqld_exception(self, _container):
         """Test a failing execution of bootstrap_instance."""
+        self.mysql.initialise_mysqld.retry.retry = tenacity.retry_if_not_result(lambda x: True)
         _container.exec.side_effect = ExecError(
             command=["mysqld"], exit_code=1, stdout=b"", stderr=b"Error"
         )
@@ -89,6 +90,17 @@ class TestMySQL(unittest.TestCase):
 
         with self.assertRaises(MySQLInitialiseMySQLDError):
             self.mysql.initialise_mysqld()
+
+    @patch("ops.model.Container")
+    def test_wait_until_mysql_connection(self, _container):
+        """Test wait_until_mysql_connection."""
+        self.mysql.wait_until_mysql_connection.retry.retry = tenacity.retry_if_not_result(
+            lambda x: True
+        )
+        _container.exists.return_value = True
+        self.mysql.container = _container
+
+        self.assertTrue(not self.mysql.wait_until_mysql_connection(check_port=False))
 
     @patch("mysql_k8s_helpers.MySQL._run_mysqlcli_script")
     def test_configure_mysql_users(self, _run_mysqlcli_script):
@@ -336,3 +348,28 @@ class TestMySQL(unittest.TestCase):
 
         with self.assertRaises(MySQLWaitUntilUnitRemovedFromClusterError):
             self.mysql._wait_until_unit_removed_from_cluster("mysql-0.mysql-endpoints")
+
+    @patch("ops.model.Container")
+    def test_log_rotate_config(self, _container):
+        """Test log_rotate_config."""
+        rendered_logrotate_config = (
+            "# Use system user\nsu mysql mysql\n\n# Create dedicated "
+            "subdirectory for rotated files\ncreateolddir 770 mysql mysql\n\n# Frequency of logs"
+            " rotation\nhourly\nmaxage 7\nrotate 10800\n\n# Naming of rotated files should be in"
+            " the format:\ndateext\ndateformat -%Y%m%d_%H%M\n\n# Settings to prevent"
+            " misconfigurations and unwanted behaviours\nifempty\nmissingok\nnocompress\nnomail\n"
+            "nosharedscripts\nnocopytruncate\n\n/var/log/mysql/error.log {\n    olddir"
+            " archive_error\n}\n\n/var/log/mysql/general.log {\n    olddir archive_general\n}\n\n"
+            "/var/log/mysql/slowquery.log {\n    olddir archive_slowquery\n}"
+        )
+
+        self.mysql.container = _container
+        self.mysql.setup_logrotate_config()
+
+        self.mysql.container.push.assert_called_once_with(
+            "/etc/logrotate.d/flush_mysql_logs",
+            rendered_logrotate_config,
+            permissions=416,
+            user="root",
+            group="root",
+        )


### PR DESCRIPTION
## Issue

Workload containers get restarted due timeout on livenessProbe pebble endpoint.
Discussion at juju lp bug: https://bugs.launchpad.net/bugs/2052517

## Solution

Here some mitigations and optimizations, not a final solution though.

* set floor for max_connections in 100
* function retries
* flush logs in single call
* + test coverage

