### PR TITLE
DPE-4768 Skip config change when no pebble connection

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -460,6 +460,11 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
     def _on_config_changed(self, _: EventBase) -> None:
         """Handle the config changed event."""
+        container = self.unit.get_container(CONTAINER_NAME)
+        if not container.can_connect():
+            # configuration also take places on pebble ready handler
+            return
+
         if not self._is_peer_data_set:
             # skip when not initialized
             return


### PR DESCRIPTION
## Issue

A `config-change` triggered before pebble-ready will error out due container being unavailable.

## Solution

Skip if no container is available. It's safe to do it, since workload configuration will take place on `pebble-ready` also.
