### PR TITLE
DPE-4643 ensure username uniqueness

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1038,7 +1038,7 @@ class MySQLBase(ABC):
         try:
             output = self._run_mysqlcli_script(
                 "; ".join(user_existence_commands),
-                username=self.server_config_user,
+                user=self.server_config_user,
                 password=self.server_config_password,
             )
             return "USER_EXISTS" in output
@@ -1588,7 +1588,7 @@ class MySQLBase(ABC):
 
             self._run_mysqlcli_script(
                 "; ".join(initialize_table_commands),
-                username=self.server_config_user,
+                user=self.server_config_user,
                 password=self.server_config_password,
             )
         except MySQLClientError as e:
@@ -2459,7 +2459,7 @@ class MySQLBase(ABC):
         try:
             output = self._run_mysqlcli_script(
                 member_state_query,
-                username=self.cluster_admin_user,
+                user=self.cluster_admin_user,
                 password=self.cluster_admin_password,
                 timeout=10,
             )
@@ -2590,7 +2590,7 @@ class MySQLBase(ABC):
         try:
             self._run_mysqlcli_script(
                 "; ".join(set_instance_offline_mode_commands),
-                username=self.cluster_admin_user,
+                user=self.cluster_admin_user,
                 password=self.cluster_admin_password,
             )
         except MySQLClientError as e:
@@ -2731,7 +2731,7 @@ class MySQLBase(ABC):
         mysqld_socket_file: str,
         tmp_base_directory: str,
         defaults_config_file: str,
-        username: Optional[str] = None,
+        user: Optional[str] = None,
         group: Optional[str] = None,
     ) -> Tuple[str, str]:
         """Executes commands to create a backup with the given args."""
@@ -2740,9 +2740,7 @@ class MySQLBase(ABC):
 
         try:
             nproc, _ = self._execute_commands(nproc_command)
-            tmp_dir, _ = self._execute_commands(
-                make_temp_dir_command, username=username, group=group
-            )
+            tmp_dir, _ = self._execute_commands(make_temp_dir_command, user=user, group=group)
         except MySQLExecError as e:
             logger.exception("Failed to execute commands prior to running backup")
             raise MySQLExecuteBackupCommandsError(e.message)
