### PR TITLE
[DPE-3354] Update ops to ^2.15.0 to get pebble exec hanging fix

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1238,13 +1238,13 @@ files = [
 
 [[package]]
 name = "ops"
-version = "2.14.0"
+version = "2.15.0"
 description = "The Python library behind great charms"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ops-2.14.0-py3-none-any.whl", hash = "sha256:b1d7b03f87fa154bf0f2c0d688cb117d5ad8a2830966498fc66ba46987ae375d"},
-    {file = "ops-2.14.0.tar.gz", hash = "sha256:23d64b5e9433176f171895fbe3f21ad1963eaa073a20ae01f0f38171c688eb1a"},
+    {file = "ops-2.15.0-py3-none-any.whl", hash = "sha256:8e47ab8a814301776b0ff42b32544ebdece7f1639168d2c86dc7a25930d2e493"},
+    {file = "ops-2.15.0.tar.gz", hash = "sha256:f3bad7417e98e8f390523fad097702eed16e99b38a25e9fe856aad226474b057"},
 ]
 
 [package.dependencies]
@@ -2388,4 +2388,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a53362c690ec46796fa38bff64cd481ab64d948617827a8e3b26c4c934436c3b"
+content-hash = "403f2876a5085412e22187528ac92ea41323dd18c46847f41c7b656223abcbc2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = []
 
 [tool.poetry.dependencies]
 python = "^3.10"
-ops = "^2.7.0"
+ops = "^2.15.0"
 lightkube = "^0.14.0"
 tenacity = "^8.2.2"
 boto3 = "^1.28.22"
@@ -60,7 +60,7 @@ pytest-operator = "^0.28.0"
 pytest-operator-cache = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.3.3", subdirectory = "python/pytest_plugins/pytest_operator_cache"}
 pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.3.3", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 juju = "^3.2.2"
-ops = "^2.5.0"
+ops = "^2.15.0"
 mysql-connector-python = "~8.0.33"
 tenacity = "^8.2.2"
 boto3 = "^1.28.22"

--- a/tests/integration/high_availability/test_node_drain.py
+++ b/tests/integration/high_availability/test_node_drain.py
@@ -29,6 +29,7 @@ TIMEOUT = 30 * 60
 
 @pytest.mark.group(1)
 @pytest.mark.skip_if_deployed
+@pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Simple test to ensure that the mysql and application charms get deployed."""
     await high_availability_test_setup(ops_test)


### PR DESCRIPTION
## Issue
https://github.com/canonical/mysql-k8s-operator/issues/364
We traced log rotation hanging occasionally to a [pebble/ops issue](https://github.com/canonical/operator/issues/1246)) - there was a fix implemented in `ops 2.14.1`, but we have not yet updated our ops version to port in this fix

## Solution
Update ops
