### PR TITLE
[DPE-4266] Strip passwords from command execute output and tracebacks

### DIFF
--- a/lib/charms/mysql/v0/async_replication.py
+++ b/lib/charms/mysql/v0/async_replication.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 # The unique Charmhub library identifier, never change it
 LIBID = "4de21f1a022c4e2c87ac8e672ec16f6a"
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 6
 
 RELATION_OFFER = "replication-offer"
 RELATION_CONSUMER = "replication"
@@ -778,9 +778,10 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
                 logger.debug("Recreating cluster prior to sync credentials")
                 self._charm.create_cluster()
                 # (re)set flags
-                self._charm.app_peer_data.update(
-                    {"removed-from-cluster-set": "", "rejoin-secondaries": "true"}
-                )
+                self._charm.app_peer_data.update({
+                    "removed-from-cluster-set": "",
+                    "rejoin-secondaries": "true",
+                })
                 event.defer()
                 return
             if not self._charm.cluster_fully_initialized:

--- a/lib/charms/mysql/v0/backups.py
+++ b/lib/charms/mysql/v0/backups.py
@@ -99,7 +99,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 
 if typing.TYPE_CHECKING:
@@ -314,11 +314,9 @@ class MySQLBackups(Object):
             return
 
         logger.info(f"Backup succeeded: with backup-id {datetime_backup_requested}")
-        event.set_results(
-            {
-                "backup-id": datetime_backup_requested,
-            }
-        )
+        event.set_results({
+            "backup-id": datetime_backup_requested,
+        })
         self.charm._on_update_status(None)
 
     def _can_unit_perform_backup(self) -> Tuple[bool, Optional[str]]:
@@ -538,11 +536,9 @@ class MySQLBackups(Object):
             return
 
         logger.info("Restore succeeded")
-        event.set_results(
-            {
-                "completed": "ok",
-            }
-        )
+        event.set_results({
+            "completed": "ok",
+        })
         # update status as soon as possible
         self.charm._on_update_status(None)
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -128,7 +128,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 65
+LIBPATCH = 66
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -421,9 +421,7 @@ class MySQLCharmBase(CharmBase, ABC):
         super().__init__(*args)
 
         # disable support
-        disable_file = Path(
-            f"{os.environ.get('CHARM_DIR')}/disable"
-        )  # pyright: ignore [reportArgumentType]
+        disable_file = Path(f"{os.environ.get('CHARM_DIR')}/disable")  # pyright: ignore [reportArgumentType]
         if disable_file.exists():
             logger.warning(
                 f"\n\tDisable file `{disable_file.resolve()}` found, the charm will skip all events."
@@ -539,19 +537,15 @@ class MySQLCharmBase(CharmBase, ABC):
             status = self._mysql.get_cluster_status()
 
         if status:
-            event.set_results(
-                {
-                    "success": True,
-                    "status": status,
-                }
-            )
+            event.set_results({
+                "success": True,
+                "status": status,
+            })
         else:
-            event.set_results(
-                {
-                    "success": False,
-                    "message": "Failed to read cluster status.  See logs for more information.",
-                }
-            )
+            event.set_results({
+                "success": False,
+                "message": "Failed to read cluster status.  See logs for more information.",
+            })
 
     def _recreate_cluster(self, event: ActionEvent) -> None:
         """Action used to recreate the cluster, for special cases."""
@@ -564,9 +558,9 @@ class MySQLCharmBase(CharmBase, ABC):
             del self.app_peer_data["removed-from-cluster-set"]
 
         # reset cluster-set-name to config or previous value
-        hash = self.generate_random_hash()
+        random_hash = self.generate_random_hash()
         self.app_peer_data["cluster-set-domain-name"] = self.model.config.get(
-            "cluster-set-name", f"cluster-set-{hash}"
+            "cluster-set-name", f"cluster-set-{random_hash}"
         )
 
         logger.info("Recreating cluster")
@@ -1234,12 +1228,10 @@ class MySQLBase(ABC):
         }
 
         if create_cluster_admin:
-            options.update(
-                {
-                    "clusterAdmin": self.cluster_admin_user,
-                    "clusterAdminPassword": self.cluster_admin_password,
-                }
-            )
+            options.update({
+                "clusterAdmin": self.cluster_admin_user,
+                "clusterAdminPassword": self.cluster_admin_password,
+            })
 
         configure_instance_command = (
             f"dba.configure_instance('{self.server_config_user}:{self.server_config_password}@{self.instance_address}', {json.dumps(options)})",
@@ -1813,7 +1805,7 @@ class MySQLBase(ABC):
         reraise=True,
         wait=wait_random(min=4, max=30),
     )
