### PR TITLE
[DPE-3717] Update ROCK to 8.0.36

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,7 +32,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:a0aad90152a77767569840cfd76eb957a1d26f43dc8d3922be823506e7533186
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:5082c99baa7a77c82d73247674e270838dc0a8165c02f7619cf5642d1427cba7
 
 peers:
   database-peers:

--- a/src/dependency.json
+++ b/src/dependency.json
@@ -9,6 +9,6 @@
     "dependencies": {},
     "name": "charmed-mysql",
     "upgrade_supported": ">8.0.31",
-    "version": "8.0.35"
+    "version": "8.0.36"
   }
 }


### PR DESCRIPTION
# Issue
We built a new ROCK for 8.0.36 that we are not using in the charm

# Solution
Update ROCK image