### PR TITLE
DPE-3389 support rollback incompat data dir 

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -498,7 +498,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         # Add the pebble layer
         logger.debug("Adding pebble layer")
-        container.add_layer(MYSQLD_SAFE_SERVICE, self._pebble_layer, combine=False)
+        container.add_layer(MYSQLD_SAFE_SERVICE, self._pebble_layer, combine=True)
         container.restart(MYSQLD_SAFE_SERVICE)
 
         logger.debug("Waiting for instance to be ready")
@@ -553,7 +553,8 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             return
 
         if not self.upgrade.idle:
-            # pebble ready task delegated to upgrade
+            # when upgrading pebble ready is
+            # task delegated to upgrade code
             return
 
         container = event.workload

--- a/src/charm.py
+++ b/src/charm.py
@@ -552,6 +552,10 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             event.defer()
             return
 
+        if not self.upgrade.idle:
+            # pebble ready task delegated to upgrade
+            return
+
         container = event.workload
         self._write_mysqld_configuration()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,8 +18,6 @@ from charms.mysql.v0.mysql import (
     BYTES_1MB,
     MySQLAddInstanceToClusterError,
     MySQLCharmBase,
-    MySQLConfigureInstanceError,
-    MySQLConfigureMySQLUsersError,
     MySQLCreateClusterError,
     MySQLGetClusterPrimaryAddressError,
     MySQLGetMemberStateError,
@@ -72,11 +70,7 @@ from constants import (
 )
 from k8s_helpers import KubernetesHelpers
 from log_rotate_manager import LogRotateManager
-from mysql_k8s_helpers import (
-    MySQL,
-    MySQLCreateCustomConfigFileError,
-    MySQLInitialiseMySQLDError,
-)
+from mysql_k8s_helpers import MySQL
 from relations.mysql import MySQLRelation
 from relations.mysql_provider import MySQLProvider
 from relations.mysql_root import MySQLRootRelation
@@ -276,7 +270,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             and not self.unit_peer_data.get("unit-initialized")
         )
 