-    def remove_instance(self, unit_label: str, lock_instance: Optional[str] = None) -> None:
+    def remove_instance(self, unit_label: str, lock_instance: Optional[str] = None) -> None:  # noqa: C901
         """Remove instance from the cluster.
 
         This method is called from each unit being torn down, thus we must obtain
@@ -1821,7 +1813,7 @@ class MySQLBase(ABC):
         obtaining the lock, removing instances/dissolving the cluster, or releasing
         the lock.
         """
-        remaining_cluster_member_addresses = list()
+        remaining_cluster_member_addresses = []
         skip_release_lock = False
         try:
             # Get the cluster primary's address to direct lock acquisition request to.
@@ -2468,7 +2460,7 @@ class MySQLBase(ABC):
                 },
                 stream_output="stderr",
             )
-        except MySQLExecError as e:
+        except MySQLExecError:
             logger.exception("Failed to execute backup commands")
             raise MySQLExecuteBackupCommandsError
         except Exception:
@@ -2826,9 +2818,9 @@ class MySQLBase(ABC):
         ]
 
         if isinstance(logs_type, list):
-            flush_logs_commands.extend(
-                [f"session.run_sql('FLUSH {log.value}')" for log in logs_type]
-            )
+            flush_logs_commands.extend([
+                f"session.run_sql('FLUSH {log.value}')" for log in logs_type
+            ])
         else:
             flush_logs_commands.append(f'session.run_sql("FLUSH {logs_type.value}")')  # type: ignore
 
@@ -2858,9 +2850,9 @@ class MySQLBase(ABC):
             "sys",
         }
 
-    def strip_off_passwords(self, input: str) -> str:
-        """Strips off passwords from the input string"""
-        stripped_input = input
+    def strip_off_passwords(self, input_string: str) -> str:
+        """Strips off passwords from the input string."""
+        stripped_input = input_string
         for password in self.passwords:
             stripped_input = stripped_input.replace(password, "xxxxxxxxxxxx")
         return stripped_input

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -2414,12 +2414,12 @@ class MySQLBase(ABC):
             tmp_dir, _ = self._execute_commands(make_temp_dir_command, user=user, group=group)
         except MySQLExecError:
             logger.exception("Failed to execute commands prior to running backup")
-            raise MySQLExecuteBackupCommandsError from None
+            raise MySQLExecuteBackupCommandsError
         except Exception:
             # Catch all other exceptions to prevent the database being stuck in
             # a bad state due to pre-backup operations
             logger.exception("Failed unexpectedly to execute commands prior to running backup")
-            raise MySQLExecuteBackupCommandsError from None
+            raise MySQLExecuteBackupCommandsError
 
         # TODO: remove flags --no-server-version-check
         # when MySQL and XtraBackup versions are in sync
@@ -2470,12 +2470,12 @@ class MySQLBase(ABC):
             )
         except MySQLExecError as e:
             logger.exception("Failed to execute backup commands")
-            raise MySQLExecuteBackupCommandsError from None
+            raise MySQLExecuteBackupCommandsError
         except Exception:
             # Catch all other exceptions to prevent the database being stuck in
             # a bad state due to pre-backup operations
             logger.exception("Failed unexpectedly to execute backup commands")
