### PR TITLE
Fix metrics-endpoint created on scale up

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -469,6 +469,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             logger.debug("Skip reconcile mysqld exporter: empty pebble layer")
             return
 
+        if not self._mysql.is_data_dir_initialised():
+            logger.debug("Skip reconcile mysqld exporter: mysql not initialised")
+            return
         self.current_event = event
         self._reconcile_pebble_layer(container)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -156,11 +156,11 @@ class TestCharm(unittest.TestCase):
         _wait_until_mysql_connection,
         _get_mysql_version,
         _initialize_juju_units_operations_table,
-        _is_data_dir_initialised,
         _create_cluster_set,
+        _is_data_dir_initialised,
         _write_content_to_file,
-        _active_status_message,
         _upgrade_idle,
+        _active_status_message,
         _rescan_cluster,
         _cluster_metadata_exists,
         _install_plugins,
@@ -186,6 +186,7 @@ class TestCharm(unittest.TestCase):
             self.layer_dict()["services"],
         )
 
+        _is_data_dir_initialised.return_value = True
         self.harness.add_relation("metrics-endpoint", "test-cos-app")
         plan = self.harness.get_container_pebble_plan("mysql")
         self.assertEqual(


### PR DESCRIPTION
## Issue

While testing, found a bug where scaling up after COS relationship is established.
The handler for `metrics-endpoint-relation-created` is running before the new unit is initialized (i.e. before pebble ready). Since the hook does `_reconcile_pebble` call, it try to start `mysqld_safe` before the data directory is initialized, causing the unit to fail to start.

## Solution

Test for data_dir initialization on the handler for `metrics-endpoint-relation-created` and only call `_reconcile_pebble` if the data_dir is initialized.