-    def _join_unit_to_cluster(self) -> None:
+    def join_unit_to_cluster(self) -> None:
         """Join the unit to the cluster.
 
         Try to join the unit from the primary unit.
@@ -485,45 +479,45 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             except ops.ModelError:
                 logger.exception("failed to open port")
 
-    def _configure_instance(self, container) -> bool:
+    def _write_mysqld_configuration(self):
+        """Write the mysqld configuration to the file."""
+        memory_limit_bytes = (self.config.profile_limit_memory or 0) * BYTES_1MB
+        new_config_content, _ = self._mysql.render_mysqld_configuration(
+            profile=self.config.profile,
+            memory_limit=memory_limit_bytes,
+        )
+        self._mysql.write_content_to_file(path=MYSQLD_CONFIG_FILE, content=new_config_content)
+
+    def _configure_instance(self, container) -> None:
         """Configure the instance for use in Group Replication."""
-        try:
-            # Run mysqld for the first time to
-            # bootstrap the data directory and users
-            logger.debug("Initializing instance")
-            self._mysql.fix_data_dir(container)
-            self._mysql.initialise_mysqld()
+        # Run mysqld for the first time to
+        # bootstrap the data directory and users
+        logger.debug("Initializing instance")
+        self._mysql.fix_data_dir(container)
+        self._mysql.initialise_mysqld()
 
-            # Add the pebble layer
-            logger.debug("Adding pebble layer")
-            container.add_layer(MYSQLD_SAFE_SERVICE, self._pebble_layer, combine=False)
-            container.restart(MYSQLD_SAFE_SERVICE)
+        # Add the pebble layer
+        logger.debug("Adding pebble layer")
+        container.add_layer(MYSQLD_SAFE_SERVICE, self._pebble_layer, combine=False)
+        container.restart(MYSQLD_SAFE_SERVICE)
 
-            logger.debug("Waiting for instance to be ready")
-            self._mysql.wait_until_mysql_connection(check_port=False)
+        logger.debug("Waiting for instance to be ready")
+        self._mysql.wait_until_mysql_connection(check_port=False)
 
-            logger.info("Configuring instance")
-            # Configure all base users and revoke privileges from the root users
-            self._mysql.configure_mysql_users()
-            # Configure instance as a cluster node
-            self._mysql.configure_instance()
+        logger.info("Configuring instance")
+        # Configure all base users and revoke privileges from the root users
+        self._mysql.configure_mysql_users()
+        # Configure instance as a cluster node
+        self._mysql.configure_instance()
 
-            if self.has_cos_relation:
-                if container.get_services(MYSQLD_EXPORTER_SERVICE)[
-                    MYSQLD_EXPORTER_SERVICE
-                ].is_running():
-                    # Restart exporter service after configuration
-                    container.restart(MYSQLD_EXPORTER_SERVICE)
-                else:
-                    container.start(MYSQLD_EXPORTER_SERVICE)
-        except (
-            MySQLConfigureInstanceError,
-            MySQLConfigureMySQLUsersError,
-            MySQLInitialiseMySQLDError,
-            MySQLCreateCustomConfigFileError,
-        ) as e:
-            logger.debug("Unable to configure instance: {}".format(e))
-            return False
+        if self.has_cos_relation:
+            if container.get_services(MYSQLD_EXPORTER_SERVICE)[
+                MYSQLD_EXPORTER_SERVICE
+            ].is_running():
+                # Restart exporter service after configuration
+                container.restart(MYSQLD_EXPORTER_SERVICE)
+            else:
+                container.start(MYSQLD_EXPORTER_SERVICE)
 
         self._open_ports()
 
@@ -534,8 +528,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         except MySQLGetMySQLVersionError:
             # Do not block the charm if the version cannot be retrieved
             pass
-
-        return True
 
     def _mysql_pebble_ready_checks(self, event) -> bool:
         """Executes some checks to see if it is safe to execute the pebble ready handler."""
@@ -561,16 +553,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             return
 
         container = event.workload
-        try:
-            memory_limit_bytes = (self.config.profile_limit_memory or 0) * BYTES_1MB
-            new_config_content, _ = self._mysql.render_mysqld_configuration(
-                profile=self.config.profile,
-                memory_limit=memory_limit_bytes,
-            )
-            self._mysql.write_content_to_file(path=MYSQLD_CONFIG_FILE, content=new_config_content)
-        except MySQLCreateCustomConfigFileError:
-            logger.exception("Unable to write custom config file")
-            raise
+        self._write_mysqld_configuration()
 
         logger.info("Setting up the logrotate configurations")
         self._mysql.setup_logrotate_config()
@@ -585,15 +568,14 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.unit.status = MaintenanceStatus("Initialising mysqld")
 
         # First run setup
-        if not self._configure_instance(container):
-            raise
+        self._configure_instance(container)
 
         if not self.unit.is_leader():
             # Non-leader units should wait for leader to add them to the cluster
             self.unit.status = WaitingStatus("Waiting for instance to join the cluster")
             self.unit_peer_data.update({"member-role": "secondary", "member-state": "waiting"})
 
-            self._join_unit_to_cluster()
+            self.join_unit_to_cluster()
             return
 
         try:
@@ -702,7 +684,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if not self.unit.is_leader() and self._is_unit_waiting_to_join_cluster():
             # join cluster test takes precedence over blocked test
             # due to matching criteria
-            self._join_unit_to_cluster()
+            self.join_unit_to_cluster()
             return
 
         if self._is_cluster_blocked():
@@ -748,7 +730,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             return
 
         if self._is_unit_waiting_to_join_cluster():
-            self._join_unit_to_cluster()
+            self.join_unit_to_cluster()
 
     def _on_database_storage_detaching(self, _) -> None:
         """Handle the database storage detaching event."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -579,7 +579,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             # Non-leader units should wait for leader to add them to the cluster
             self.unit.status = WaitingStatus("Waiting for instance to join the cluster")
             self.unit_peer_data.update({"member-role": "secondary", "member-state": "waiting"})
-
             self.join_unit_to_cluster()
             return
 
@@ -594,7 +593,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             self.app_peer_data["units-added-to-cluster"] = "1"
 
             state, role = self._mysql.get_member_state()
-
             self.unit_peer_data.update(
                 {"member-state": state, "member-role": role, "unit-initialized": "True"}
             )

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -16,6 +16,7 @@ from charms.mysql.v0.mysql import (
     MySQLConfigureMySQLUsersError,
     MySQLExecError,
     MySQLGetClusterEndpointsError,
+    MySQLServiceNotRunningError,
     MySQLStartMySQLDError,
     MySQLStopMySQLDError,
 )
@@ -59,10 +60,6 @@ if TYPE_CHECKING:
 
 class MySQLInitialiseMySQLDError(Error):
     """Exception raised when there is an issue initialising an instance."""
-
-
-class MySQLServiceNotRunningError(Error):
-    """Exception raised when the MySQL service is not running."""
 
 
 class MySQLCreateCustomConfigFileError(Error):