-            raise MySQLExecuteBackupCommandsError from None
+            raise MySQLExecuteBackupCommandsError
 
     def delete_temp_backup_directory(
         self,

--- a/lib/charms/mysql/v0/s3_helpers.py
+++ b/lib/charms/mysql/v0/s3_helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """S3 helper functions for the MySQL charms."""
+
 import base64
 import logging
 import tempfile
@@ -31,7 +32,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 # botocore/urllib3 clutter the logs when on debug
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/lib/charms/mysql/v0/tls.py
+++ b/lib/charms/mysql/v0/tls.py
@@ -19,7 +19,6 @@ It requires the TLS certificates library and the MySQL library.
 
 """
 
-
 import base64
 import logging
 import re
@@ -52,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "eb73947deedd4380a3a90d527e0878eb"
 LIBAPI = 0
-LIBPATCH = 6
+LIBPATCH = 7
 
 SCOPE = "unit"
 

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -107,7 +107,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 PYDEPS = ["pydantic"]
 
@@ -116,14 +116,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_RELATION_NAME = "tracing"
 RELATION_INTERFACE_NAME = "tracing"
 
+# Supported list rationale https://github.com/canonical/tempo-coordinator-k8s-operator/issues/8
 ReceiverProtocol = Literal[
     "zipkin",
-    "kafka",
-    "opencensus",
-    "tempo_http",
-    "tempo_grpc",
     "otlp_grpc",
     "otlp_http",
+    "jaeger_grpc",
+    "jaeger_thrift_http",
 ]
 
 RawReceiver = Tuple[ReceiverProtocol, str]
@@ -141,14 +140,12 @@ class TransportProtocolType(str, enum.Enum):
     grpc = "grpc"
 
 
-receiver_protocol_to_transport_protocol = {
+receiver_protocol_to_transport_protocol: Dict[ReceiverProtocol, TransportProtocolType] = {
     "zipkin": TransportProtocolType.http,
-    "kafka": TransportProtocolType.http,
-    "opencensus": TransportProtocolType.http,
-    "tempo_http": TransportProtocolType.http,
-    "tempo_grpc": TransportProtocolType.grpc,
     "otlp_grpc": TransportProtocolType.grpc,
     "otlp_http": TransportProtocolType.http,
+    "jaeger_thrift_http": TransportProtocolType.http,
+    "jaeger_grpc": TransportProtocolType.grpc,
 }
 """A mapping between telemetry protocols and their corresponding transport protocol.
 """

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -562,6 +562,7 @@ class MySQL(MySQLBase):
                 environment=env_extra,
                 timeout=timeout,
             )
+
             if stream_output:
                 if stream_output == "stderr" and process.stderr:
                     for line in process.stderr:
@@ -569,11 +570,12 @@ class MySQL(MySQLBase):
                 if stream_output == "stdout" and process.stdout:
                     for line in process.stdout:
                         logger.debug(line.strip())
+
             stdout, stderr = process.wait_output()
             return (stdout.strip(), stderr.strip() if stderr else "")
         except ExecError:
-            logger.exception(f"Failed command: {commands=}, {user=}, {group=}")
-            raise MySQLExecError
+            logger.error(f"Failed command: commands={self.strip_off_passwords(' '.join(commands))}, {user=}, {group=}")
+            raise MySQLExecError from None
 
     def _run_mysqlsh_script(
         self, script: str, verbose: int = 1, timeout: Optional[int] = None
@@ -651,7 +653,7 @@ class MySQL(MySQLBase):
             stdout, _ = process.wait_output()
             return stdout
         except ExecError as e:
-            raise MySQLClientError(e.stderr)
+            raise MySQLClientError(self.strip_off_passwords(e.stderr))
         except ChangeError as e:
             raise MySQLClientError(e)
 

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -574,7 +574,9 @@ class MySQL(MySQLBase):
             stdout, stderr = process.wait_output()
             return (stdout.strip(), stderr.strip() if stderr else "")
         except ExecError:
-            logger.error(f"Failed command: commands={self.strip_off_passwords(' '.join(commands))}, {user=}, {group=}")
+            logger.error(
+                f"Failed command: commands={self.strip_off_passwords(' '.join(commands))}, {user=}, {group=}"
+            )
             raise MySQLExecError from None
 
     def _run_mysqlsh_script(
@@ -612,10 +614,10 @@ class MySQL(MySQLBase):
             process = self.container.exec(cmd, timeout=timeout)
             stdout, _ = process.wait_output()
             return stdout
-        except ExecError as e:
-            raise MySQLClientError(e.stderr)
-        except ChangeError as e:
-            raise MySQLClientError(e)
+        except ExecError:
+            raise MySQLClientError
+        except ChangeError:
+            raise MySQLClientError
 
     def _run_mysqlcli_script(
         self,
@@ -655,7 +657,7 @@ class MySQL(MySQLBase):
         except ExecError as e:
             raise MySQLClientError(self.strip_off_passwords(e.stderr))
         except ChangeError as e:
-            raise MySQLClientError(e)
+            raise MySQLClientError(self.strip_off_passwords(e.err))
 
     def write_content_to_file(
         self,


### PR DESCRIPTION
## Issue
We are leaking passwords when there's an issue creating a backup. For instance:

```
unit-mysql-k8s-0: 19:14:27 ERROR unit.mysql-k8s/0.juju-log Failed command: commands=['bash', '-c', 'set -o pipefail; xxtrabackup --defaults-file=/etc/mysql/my.cnf --defaults-group=mysqld --no-version-check --par
allel=12 --user=backups --password=vrEsWPEgo93NN8cv1a12nnZu --socket=/var/run/mysqld/mysqld.sock --lock-ddl --backup --stream=xbstream --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=/var/lib/m
ysql/xtra_backup_Eq2D --no-server-version-check | xbcloud put --curl-retriable-errors=7 --insecure --parallel=10 --md5 --storage=S3 --s3-region=us-east-1 --s3-bucket=mysql-backups-development --s3-endpoint=https
://s3.amazonaws.com --s3-api-version=auto --s3-bucket-lookup=auto mysql-k8s-test/2024-07-31T19:14:25Z'], user='mysql', group='mysql'                                                                               
Traceback (most recent call last):                                                                                                                                                                                 
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/src/mysql_k8s_helpers.py", line 572, in _execute_commands                                                                                                      
    stdout, stderr = process.wait_output()                                                                                                                                                                         
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/pebble.py", line 1771, in wait_output                                                                                                                 
    raise ExecError[AnyStr](self._command, exit_code, out_value, err_value)                                                                                                                                        
ops.pebble.ExecError: non-zero exit code 1 executing ['bash', '-c', 'set -o pipefail; xxtrabackup --defaults-file=/etc/mysql/my.cnf --defaults-group=mysqld --no-version-check --parallel=12 --user=backups --passw
ord=vrEsWPEgo93NN8cv1a12nnZu --socket=/var/run/mysqld/mysqld.sock --lock-ddl --backup --stream=xbstream --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=/var/lib/mysql/xtra_backup_Eq2D --no-serv
er-version-check | xbcloud put --curl-retriable-errors=7 --insecure --parallel=10 --md5 --storage=S3 --s3-region=us-east-1 --s3-bucket=mysql-backups-development --s3-endpoint=https://s3.amazonaws.com --s3-api-ve
rsion=auto --s3-bucket-lookup=auto mysql-k8s-test/2024-07-31T19:14:25Z'], stdout='', stderr=''                                                                                                                     
unit-mysql-k8s-0: 19:14:27 ERROR unit.mysql-k8s/0.juju-log Failed to execute backup commands                                                                                                                       
Traceback (most recent call last):                                                                                                                                                                                 
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/src/mysql_k8s_helpers.py", line 572, in _execute_commands                                                                                                      
    stdout, stderr = process.wait_output()                                                                                                                                                                         
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/pebble.py", line 1771, in wait_output                                                                                                                 
    raise ExecError[AnyStr](self._command, exit_code, out_value, err_value)                                                                                                                                        
ops.pebble.ExecError: non-zero exit code 1 executing ['bash', '-c', 'set -o pipefail; xxtrabackup --defaults-file=/etc/mysql/my.cnf --defaults-group=mysqld --no-version-check --parallel=12 --user=backups --passw
ord=vrEsWPEgo93NN8cv1a12nnZu --socket=/var/run/mysqld/mysqld.sock --lock-ddl --backup --stream=xbstream --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=/var/lib/mysql/xtra_backup_Eq2D --no-serv
er-version-check | xbcloud put --curl-retriable-errors=7 --insecure --parallel=10 --md5 --storage=S3 --s3-region=us-east-1 --s3-bucket=mysql-backups-development --s3-endpoint=https://s3.amazonaws.com --s3-api-ve
rsion=auto --s3-bucket-lookup=auto mysql-k8s-test/2024-07-31T19:14:25Z'], stdout='', stderr=''                                                                                                                     
                                                                                                                                                                                                                   
During handling of the above exception, another exception occurred:                                                                                                                                                
                                                                                                                                                                                                                   
Traceback (most recent call last):                                                                                                                                                                                 
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/lib/charms/mysql/v0/mysql.py", line 2452, in execute_backup_commands                                                                                           
    return self._execute_commands(                                                                                                                                                                                 
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 647, in wrapped_function                                                                                       
    return callable(*args, **kwargs)  # type: ignore                                                                                                                                                               
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/src/mysql_k8s_helpers.py", line 576, in _execute_commands                                                                                                      
    raise MySQLExecError                                                                                                                                                                                           
charms.mysql.v0.mysql.MySQLExecError                                                                                                                                                                               
```

## Solution
Modify code to avoid leaks of any passwords when `_execute_command` or `_run_mysqlcli_script` is called. For instance, the above stack trace becomes:

```
unit-mysql-k8s-0: 20:45:38 ERROR unit.mysql-k8s/0.juju-log Failed command: commands=bash -c set -o pipefail; xxtrabackup --defaults-file=/etc/mysql/my.cnf --defaults-group=mysqld --no-version-check --parallel=12 --user=backups --password=xxxxxxxxxxxx --socket=/var/run/mysqld/mysqld.sock --lock-ddl --backup --stream=xbstream --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=/var/lib/mysql/xtra_backup_g7WB --no-server-version-check | xbcloud put --curl-retriable-errors=7 --insecure --parallel=10 --md5 --storage=S3 --s3-region=us-east-1 --s3-bucket=mysql-backups-development --s3-endpoint=https://s3.amazonaws.com --s3-api-version=auto --s3-bucket-lookup=auto mysql-k8s-test/2024-07-31T20:45:36Z, user='mysql', group='mysql'
unit-mysql-k8s-0: 20:45:38 ERROR unit.mysql-k8s/0.juju-log Failed to execute backup commands
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/lib/charms/mysql/v0/mysql.py", line 2460, in execute_backup_commands
    return self._execute_commands(
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 647, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/src/mysql_k8s_helpers.py", line 578, in _execute_commands
    raise MySQLExecError from None
charms.mysql.v0.mysql.MySQLExecError
```