### PR TITLE
DPE-4933 Avoid early calls to unit_initialized

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -445,7 +445,8 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self.unit.status = MaintenanceStatus("restarting MySQL")
         container = self.unit.get_container(CONTAINER_NAME)
         if container.can_connect():
-            container.restart(MYSQLD_SAFE_SERVICE)
+            logger.debug("Restarting mysqld")
+            container.pebble.restart_services([MYSQLD_SAFE_SERVICE], timeout=3600)
             sleep(10)
             self._on_update_status(None)
 

--- a/src/log_rotate_manager.py
+++ b/src/log_rotate_manager.py
@@ -12,6 +12,8 @@ import typing
 from ops.framework import Object
 from ops.model import ActiveStatus
 
+from constants import CONTAINER_NAME
+
 if typing.TYPE_CHECKING:
     from charm import MySQLOperatorCharm
 
@@ -31,9 +33,11 @@ class LogRotateManager(Object):
 
     def start_log_rotate_manager(self):
         """Forks off a process that periodically dispatch a custom event to rotate logs."""
+        container = self.charm.unit.get_container(CONTAINER_NAME)
         if (
             not isinstance(self.charm.unit.status, ActiveStatus)
             or self.charm.peers is None
+            or not container.can_connect()
             or not self.charm.unit_initialized
         ):
             return

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -136,12 +136,12 @@ class MySQLRelation(Object):
         if not (relation_data := self.charm.app_peer_data.get(MYSQL_RELATION_DATA_KEY)):
             return
 
-        if not self.charm.unit_initialized:
-            # Skip update status for uninitialized unit
-            return
-
         container = self.charm.unit.get_container(CONTAINER_NAME)
         if not container.can_connect():
+            return
+
+        if not self.charm.unit_initialized:
+            # Skip update status for uninitialized unit
             return
 
         if not self.charm.unit.is_leader():

--- a/src/relations/mysql_root.py
+++ b/src/relations/mysql_root.py
@@ -12,7 +12,7 @@ from ops.charm import RelationBrokenEvent, RelationCreatedEvent
 from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus
 
-from constants import LEGACY_MYSQL_ROOT, PASSWORD_LENGTH, ROOT_PASSWORD_KEY
+from constants import CONTAINER_NAME, LEGACY_MYSQL_ROOT, PASSWORD_LENGTH, ROOT_PASSWORD_KEY
 from mysql_k8s_helpers import (
     MySQLCreateDatabaseError,
     MySQLCreateUserError,
@@ -150,6 +150,11 @@ class MySQLRootRelation(Object):
         being elected).
         """
         if not self.charm.unit.is_leader():
+            return
+
+        container = self.charm.unit.get_container(CONTAINER_NAME)
+        if not container.can_connect():
+            event.defer()
             return
 
         # Wait until on-config-changed event is executed


### PR DESCRIPTION
## Issue

Recent changes from the way we check for `unit_initilized` is causing pebble errors when pebble is not yet ready on the workload container.
More clearly, `unit_initialized` was moved from a databag flag to a query to the mysqld itself, meaning if that unit was added to the current cluster.

## Solution

1. Ensure calls to `unit_initialized` are only made if the workload container is ready (`can_connect() == True`).
2. During unrelated tests, It was noticed that default mysqld restart timeout value (30s) isn't enough for real world cases, so it's increased to 3600s.