@@ -229,10 +226,13 @@ class MySQL(MySQLBase):
         Retry every 5 seconds for 30 seconds if there is an issue obtaining a connection.
         """
         if not self.container.exists(MYSQLD_SOCK_FILE):
-            raise MySQLServiceNotRunningError()
+            raise MySQLServiceNotRunningError
 
-        if check_port and not self.check_mysqlsh_connection():
-            raise MySQLServiceNotRunningError("Connection with mysqlsh not possible")
+        try:
+            if check_port and not self.check_mysqlsh_connection():
+                raise MySQLServiceNotRunningError("Connection with mysqlsh not possible")
+        except MySQLClientError:
+            raise MySQLServiceNotRunningError
 
         logger.debug("MySQL connection possible")
 

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -852,3 +852,7 @@ class MySQL(MySQLBase):
         """Set the cluster primary and update pod labels."""
         super().set_cluster_primary(new_primary_address)
         self.update_endpoints()
+
+    def fetch_error_log(self) -> Optional[str]:
+        """Fetch the MySQL error log."""
+        return self.read_file_content("/var/log/mysql/error.log")

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -216,6 +216,12 @@ class MySQLProvider(Object):
         if self.charm._is_cluster_blocked():
             return
 
+        if self.charm.upgrade.state == "failed":
+            # skip updating endpoints if upgrade failed
+            # unit pod still will be labeled from another unit
+            logger.debug("Skip labelling pods on failed upgrade")
+            return
+
         container = self.charm.unit.get_container(CONTAINER_NAME)
         if (
             not container.can_connect()

--- a/src/rotate_mysql_logs.py
+++ b/src/rotate_mysql_logs.py
@@ -43,7 +43,12 @@ class RotateMySQLLogs(Object):
 
     def _rotate_mysql_logs(self, _) -> None:
         """Rotate the mysql logs."""
-        if self.charm.peers is None or self.charm.unit_peer_data.get("unit-initialized") != "True":
+        if (
+            self.charm.peers is None
+            or self.charm.unit_peer_data.get("unit-initialized") != "True"
+            or not self.charm.upgrade.idle
+        ):
+            # skip when not initialized or during an upgrade
             return
 
         try:

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -32,7 +32,7 @@ from tenacity.wait import wait_fixed
 from typing_extensions import override
 
 import k8s_helpers
-from constants import CONTAINER_NAME, MYSQLD_SAFE_SERVICE
+from constants import MYSQLD_SAFE_SERVICE
 
 if TYPE_CHECKING:
     from charm import MySQLOperatorCharm
@@ -259,8 +259,9 @@ class MySQLK8sUpgrade(DataUpgrade):
                 logger.error("Unit failed to rejoin the cluster after upgrade")
                 self.set_unit_failed()
                 return
-            logger.info("Downgrade is incompatible. Resetting workload")
+            logger.warning("Downgrade is incompatible. Resetting workload")
             self._reset_on_unsupported_downgrade(container)
+            self._complete_upgrade()
 
     def _recover_multi_unit_cluster(self) -> None:
         logger.debug("Recovering unit")

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -22,8 +22,9 @@ from charms.mysql.v0.mysql import (
     MySQLSetClusterPrimaryError,
     MySQLSetVariableError,
 )
-from ops import JujuVersion
+from ops import Container, JujuVersion
 from ops.model import BlockedStatus, MaintenanceStatus, RelationDataContent
+from ops.pebble import ChangeError
 from pydantic import BaseModel
 from tenacity import RetryError, Retrying
 from tenacity.stop import stop_after_attempt
@@ -31,7 +32,7 @@ from tenacity.wait import wait_fixed
 from typing_extensions import override
 
 import k8s_helpers
-from constants import CONTAINER_NAME
+from constants import CONTAINER_NAME, MYSQLD_SAFE_SERVICE
 
 if TYPE_CHECKING:
     from charm import MySQLOperatorCharm
@@ -229,11 +230,6 @@ class MySQLK8sUpgrade(DataUpgrade):
         self.charm._mysql.setup_logrotate_config()
 
         try:
-            self.charm.unit.set_workload_version(self.charm._mysql.get_mysql_version() or "unset")
-        except MySQLGetMySQLVersionError:
-            # don't fail on this, just log it
-            logger.warning("Failed to get MySQL version")
-        try:
             self.charm._reconcile_pebble_layer(container)
             self._check_server_upgradeability()
             self.charm.unit.status = MaintenanceStatus("recovering unit after upgrade")
@@ -248,14 +244,23 @@ class MySQLK8sUpgrade(DataUpgrade):
             self.charm.unit.status = BlockedStatus(
                 "upgrade failed. Check logs for rollback instruction"
             )
-        except (RetryError, MySQLServerNotUpgradableError, MySQLServiceNotRunningError):
+        except (
+            RetryError,
+            MySQLServerNotUpgradableError,
+            MySQLServiceNotRunningError,
+            ChangeError,
+        ):
             # Failed to recover unit
-            if not self._check_server_unsupported_downgrade():
+            if (
+                not self._check_server_unsupported_downgrade()
+                or self.charm.app.planned_units() == 1
+            ):
+                # don't try to recover single unit cluster or errors other then downgrade
                 logger.error("Unit failed to rejoin the cluster after upgrade")
                 self.set_unit_failed()
                 return
             logger.info("Downgrade is incompatible. Resetting workload")
-            self._reset_on_unsupported_downgrade()
+            self._reset_on_unsupported_downgrade(container)
 
     def _recover_multi_unit_cluster(self) -> None:
         logger.debug("Recovering unit")
@@ -282,6 +287,11 @@ class MySQLK8sUpgrade(DataUpgrade):
     def _complete_upgrade(self):
         # complete upgrade for the unit
         logger.debug("Upgraded unit is healthy. Set upgrade state to `completed`")
+        try:
+            self.charm.unit.set_workload_version(self.charm._mysql.get_mysql_version() or "unset")
+        except MySQLGetMySQLVersionError:
+            # don't fail on this, just log it
+            logger.warning("Failed to get MySQL version")
         self.set_unit_completed()
         if self.charm.unit_label == f"{self.charm.app.name}/1":
             # penultimate unit, reset the primary for faster switchover
@@ -329,12 +339,12 @@ class MySQLK8sUpgrade(DataUpgrade):
 
         return False
 
-    def _reset_on_unsupported_downgrade(self) -> None:
+    def _reset_on_unsupported_downgrade(self, container: Container) -> None:
         """Reset the cluster on unsupported downgrade."""
+        container.stop(MYSQLD_SAFE_SERVICE)
         self.charm._mysql.reset_data_dir()
-        self.charm._mysql.initialise_mysqld()
         self.charm._write_mysqld_configuration()
-        self.charm._configure_instance(self.charm.unit.get_container(CONTAINER_NAME))
+        self.charm._configure_instance(container)
         # reset flags
         self.charm.unit_peer_data.update({"member-role": "secondary", "member-state": "waiting"})
         # rescan is needed to remove the instance old incarnation from the cluster

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -12,6 +12,8 @@ from typing import List, Optional, Tuple
 import kubernetes
 import yaml
 from juju.unit import Unit
+from lightkube import Client
+from lightkube.resources.apps_v1 import StatefulSet
 from pytest_operator.plugin import OpsTest
 from tenacity import (
     RetryError,
@@ -575,3 +577,9 @@ async def ensure_process_not_running(
     assert (
         return_code != 0
     ), f"Process {process} is still running with pid {pid} on unit {unit_name}, container {container_name}"
+
+
+def get_sts_partition(ops_test: OpsTest, app_name: str) -> int:
+    client = Client()  # type: ignore
+    statefulset = client.get(res=StatefulSet, namespace=ops_test.model.info.name, name=app_name)
+    return statefulset.spec.updateStrategy.rollingUpdate.partition  # type: ignore

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -124,7 +124,14 @@ async def test_upgrade_from_edge(ops_test: OpsTest, continuous_writes) -> None:
     assert leader_unit is not None, "No leader unit found"
 
     logger.info("Resume upgrade")
-    await juju_.run_action(leader_unit, "resume-upgrade")
+    try:
+        await juju_.run_action(leader_unit, "resume-upgrade")
+    except AssertionError:
+        # ignore action return error as it is expected when
+        # the leader unit is the next one to be upgraded
+        # due it being immediately rolled when the partition
+        # is patched in the statefulset
+        pass
 
     logger.info("Wait for upgrade to complete")
     await ops_test.model.block_until(
@@ -190,7 +197,14 @@ async def test_fail_and_rollback(ops_test, continuous_writes, built_charm) -> No
     )
 
     logger.info("Resume upgrade")
-    await juju_.run_action(leader_unit, "resume-upgrade")
+    try:
+        await juju_.run_action(leader_unit, "resume-upgrade")
+    except AssertionError:
+        # ignore action return error as it is expected when
+        # the leader unit is the next one to be upgraded
+        # due it being immediately rolled when the partition
+        # is patched in the statefulset
+        pass
 
     logger.info("Wait for application to recover")
     await ops_test.model.block_until(

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -180,7 +180,7 @@ async def test_fail_and_rollback(ops_test, continuous_writes, built_charm) -> No
     )
 
     logger.info("Ensure continuous_writes while in failure state on remaining units")
-    mysql_units = [unit_ for unit_ in application.units if unit_ != unit]
+    mysql_units = [unit_ for unit_ in application.units if unit_.name != unit.name]
     await ensure_all_units_continuous_writes_incrementing(ops_test, mysql_units)
 
     logger.info("Re-run pre-upgrade-check action")

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -7,11 +7,10 @@ import logging
 import shutil
 import zipfile
 from pathlib import Path
+from time import sleep
 from typing import Union
 
 import pytest
-from lightkube import Client
-from lightkube.resources.apps_v1 import StatefulSet
 from pytest_operator.plugin import OpsTest
 
 from .. import juju_
@@ -25,6 +24,7 @@ from ..helpers import (
 from .high_availability_helpers import (
     METADATA,
     ensure_all_units_continuous_writes_incrementing,
+    get_sts_partition,
     relate_mysql_and_application,
 )
 
@@ -89,12 +89,8 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
     assert primary_unit.name == f"{MYSQL_APP_NAME}/0", "Primary unit not set to unit 0"
 
     logger.info("Assert partition is set to 2")
-    client = Client()
-    statefulset = client.get(
-        res=StatefulSet, namespace=ops_test.model.info.name, name=MYSQL_APP_NAME
-    )
 
-    assert statefulset.spec.updateStrategy.rollingUpdate.partition == 2, "Partition not set to 2"
+    assert get_sts_partition(ops_test, MYSQL_APP_NAME) == 2, "Partition not set to 2"
 
 
 @pytest.mark.group(1)
@@ -197,14 +193,17 @@ async def test_fail_and_rollback(ops_test, continuous_writes, built_charm) -> No
     )
 
     logger.info("Resume upgrade")
-    try:
-        await juju_.run_action(leader_unit, "resume-upgrade")
-    except AssertionError:
-        # ignore action return error as it is expected when
-        # the leader unit is the next one to be upgraded
-        # due it being immediately rolled when the partition
-        # is patched in the statefulset
-        pass
+    while get_sts_partition(ops_test, MYSQL_APP_NAME) == 2:
+        # resume action sometime fails in CI, no clear reason
+        try:
+            await juju_.run_action(leader_unit, "resume-upgrade")
+            sleep(2)
+        except AssertionError:
+            # ignore action return error as it is expected when
+            # the leader unit is the next one to be upgraded
+            # due it being immediately rolled when the partition
+            # is patched in the statefulset
+            pass
 
     logger.info("Wait for application to recover")
     await ops_test.model.block_until(

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -120,7 +120,14 @@ async def test_upgrade_from_stable(ops_test: OpsTest):
     assert leader_unit is not None, "No leader unit found"
 
     logger.info("Resume upgrade")
-    await juju_.run_action(leader_unit, "resume-upgrade")
+    try:
+        await juju_.run_action(leader_unit, "resume-upgrade")
+    except AssertionError:
+        # ignore action return error as it is expected when
+        # the leader unit is the next one to be upgraded
+        # due it being immediately rolled when the partition
+        # is patched in the statefulset
+        pass
 
     logger.info("Wait for upgrade to complete")
     await ops_test.model.block_until(

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -3,10 +3,9 @@
 
 import asyncio
 import logging
+from time import sleep
 
 import pytest
-from lightkube import Client
-from lightkube.resources.apps_v1 import StatefulSet
 from pytest_operator.plugin import OpsTest
 
 from .. import juju_
@@ -19,6 +18,7 @@ from ..helpers import (
 from .high_availability_helpers import (
     METADATA,
     ensure_all_units_continuous_writes_incrementing,
+    get_sts_partition,
     relate_mysql_and_application,
 )
 
@@ -83,12 +83,7 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
     assert primary_unit.name == f"{MYSQL_APP_NAME}/0", "Primary unit not set to unit 0"
 
     logger.info("Assert partition is set to 2")
-    client = Client()
-    statefulset = client.get(
-        res=StatefulSet, namespace=ops_test.model.info.name, name=MYSQL_APP_NAME
-    )
-
-    assert statefulset.spec.updateStrategy.rollingUpdate.partition == 2, "Partition not set to 2"
+    assert get_sts_partition(ops_test, MYSQL_APP_NAME) == 2, "Partition not set to 2"
 
 
 @pytest.mark.group(1)
@@ -120,14 +115,17 @@ async def test_upgrade_from_stable(ops_test: OpsTest):
     assert leader_unit is not None, "No leader unit found"
 
     logger.info("Resume upgrade")
-    try:
-        await juju_.run_action(leader_unit, "resume-upgrade")
-    except AssertionError:
-        # ignore action return error as it is expected when
-        # the leader unit is the next one to be upgraded
-        # due it being immediately rolled when the partition
-        # is patched in the statefulset
-        pass
+    while get_sts_partition(ops_test, MYSQL_APP_NAME) == 2:
+        # resume action sometime fails in CI, no clear reason
+        try:
+            await juju_.run_action(leader_unit, "resume-upgrade")
+            sleep(2)
+        except AssertionError:
+            # ignore action return error as it is expected when
+            # the leader unit is the next one to be upgraded
+            # due it being immediately rolled when the partition
+            # is patched in the statefulset
+            pass
 
     logger.info("Wait for upgrade to complete")
     await ops_test.model.block_until(

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -158,7 +158,7 @@ async def test_rollback(ops_test, continuous_writes) -> None:
     logger.info("Wait for application to recover")
     await ops_test.model.block_until(
         lambda: all(unit.workload_status == "active" for unit in application.units),
-        timeout=TIMEOUT,
+        timeout=2 * TIMEOUT,
     )
 
     logger.info("Ensure continuous_writes after rollback procedure")

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -28,7 +28,7 @@ TEST_APP = "mysql-test-app"
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, mysql_charm_series: str) -> None:
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Simple test to ensure that the mysql and application charms get deployed."""
     sub_regex_older_rock = (
         "s/sha256:.*$/sha256:0f5fe7d7679b1881afde24ecfb9d14a9daade790ec787087aa5d8de1d7b00b21/"
@@ -45,7 +45,6 @@ async def test_build_and_deploy(ops_test: OpsTest, mysql_charm_series: str) -> N
             application_name=MYSQL_APP_NAME,
             config=config,
             num_units=3,
-            series=mysql_charm_series,
         )
 
         await ops_test.model.deploy(

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -91,7 +91,7 @@ async def test_upgrade_to_failling(
 
     sub_regex_failing_rejoin = (
         's/logger.debug("Recovering unit")'
-        "/self.charm._mysql.set_instance_offline_mode(True); raise RetryError/"
+        '/self.charm._mysql.set_instance_offline_mode(True); raise RetryError("dummy")/'
     )
     src_patch(sub_regex=sub_regex_failing_rejoin, file_name="src/upgrade.py")
     new_charm = await charm_local_build(ops_test, refresh=True)

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -1,0 +1,195 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import ast
+import logging
+import os
+import pathlib
+import shutil
+import subprocess
+from zipfile import ZipFile
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from .. import juju_
+from ..helpers import get_leader_unit, get_relation_data, get_unit_by_index
+from .high_availability_helpers import (
+    ensure_all_units_continuous_writes_incrementing,
+    relate_mysql_and_application,
+)
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT = 20 * 60
+MYSQL_APP_NAME = "mysql-k8s"
+TEST_APP = "mysql-test-app"
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, mysql_charm_series: str) -> None:
+    """Simple test to ensure that the mysql and application charms get deployed."""
+    sub_regex_older_rock = (
+        "s/sha256:.*$/sha256:0f5fe7d7679b1881afde24ecfb9d14a9daade790ec787087aa5d8de1d7b00b21/"
+    )
+    src_patch(sub_regex=sub_regex_older_rock, file_name="metadata.yaml")
+    charm = await charm_local_build(ops_test)
+
+    src_patch(revert=True)
+    config = {"profile": "testing"}
+
+    async with ops_test.fast_forward("10s"):
+        await ops_test.model.deploy(
+            charm,
+            application_name=MYSQL_APP_NAME,
+            config=config,
+            num_units=3,
+            series=mysql_charm_series,
+        )
+
+        await ops_test.model.deploy(
+            TEST_APP,
+            application_name=TEST_APP,
+            channel="latest/edge",
+            num_units=1,
+        )
+
+        await relate_mysql_and_application(ops_test, MYSQL_APP_NAME, TEST_APP)
+        await ops_test.model.wait_for_idle(
+            apps=[MYSQL_APP_NAME, TEST_APP],
+            status="active",
+            timeout=TIMEOUT,
+        )
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
+    """Test that the pre-upgrade-check action runs successfully."""
+    logger.info("Get leader unit")
+    leader_unit = await get_leader_unit(ops_test, MYSQL_APP_NAME)
+
+    assert leader_unit is not None, "No leader unit found"
+    logger.info("Run pre-upgrade-check action")
+    await juju_.run_action(leader_unit, "pre-upgrade-check")
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_upgrade_to_failling(
+    ops_test: OpsTest,
+    continuous_writes,
+) -> None:
+    logger.info("Ensure continuous_writes")
+    await ensure_all_units_continuous_writes_incrementing(ops_test)
+
+    application = ops_test.model.applications[MYSQL_APP_NAME]
+    logger.info("Build charm locally")
+
+    sub_regex_failing_rejoin = (
+        's/logger.debug("Recovering unit")'
+        "/self.charm._mysql.set_instance_offline_mode(True); raise RetryError/"
+    )
+    src_patch(sub_regex=sub_regex_failing_rejoin, file_name="src/upgrade.py")
+    new_charm = await charm_local_build(ops_test, refresh=True)
+    src_patch(revert=True)
+
+    logger.info("Refresh the charm")
+    await application.refresh(path=new_charm)
+
+    logger.info("Wait for upgrade to start")
+    await ops_test.model.block_until(
+        lambda: "waiting" in {unit.workload_status for unit in application.units},
+        timeout=TIMEOUT,
+    )
+    logger.info("Get first upgrading unit")
+    relation_data = await get_relation_data(ops_test, MYSQL_APP_NAME, "upgrade")
+    upgrade_stack = relation_data[0]["application-data"]["upgrade-stack"]
+    upgrading_unit = get_unit_by_index(
+        MYSQL_APP_NAME, application.units, ast.literal_eval(upgrade_stack)[-1]
+    )
+
+    assert upgrading_unit is not None, "No upgrading unit found"
+
+    logger.info("Wait for upgrade to fail on upgrading unit")
+    await ops_test.model.block_until(
+        lambda: upgrading_unit.workload_status == "blocked",
+        timeout=TIMEOUT,
+    )
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_rollback(ops_test, continuous_writes) -> None:
+    application = ops_test.model.applications[MYSQL_APP_NAME]
+
+    sub_regex_older_rock = (
+        "s/sha256:.*$/sha256:0f5fe7d7679b1881afde24ecfb9d14a9daade790ec787087aa5d8de1d7b00b21/"
+    )
+    src_patch(sub_regex=sub_regex_older_rock, file_name="src/constants.py")
+    charm = await charm_local_build(ops_test, refresh=True)
+
+    logger.info("Get leader unit")
+    leader_unit = await get_leader_unit(ops_test, MYSQL_APP_NAME)
+
+    assert leader_unit is not None, "No leader unit found"
+
+    logger.info("Run pre-upgrade-check action")
+    await juju_.run_action(leader_unit, "pre-upgrade-check")
+
+    logger.info("Refresh with previous charm")
+    await application.refresh(path=charm)
+
+    logger.info("Wait for upgrade to start")
+    await ops_test.model.block_until(
+        lambda: "waiting" in {unit.workload_status for unit in application.units},
+        timeout=TIMEOUT,
+    )
+    await ops_test.model.wait_for_idle(apps=[MYSQL_APP_NAME], status="active", timeout=TIMEOUT)
+
+    logger.info("Ensure continuous_writes after rollback procedure")
+    await ensure_all_units_continuous_writes_incrementing(ops_test)
+
+
+def src_patch(sub_regex: str = "", file_name: str = "", revert: bool = False) -> None:
+    """Apply a patch to the source code."""
+    if revert:
+        cmd = "git checkout src/"  # revert changes on src/ dir
+        logger.info("Reverting patch on source")
+    else:
+        cmd = f"sed -i -e '{sub_regex}' {file_name}"
+        logger.info("Applying patch to source")
+    subprocess.run([cmd], shell=True, check=True)
+
+
+async def charm_local_build(ops_test: OpsTest, refresh: bool = False):
+    """Wrapper for a local charm build zip file updating."""
+    local_charms = pathlib.Path().glob("local-*.charm")
+    for lc in local_charms:
+        # clean up local charms from previous runs to avoid
+        # pytest_operator_cache globbing them
+        lc.unlink()
+
+    charm = await ops_test.build_charm(".")
+
+    if os.environ.get("CI") == "true":
+        # CI will get charm from common cache
+        # make local copy and update charm zip
+
+        update_files = ["src/constants.py", "src/upgrade.py"]
+
+        charm = pathlib.Path(shutil.copy(charm, f"local-{charm.stem}.charm"))
+
+        for path in update_files:
+            with open(path, "r") as f:
+                content = f.read()
+
+            with ZipFile(charm, mode="a") as charm_zip:
+                charm_zip.writestr(path, content)
+
+    if refresh:
+        # when refreshing, return posix path
+        return charm
+    # when deploying, return prefixed full path
+    return f"local:{charm.resolve()}"

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import yaml
 from zipfile import ZipFile
 
 import pytest
@@ -25,6 +26,8 @@ TIMEOUT = 20 * 60
 MYSQL_APP_NAME = "mysql-k8s"
 TEST_APP = "mysql-test-app"
 
+METADATA = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
+
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -39,12 +42,15 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     src_patch(revert=True)
     config = {"profile": "testing"}
 
+    resources = {"mysql-image": METADATA["resources"]["mysql-image"]["upstream-source"]}
     async with ops_test.fast_forward("10s"):
         await ops_test.model.deploy(
             charm,
             application_name=MYSQL_APP_NAME,
             config=config,
             num_units=3,
+            resources=resources,
+            trust=True,
         )
 
         await ops_test.model.deploy(

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -134,7 +134,14 @@ async def test_rollback(ops_test) -> None:
     )
 
     logger.info("Resume upgrade")
-    await juju_.run_action(leader_unit, "resume-upgrade")
+    try:
+        await juju_.run_action(leader_unit, "resume-upgrade")
+    except AssertionError:
+        # ignore action return error as it is expected when
+        # the leader unit is the next one to be upgraded
+        # due it being immediately rolled when the partition
+        # is patched in the statefulset
+        pass
 
     logger.info("Wait for application to recover")
     await ops_test.model.block_until(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -39,6 +39,7 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
         self.peer_relation_id = self.harness.add_relation("database-peers", "database-peers")
+        self.restart_relation_id = self.harness.add_relation("restart", "restart")
         self.harness.add_relation_unit(self.peer_relation_id, f"{APP_NAME}/1")
         self.charm = self.harness.charm
         self.maxDiff = None
@@ -112,6 +113,7 @@ class TestCharm(unittest.TestCase):
                 secret_data[password].isalnum() and len(secret_data[password]) == PASSWORD_LENGTH
             )
 
+    @patch("upgrade.MySQLK8sUpgrade.idle", return_value=True)
     @patch("mysql_k8s_helpers.MySQL.write_content_to_file")
     @patch("mysql_k8s_helpers.MySQL.is_data_dir_initialised", return_value=False)
     @patch("mysql_k8s_helpers.MySQL.create_cluster_set")
@@ -149,6 +151,7 @@ class TestCharm(unittest.TestCase):
         _is_data_dir_initialised,
         _create_cluster_set,
         _write_content_to_file,
+        _upgrade_idle,
     ):
         # Check if initial plan is empty
         self.harness.set_can_connect("mysql", True)
