### PR TITLE
Fix assumes (k8s only)

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -92,4 +92,7 @@ assumes:
           - juju < 3
       - all-of:
           - juju >= 3.4.3
+          - juju < 3.5
+      - all-of:
+          - juju >= 3.5.2
           - juju < 4


### PR DESCRIPTION
## Issue

juju [bug](https://bugs.launchpad.net/juju/+bug/2065284) affecting k8s only prevent async replication
to fully work on juju 3.5.{0,1} but not on ^3.4.3

## Solution

Adjust assumes on metadata to ensure we only deploy on supported versions