@@ -2791,7 +2789,7 @@ class MySQLBase(ABC):
             return self._execute_commands(
                 xtrabackup_commands,
                 bash=True,
-                username=username,
+                user=user,
                 group=group,
                 env_extra={
                     "ACCESS_KEY_ID": s3_parameters["access-key"],
@@ -2810,7 +2808,7 @@ class MySQLBase(ABC):
     def delete_temp_backup_directory(
         self,
         tmp_base_directory: str,
-        username: Optional[str] = None,
+        user: Optional[str] = None,
         group: Optional[str] = None,
     ) -> None:
         """Delete the temp backup directory."""
@@ -2823,7 +2821,7 @@ class MySQLBase(ABC):
 
             self._execute_commands(
                 delete_temp_dir_command,
-                username=username,
+                user=user,
                 group=group,
             )
         except MySQLExecError as e:
@@ -2840,7 +2838,7 @@ class MySQLBase(ABC):
         temp_restore_directory: str,
         xbcloud_location: str,
         xbstream_location: str,
-        username=None,
+        user=None,
         group=None,
     ) -> Tuple[str, str, str]:
         """Retrieve the specified backup from S3.
@@ -2859,7 +2857,7 @@ class MySQLBase(ABC):
 
             tmp_dir, _ = self._execute_commands(
                 make_temp_dir_command,
-                username=username,
+                user=user,
                 group=group,
             )
         except MySQLExecError as e:
@@ -2895,7 +2893,7 @@ class MySQLBase(ABC):
                     "ACCESS_KEY_ID": s3_parameters["access-key"],
                     "SECRET_ACCESS_KEY": s3_parameters["secret-key"],
                 },
-                username=username,
+                user=user,
                 group=group,
             )
             return (stdout, stderr, tmp_dir)
@@ -2911,7 +2909,7 @@ class MySQLBase(ABC):
         backup_location: str,
         xtrabackup_location: str,
         xtrabackup_plugin_dir: str,
-        username=None,
+        user=None,
         group=None,
     ) -> Tuple[str, str]:
         """Prepare the backup in the provided dir for restore."""
@@ -2938,7 +2936,7 @@ class MySQLBase(ABC):
 
             return self._execute_commands(
                 prepare_backup_command,
-                username=username,
+                user=user,
                 group=group,
             )
         except MySQLExecError as e:
@@ -2951,7 +2949,7 @@ class MySQLBase(ABC):
     def empty_data_files(
         self,
         mysql_data_directory: str,
-        username=None,
+        user=None,
         group=None,
     ) -> None:
         """Empty the mysql data directory in preparation of backup restore."""
@@ -2961,7 +2959,7 @@ class MySQLBase(ABC):
             logger.debug(f"Command to empty data directory: {' '.join(empty_data_files_command)}")
             self._execute_commands(
                 empty_data_files_command,
-                username=username,
+                user=user,
                 group=group,
             )
         except MySQLExecError as e:
@@ -2978,7 +2976,7 @@ class MySQLBase(ABC):
         defaults_config_file: str,
         mysql_data_directory: str,
         xtrabackup_plugin_directory: str,
-        username=None,
+        user=None,
         group=None,
     ) -> Tuple[str, str]:
         """Restore the provided prepared backup."""
@@ -2998,7 +2996,7 @@ class MySQLBase(ABC):
 
             return self._execute_commands(
                 restore_backup_command,
-                username=username,
+                user=user,
                 group=group,
             )
         except MySQLExecError as e:
@@ -3011,7 +3009,7 @@ class MySQLBase(ABC):
     def delete_temp_restore_directory(
         self,
         temp_restore_directory: str,
-        username=None,
+        user=None,
         group=None,
     ) -> None:
         """Delete the temp restore directory from the mysql data directory."""
@@ -3024,7 +3022,7 @@ class MySQLBase(ABC):
             )
             self._execute_commands(
                 delete_temp_restore_directory_command,
-                username=username,
+                user=user,
                 group=group,
             )
         except MySQLExecError as e:
@@ -3036,7 +3034,7 @@ class MySQLBase(ABC):
         self,
         commands: List[str],
         bash: bool = False,
-        username: Optional[str] = None,
+        user: Optional[str] = None,
         group: Optional[str] = None,
         env_extra: Dict = None,
     ) -> Tuple[str, str]:
@@ -3071,7 +3069,7 @@ class MySQLBase(ABC):
         try:
             self._run_mysqlcli_script(
                 enable_commands,
-                username=self.server_config_user,
+                user=self.server_config_user,
                 password=self.server_config_password,
             )
         except MySQLClientError:
@@ -3219,7 +3217,7 @@ class MySQLBase(ABC):
     def _run_mysqlcli_script(
         self,
         script: str,
-        username: str = "root",
+        user: str = "root",
         password: Optional[str] = None,
         timeout: Optional[int] = None,
     ) -> str:

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -85,7 +85,7 @@ class MySQLProvider(Object):
         """
         if legacy:
             return f"relation-{relation_id}"
-        return f"{self.model.uuid.replace('-', '')}_relation-{relation_id}"[-32:]
+        return f"relation-{relation_id}_{self.model.uuid.replace('-', '')}"[:32]
 
     # =============
     # Handlers

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -81,11 +81,11 @@ class MySQLProvider(Object):
             legacy (bool): If True, generate a username without the model uuid.
 
         Returns:
-            str: A valid unique username (max 32 characters long)
+            str: A valid unique username (limited to 26 characters)
         """
         if legacy:
             return f"relation-{relation_id}"
-        return f"relation-{relation_id}_{self.model.uuid.replace('-', '')}"[:32]
+        return f"relation-{relation_id}_{self.model.uuid.replace('-', '')}"[:26]
 
     # =============
     # Handlers

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -73,6 +73,17 @@ class MySQLProvider(Object):
         self.database.update_relation_data(relation.id, {"password": password})
         return password
 
+    def _get_username(self, relation_id: int) -> str:
+        """Generate a unique username for the relation using the model uuid and the relation id.
+
+        Args:
+            relation_id (int): The relation id.
+
+        Returns:
+            str: A valid unique username (max 32 characters long)
+        """
+        return f"{self.model.uuid.replace('-', '')}-{relation_id}"[-32:]
+
     # =============
     # Handlers
     # =============
@@ -94,7 +105,7 @@ class MySQLProvider(Object):
         if event.extra_user_roles:
             extra_user_roles = event.extra_user_roles.split(",")
         # user name is derived from the relation id
-        db_user = f"relation-{relation_id}"
+        db_user = self._get_username(relation_id)
         db_pass = self._get_or_set_password(event.relation)
 
         remote_app = event.app.name

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -185,7 +185,7 @@ async def test_deploy_router_and_app(first_model: Model) -> None:
         MYSQL_ROUTER_APP_NAME,
         application_name=MYSQL_ROUTER_APP_NAME,
         series="jammy",
-        channel="8.0/stable",
+        channel="8.0/edge/dpe4643",  # TODO: remove after router is released
         num_units=1,
         trust=True,
     )

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -195,7 +195,6 @@ async def test_deploy_router_and_app(first_model: Model) -> None:
         application_name=MYSQL_ROUTER_APP_NAME,
         series="jammy",
         channel="8.0/edge",
-        revision=119,  # TODO: remove after router is released
         num_units=1,
         trust=True,
     )

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -185,7 +185,8 @@ async def test_deploy_router_and_app(first_model: Model) -> None:
         MYSQL_ROUTER_APP_NAME,
         application_name=MYSQL_ROUTER_APP_NAME,
         series="jammy",
-        channel="8.0/edge/dpe4643",  # TODO: remove after router is released
+        channel="8.0/edge",
+        revision=119,  # TODO: remove after router is released
         num_units=1,
         trust=True,
     )

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -96,7 +96,7 @@ class TestDatabase(unittest.TestCase):
 
         username = (
             f"relation-{self.database_relation_id}_{self.harness.model.uuid.replace('-', '')}"
-        )[:32]
+        )[:26]
         self.assertEqual(
             database_relation_databag,
             {

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -94,12 +94,13 @@ class TestDatabase(unittest.TestCase):
             self.database_relation_id, "app", {"database": "test_db"}
         )
 
+        username = f"{self.harness.model.uuid.replace('-', '')}-{self.database_relation_id}"[-32:]
         self.assertEqual(
             database_relation_databag,
             {
                 "data": '{"database": "test_db"}',
                 "password": "super_secure_password",
-                "username": f"relation-{self.database_relation_id}",
+                "username": username,
                 "endpoints": "mysql-k8s-primary:3306",
                 "version": "8.0.29-0ubuntu0.20.04.3",
                 "read-only-endpoints": "mysql-k8s-replicas:3306",

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -94,7 +94,11 @@ class TestDatabase(unittest.TestCase):
             self.database_relation_id, "app", {"database": "test_db"}
         )
 
-        username = f"{self.harness.model.uuid.replace('-', '')}-{self.database_relation_id}"[-32:]
+        username = (
+            f"{self.harness.model.uuid.replace('-', '')}_relation-{self.database_relation_id}"[
+                -32:
+            ]
+        )
         self.assertEqual(
             database_relation_databag,
             {

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -95,10 +95,8 @@ class TestDatabase(unittest.TestCase):
         )
 
         username = (
-            f"{self.harness.model.uuid.replace('-', '')}_relation-{self.database_relation_id}"[
-                -32:
-            ]
-        )
+            f"relation-{self.database_relation_id}_{self.harness.model.uuid.replace('-', '')}"
+        )[:32]
         self.assertEqual(
             database_relation_databag,
             {


### PR DESCRIPTION
## Issue

Current username creation can lead to username collisions on cmr, due to it relying on relation id, that's only unique within a model.

## Solution

Assemble the username with the model uuid and relation id, trimming to mysql's 32 char limit.