@@ -173,6 +176,33 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             plan.to_dict()["services"], self.layer_dict(with_mysqld_exporter=True)["services"]
         )
+
+    @patch("charm.MySQLOperatorCharm.join_unit_to_cluster")
+    @patch("charm.MySQLOperatorCharm._configure_instance")
+    @patch("charm.MySQLOperatorCharm._write_mysqld_configuration")
+    @patch("upgrade.MySQLK8sUpgrade.idle", return_value=True)
+    @patch("charm.MySQLOperatorCharm._mysql")
+    def test_pebble_ready_set_data(
+        self, mock_mysql, mock_upgrade_idle, mock_write_conf, mock_conf, mock_join
+    ):
+        mock_mysql.is_data_dir_initialised.return_value = False
+        mock_mysql.get_member_state.return_value = ("online", "primary")
+        self.harness.set_can_connect("mysql", True)
+        self.harness.set_leader()
+
+        # test on non leader
+        self.harness.set_leader(is_leader=False)
+        self.harness.container_pebble_ready("mysql")
+        self.assertEqual(self.charm.unit_peer_data.get("unit-initialized"), None)
+        self.assertEqual(self.charm.unit_peer_data["member-role"], "secondary")
+        self.assertEqual(self.charm.unit_peer_data["member-state"], "waiting")
+
+        # test on leader
+        self.harness.set_leader(is_leader=True)
+        self.harness.container_pebble_ready("mysql")
+        self.assertEqual(self.charm.unit_peer_data["unit-initialized"], "True")
+        self.assertEqual(self.charm.unit_peer_data["member-state"], "online")
+        self.assertEqual(self.charm.unit_peer_data["member-role"], "primary")
 
     @patch("charm.MySQLOperatorCharm._mysql", new_callable=PropertyMock)
     def test_mysql_pebble_ready_non_leader(self, _mysql_mock):

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -147,6 +147,9 @@ class TestUpgrade(unittest.TestCase):
         mock_set_rolling_update_partition.assert_called_once()
         assert mock_set_dynamic_variable.call_count == 2
 
