### PR TITLE
DPE-3557 Workaround pvc transient error

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -265,6 +265,7 @@ async def scale_application(
                 timeout=(15 * 60),
                 wait_for_exact_units=desired_count,
                 raise_on_blocked=True,
+                raise_on_error=False,
             )
 
 

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -165,6 +165,7 @@ async def deploy_and_scale_mysql(
             status="active",
             raise_on_blocked=True,
             timeout=TIMEOUT,
+            raise_on_error=False,
         )
 
         assert len(ops_test.model.applications[mysql_application_name].units) == num_units

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -109,11 +109,13 @@ async def test_build_and_deploy(
             apps=[MYSQL_APP1],
             status="active",
             timeout=10 * MINUTE,
+            raise_on_error=False,
         ),
         second_model.wait_for_idle(
             apps=[MYSQL_APP2],
             status="active",
             timeout=10 * MINUTE,
+            raise_on_error=False,
         ),
     )
 

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -60,6 +60,7 @@ async def test_deploy_latest(ops_test: OpsTest) -> None:
         apps=[MYSQL_APP_NAME, TEST_APP_NAME],
         status="active",
         timeout=TIMEOUT,
+        raise_on_error=False,
     )
     assert len(ops_test.model.applications[MYSQL_APP_NAME].units) == 3
 

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -57,6 +57,7 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
         apps=[MYSQL_APP_NAME, TEST_APP_NAME],
         status="active",
         timeout=TIMEOUT,
+        raise_on_error=False,
     )
     assert len(ops_test.model.applications[MYSQL_APP_NAME].units) == 3
 

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -53,6 +53,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
             apps=[MYSQL_APP_NAME],
             status="active",
             timeout=TIMEOUT,
+            raise_on_error=False,
         )
 
 

--- a/tests/integration/relations/test_database.py
+++ b/tests/integration/relations/test_database.py
@@ -71,6 +71,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
                 status="active",
                 raise_on_blocked=True,
                 timeout=1000,
+                raise_on_error=False,
             ),
             ops_test.model.wait_for_idle(
                 apps=[APPLICATION_APP_NAME],

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -68,6 +68,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
             raise_on_blocked=True,
             timeout=TIMEOUT,
             wait_for_exact_units=3,
+            raise_on_error=False,
         )
         assert len(ops_test.model.applications[APP_NAME].units) == 3
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -84,6 +84,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
             status="active",
             raise_on_blocked=True,
             timeout=15 * 60,
+            raise_on_error=False,
         )
 
 


### PR DESCRIPTION
## Issue

Integration tests often fails on a [PVC failing to be created](https://github.com/canonical/mysql-k8s-operator/actions/runs/9983902668/job/27592545064#step:22:149)

## Solution

Workaround it by not raise error on wait_for_idle when run after mysql-k8s deploy/scale commands (i.e. when PVC is created)

Credits to @lucasgameiroborges 

Fixes #378 