+    @patch("mysql_k8s_helpers.MySQL.setup_logrotate_config")
+    @patch("charm.MySQLOperatorCharm._reconcile_pebble_layer")
+    @patch("charm.MySQLOperatorCharm._write_mysqld_configuration")
     @patch("upgrade.RECOVER_ATTEMPTS", 1)
     @patch("mysql_k8s_helpers.MySQL.hold_if_recovering")
     @patch("mysql_k8s_helpers.MySQL.get_mysql_version", return_value="8.0.33")
@@ -158,13 +161,16 @@ class TestUpgrade(unittest.TestCase):
         mock_is_server_upgradable,
         mock_get_mysql_version,
         mock_hold_if_recovering,
+        mock_write_mysqld_configuration,
+        mock_reconcile_pebble_layer,
+        mock_setup_logrotate_config,
     ):
         """Test the pebble ready."""
         self.charm.on.config_changed.emit()
         self.harness.update_relation_data(
             self.upgrade_relation_id, "mysql-k8s/0", {"state": "upgrading"}
         )
-        self.charm.upgrade._on_pebble_ready(None)
+        self.harness.container_pebble_ready("mysql")
         self.assertEqual(
             self.harness.get_relation_data(self.upgrade_relation_id, "mysql-k8s/1")["state"],
             "idle",  # change to `completed` - behavior not yet set in the lib
@@ -177,7 +183,7 @@ class TestUpgrade(unittest.TestCase):
         # setup for exception
         mock_is_instance_in_cluster.return_value = False
 
-        self.charm.upgrade._on_pebble_ready(None)
+        self.harness.container_pebble_ready("mysql")
         self.assertTrue(isinstance(self.charm.unit.status, BlockedStatus))
 
     @patch("k8s_helpers.KubernetesHelpers.set_rolling_update_partition")


### PR DESCRIPTION
## Issue

Upgrade rollback fails when new mysqld modify data_dir without backward compatibility.

## Solution

Add treatment for the case that data_dir is modified, for multi-unit cluster (reset and clone)

