### PR TITLE
DPE-5210 Common credentials fixture and `exec` timeout workaround

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1536,7 +1536,9 @@ class MySQLBase(ABC):
         )
 
         try:
-            output = self._run_mysqlsh_script("\n".join(check_cluster_metadata_commands))
+            output = self._run_mysqlsh_script(
+                "\n".join(check_cluster_metadata_commands), timeout=10
+            )
         except MySQLClientError:
             logger.warning(f"Failed to check if cluster metadata exists {from_instance=}")
             return False

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -134,7 +134,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 69
+LIBPATCH = 70
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -581,7 +581,7 @@ class MySQL(MySQLBase):
             raise MySQLExecError from None
 
     def _run_mysqlsh_script(
-        self, script: str, verbose: int = 1, timeout: Optional[int] = None
+        self, script: str, timeout: Optional[int] = None, verbose: int = 0
     ) -> str:
         """Execute a MySQL shell script.
 
@@ -611,8 +611,14 @@ class MySQL(MySQLBase):
             MYSQLSH_SCRIPT_FILE,
         ]
 
+        # workaround for timeout not working on pebble exec
+        # https://github.com/canonical/operator/issues/1329
+        if timeout:
+            cmd.insert(0, str(timeout))
+            cmd.insert(0, "timeout")
+
         try:
-            process = self.container.exec(cmd, timeout=timeout)
+            process = self.container.exec(cmd)
             stdout, _ = process.wait_output()
             return stdout
         except ExecError:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,25 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from constants import SERVER_CONFIG_USERNAME
+
+from . import juju_
+from .high_availability.high_availability_helpers import get_application_name
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="function")
+async def credentials(ops_test: OpsTest):
+    """Return the credentials for the MySQL cluster."""
+    logger.info("Getting credentials for the MySQL cluster")
+    mysql_app_name = get_application_name(ops_test, "mysql-k8s")
+    unit = ops_test.model.applications[mysql_app_name].units[0]
+    credentials = await juju_.run_action(unit, "get-password", username=SERVER_CONFIG_USERNAME)
+
+    yield credentials

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -159,7 +159,7 @@ async def get_primary_unit(
     return None
 
 
-async def execute_queries_on_unit(
+def execute_queries_on_unit(
     unit_address: str,
     username: str,
     password: str,
@@ -474,7 +474,7 @@ async def retrieve_database_variable_value(
     server_config_creds = await get_server_config_credentials(unit)
     queries = [f"SELECT @@{variable_name};"]
 
-    output = await execute_queries_on_unit(
+    output = execute_queries_on_unit(
         unit_ip, server_config_creds["username"], server_config_creds["password"], queries
     )
 

--- a/tests/integration/high_availability/conftest.py
+++ b/tests/integration/high_availability/conftest.py
@@ -58,8 +58,8 @@ def built_charm(ops_test: OpsTest) -> pathlib.Path:
     return packed_charm[0].resolve(strict=True)
 
 
-@pytest.fixture()
-async def highly_available_cluster(ops_test: OpsTest) -> None:
+@pytest.fixture(scope="module")
+async def highly_available_cluster(ops_test: OpsTest):
     """Run the set up for high availability tests.
 
     Args:

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -431,7 +431,7 @@ async def get_max_written_value(first_model: Model, second_model: Model) -> list
     logger.info("Querying max value on all units")
     for unit in first_model_units + second_model_units:
         address = await get_unit_address(None, unit.name, unit.model)
-        values = await execute_queries_on_unit(
+        values = execute_queries_on_unit(
             address, credentials["username"], credentials["password"], select_max_written_value_sql
         )
         results.append(values[0])

--- a/tests/integration/high_availability/test_node_drain.py
+++ b/tests/integration/high_availability/test_node_drain.py
@@ -30,7 +30,7 @@ TIMEOUT = 30 * 60
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_pod_eviction_and_pvc_deletion(
-    ops_test: OpsTest, highly_available_cluster, continuous_writes
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
 ) -> None:
     """Test behavior when node drains - pod is evicted and pvs are rotated."""
     mysql_application_name = get_application_name(ops_test, "mysql")
@@ -42,7 +42,7 @@ async def test_pod_eviction_and_pvc_deletion(
     ), "The deployed mysql application is not fully online"
 
     logger.info("Ensuring all units have continuous writes incrementing")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
     mysql_unit = ops_test.model.applications[mysql_application_name].units[0]
     primary = await get_primary_unit(ops_test, mysql_unit, mysql_application_name)
@@ -71,4 +71,4 @@ async def test_pod_eviction_and_pvc_deletion(
     ), "The deployed mysql application is not fully online after primary pod eviction"
 
     logger.info("Ensuring all units have continuous writes incrementing")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)

--- a/tests/integration/high_availability/test_replication.py
+++ b/tests/integration/high_availability/test_replication.py
@@ -35,7 +35,7 @@ TIMEOUT = 15 * 60
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_check_consistency(
-    ops_test: OpsTest, highly_available_cluster, continuous_writes
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
 ) -> None:
     """Test to write to primary, and read the same data back from replicas."""
     mysql_application_name = get_application_name(ops_test, "mysql")
@@ -44,16 +44,18 @@ async def test_check_consistency(
     assert len(ops_test.model.applications[mysql_application_name].units) == 3
 
     database_name, table_name = "test-check-consistency", "data"
-    await insert_data_into_mysql_and_validate_replication(ops_test, database_name, table_name)
-    await clean_up_database_and_table(ops_test, database_name, table_name)
+    await insert_data_into_mysql_and_validate_replication(
+        ops_test, database_name, table_name, credentials
+    )
+    await clean_up_database_and_table(ops_test, database_name, table_name, credentials)
 
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
 
 @pytest.mark.group(2)
 @pytest.mark.abort_on_fail
 async def test_no_replication_across_clusters(
-    ops_test: OpsTest, highly_available_cluster, continuous_writes
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
 ) -> None:
     """Test to ensure that writes to one cluster do not replicate to another cluster."""
     mysql_application_name = get_application_name(ops_test, "mysql")
@@ -72,13 +74,16 @@ async def test_no_replication_across_clusters(
 
     # insert some data into the first/original mysql cluster
     database_name, table_name = "test-no-replication-across-clusters", "data"
-    await insert_data_into_mysql_and_validate_replication(ops_test, database_name, table_name)
+    await insert_data_into_mysql_and_validate_replication(
+        ops_test, database_name, table_name, credentials
+    )
 
     # ensure that the inserted data DOES NOT get replicated into the another mysql cluster
     another_mysql_unit = ops_test.model.applications[another_mysql_application_name].units[0]
     another_mysql_primary = await get_primary_unit(
         ops_test, another_mysql_unit, another_mysql_application_name
     )
+    assert another_mysql_primary
     another_server_config_credentials = await get_server_config_credentials(another_mysql_primary)
 
     select_databases_sql = [
@@ -88,7 +93,7 @@ async def test_no_replication_across_clusters(
     for unit in ops_test.model.applications[another_mysql_application_name].units:
         unit_address = await get_unit_address(ops_test, unit.name)
 
-        output = await execute_queries_on_unit(
+        output = execute_queries_on_unit(
             unit_address,
             another_server_config_credentials["username"],
             another_server_config_credentials["password"],
@@ -107,32 +112,35 @@ async def test_no_replication_across_clusters(
     )
 
     # clean up inserted data, and created tables + databases
-    await clean_up_database_and_table(ops_test, database_name, table_name)
+    await clean_up_database_and_table(ops_test, database_name, table_name, credentials)
 
 
 @pytest.mark.group(3)
 @pytest.mark.abort_on_fail
-async def test_scaling_without_data_loss(ops_test: OpsTest, highly_available_cluster) -> None:
+async def test_scaling_without_data_loss(
+    ops_test: OpsTest, highly_available_cluster, credentials
+) -> None:
     """Test to ensure that data is preserved when a unit is scaled up and then down.
 
     Ensures that there are no running continuous writes as the extra data in the
     database makes scaling up slower.
     """
     mysql_application_name = get_application_name(ops_test, "mysql")
+    assert mysql_application_name, "mysql application not found"
 
     # assert that there are 3 units in the mysql cluster
     assert len(ops_test.model.applications[mysql_application_name].units) == 3
 
     mysql_unit = ops_test.model.applications[mysql_application_name].units[0]
     primary = await get_primary_unit(ops_test, mysql_unit, mysql_application_name)
+    assert primary, "Primary unit not found"
 
     # insert a value before scale up, and ensure that the value exists in all units
     database_name, table_name = "test-preserves-data-on-delete", "data"
     value_before_scale_up = await insert_data_into_mysql_and_validate_replication(
-        ops_test, database_name, table_name
+        ops_test, database_name, table_name, credentials
     )
 
-    server_config_credentials = await get_server_config_credentials(primary)
     select_value_before_scale_up_sql = [
         f"SELECT id FROM `{database_name}`.`{table_name}` WHERE id = '{value_before_scale_up}'",
     ]
@@ -149,17 +157,17 @@ async def test_scaling_without_data_loss(ops_test: OpsTest, highly_available_clu
             for unit in ops_test.model.applications[mysql_application_name].units:
                 unit_address = await get_unit_address(ops_test, unit.name)
 
-                output = await execute_queries_on_unit(
+                output = execute_queries_on_unit(
                     unit_address,
-                    server_config_credentials["username"],
-                    server_config_credentials["password"],
+                    credentials["username"],
+                    credentials["password"],
                     select_value_before_scale_up_sql,
                 )
                 assert output[0] == value_before_scale_up
 
     # insert data after scale up
     value_after_scale_up = await insert_data_into_mysql_and_validate_replication(
-        ops_test, database_name, table_name
+        ops_test, database_name, table_name, credentials
     )
 
     # verify inserted data is present on all units
@@ -177,27 +185,28 @@ async def test_scaling_without_data_loss(ops_test: OpsTest, highly_available_clu
     for unit in ops_test.model.applications[mysql_application_name].units:
         unit_address = await get_unit_address(ops_test, unit.name)
 
-        output = await execute_queries_on_unit(
+        output = execute_queries_on_unit(
             unit_address,
-            server_config_credentials["username"],
-            server_config_credentials["password"],
+            credentials["username"],
+            credentials["password"],
             select_value_after_scale_up_sql,
         )
         assert output[0] == value_after_scale_up
 
     # clean up inserted data, and created tables + databases
-    await clean_up_database_and_table(ops_test, database_name, table_name)
+    await clean_up_database_and_table(ops_test, database_name, table_name, credentials)
 
 
 @pytest.mark.group(4)
 @pytest.mark.abort_on_fail
 async def test_kill_primary_check_reelection(
-    ops_test: OpsTest, highly_available_cluster, continuous_writes
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
 ) -> None:
     """Test to kill the primary under load and ensure re-election of primary."""
     mysql_application_name = get_application_name(ops_test, "mysql")
+    assert mysql_application_name, "mysql application not found"
 
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
     mysql_unit = ops_test.model.applications[mysql_application_name].units[0]
     primary = await get_primary_unit(ops_test, mysql_unit, mysql_application_name)
@@ -231,8 +240,10 @@ async def test_kill_primary_check_reelection(
             ops_test, 3
         ), "Old primary has not come back online after being killed"
 
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
     database_name, table_name = "test-kill-primary-check-reelection", "data"
-    await insert_data_into_mysql_and_validate_replication(ops_test, database_name, table_name)
-    await clean_up_database_and_table(ops_test, database_name, table_name)
+    await insert_data_into_mysql_and_validate_replication(
+        ops_test, database_name, table_name, credentials
+    )
+    await clean_up_database_and_table(ops_test, database_name, table_name, credentials)

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -43,7 +43,7 @@ TIMEOUT = 40 * 60
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_kill_db_process(
-    ops_test: OpsTest, highly_available_cluster, continuous_writes
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
 ) -> None:
     """Test to send a SIGKILL to the primary db process and ensure that the cluster self heals."""
     mysql_application_name = get_application_name(ops_test, "mysql")
@@ -55,7 +55,7 @@ async def test_kill_db_process(
     ), "The deployed mysql application is not fully online"
 
     logger.info("Ensuring all units have continuous writes incrementing")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
     mysql_unit = ops_test.model.applications[mysql_application_name].units[0]
     primary = await get_primary_unit(ops_test, mysql_unit, mysql_application_name)
@@ -73,7 +73,7 @@ async def test_kill_db_process(
         "SIGKILL",
     )
 
-    # Wait for the SIGKILL above to take effect before continuining with test checks
+    # Wait for the SIGKILL above to take effect before continuing with test checks
     time.sleep(10)
 
     logger.info("Waiting until 3 mysql instances are online")
@@ -97,22 +97,25 @@ async def test_kill_db_process(
     logger.info("Ensuring all units have continuous writes incrementing")
     # ensure continuous writes still incrementing for all units
     async with ops_test.fast_forward():
-        await ensure_all_units_continuous_writes_incrementing(ops_test)
+        await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
     # ensure that we are able to insert data into the primary and have it replicated to all units
     database_name, table_name = "test-kill-db-process", "data"
-    await insert_data_into_mysql_and_validate_replication(ops_test, database_name, table_name)
-    await clean_up_database_and_table(ops_test, database_name, table_name)
+    await insert_data_into_mysql_and_validate_replication(
+        ops_test, database_name, table_name, credentials
+    )
+    await clean_up_database_and_table(ops_test, database_name, table_name, credentials)
 
 
 @pytest.mark.group(2)
 @pytest.mark.abort_on_fail
 @pytest.mark.unstable
 async def test_freeze_db_process(
-    ops_test: OpsTest, highly_available_cluster, continuous_writes
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
 ) -> None:
     """Test to send a SIGSTOP to the primary db process and ensure that the cluster self heals."""
     mysql_application_name = get_application_name(ops_test, "mysql")
+    assert mysql_application_name, "mysql application name is not set"
 
     # ensure all units in the cluster are online
     assert await ensure_n_online_mysql_members(
@@ -120,7 +123,7 @@ async def test_freeze_db_process(
     ), "The deployed mysql application is not fully online"
 
     logger.info("Ensuring that all units continuous writes incrementing")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
     mysql_unit = ops_test.model.applications[mysql_application_name].units[0]
     primary = await get_primary_unit(ops_test, mysql_unit, mysql_application_name)
@@ -128,7 +131,7 @@ async def test_freeze_db_process(
     mysql_pid = await get_process_pid(
         ops_test, primary.name, MYSQL_CONTAINER_NAME, MYSQLD_PROCESS_NAME
     )
-    assert mysql_pid > 0, "mysql process id is not positive"
+    assert (mysql_pid or -1) > 0, "mysql process id is not positive"
 
     logger.info(f"Sending SIGSTOP to unit {primary.name}")
     await send_signal_to_pod_container_process(
@@ -173,7 +176,7 @@ async def test_freeze_db_process(
         for attempt in Retrying(stop=stop_after_delay(15 * 60), wait=wait_fixed(10)):
             with attempt:
                 await ensure_all_units_continuous_writes_incrementing(
-                    ops_test, remaining_online_units
+                    ops_test, credentials=credentials, mysql_units=remaining_online_units
                 )
 
     logger.info(f"Sending SIGCONT to {primary.name}")
@@ -225,16 +228,18 @@ async def test_freeze_db_process(
     ), "The deployed mysql application does not have three online nodes"
 
     logger.info("Ensure all units continuous writes incrementing")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
 
 @pytest.mark.group(3)
 @pytest.mark.abort_on_fail
 async def test_graceful_crash_of_primary(
-    ops_test: OpsTest, highly_available_cluster, continuous_writes
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
 ) -> None:
     """Test to send SIGTERM to primary instance and then verify recovery."""
     mysql_application_name = get_application_name(ops_test, "mysql")
+
+    assert mysql_application_name, "mysql application name is not set"
 
     logger.info("Ensuring that there are 3 online mysql members")
     assert await ensure_n_online_mysql_members(
@@ -242,7 +247,7 @@ async def test_graceful_crash_of_primary(
     ), "The deployed mysql application does not have three online nodes"
 
     logger.info("Ensuring that all units have incrementing continuous writes")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
     mysql_unit = ops_test.model.applications[mysql_application_name].units[0]
     primary = await get_primary_unit(ops_test, mysql_unit, mysql_application_name)
@@ -290,16 +295,19 @@ async def test_graceful_crash_of_primary(
     async with ops_test.fast_forward():
         for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(10)):
             with attempt:
-                await ensure_all_units_continuous_writes_incrementing(ops_test)
+                await ensure_all_units_continuous_writes_incrementing(
+                    ops_test, credentials=credentials
+                )
 
 
 @pytest.mark.group(4)
 @pytest.mark.abort_on_fail
 async def test_network_cut_affecting_an_instance(
-    ops_test: OpsTest, highly_available_cluster, continuous_writes, chaos_mesh
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, chaos_mesh, credentials
 ) -> None:
     """Test for a network cut affecting an instance."""
     mysql_application_name = get_application_name(ops_test, "mysql")
+    assert mysql_application_name, "mysql application name is not set"
 
     logger.info("Ensuring that there are 3 online mysql members")
     assert await ensure_n_online_mysql_members(
@@ -307,7 +315,7 @@ async def test_network_cut_affecting_an_instance(
     ), "The deployed mysql application does not have three online nodes"
 
     logger.info("Ensuring that all instances have incrementing continuous writes")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
     mysql_units = ops_test.model.applications[mysql_application_name].units
     primary = await get_primary_unit(ops_test, mysql_units[0], mysql_application_name)
@@ -339,7 +347,9 @@ async def test_network_cut_affecting_an_instance(
     assert primary.name != new_primary.name
 
     logger.info("Ensure all units have incrementing continuous writes")
-    await ensure_all_units_continuous_writes_incrementing(ops_test, remaining_units)
+    await ensure_all_units_continuous_writes_incrementing(
+        ops_test, credentials=credentials, mysql_units=remaining_units
+    )
 
     logger.info("Remove networkchaos policy isolating instance from cluster")
     remove_instance_isolation(ops_test)
@@ -374,17 +384,18 @@ async def test_network_cut_affecting_an_instance(
     ), "The deployed mysql application does not have three online nodes"
 
     logger.info("Ensure all units have incrementing continuous writes")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
 
 @pytest.mark.group(5)
 @pytest.mark.abort_on_fail
 @pytest.mark.unstable
 async def test_graceful_full_cluster_crash_test(
-    ops_test: OpsTest, highly_available_cluster, continuous_writes
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
 ) -> None:
     """Test to send SIGTERM to all units and then ensure that the cluster recovers."""
     mysql_application_name = get_application_name(ops_test, "mysql")
+    assert mysql_application_name, "mysql application name is not set"
 
     logger.info("Ensure there are 3 online mysql members")
     assert await ensure_n_online_mysql_members(
@@ -392,7 +403,7 @@ async def test_graceful_full_cluster_crash_test(
     ), "The deployed mysql application does not have three online nodes"
 
     logger.info("Ensure that all units have incrementing continuous writes")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
     mysql_units = ops_test.model.applications[mysql_application_name].units
 
@@ -400,7 +411,7 @@ async def test_graceful_full_cluster_crash_test(
     logger.info("Get mysqld pids on all instances")
     for unit in mysql_units:
         pid = await get_process_pid(ops_test, unit.name, MYSQL_CONTAINER_NAME, MYSQLD_PROCESS_NAME)
-        assert pid > 1
+        assert (pid or -1) > 1, "mysql process id is not known/positive"
 
         unit_mysqld_pids[unit.name] = pid
 
@@ -445,16 +456,18 @@ async def test_graceful_full_cluster_crash_test(
     for member in cluster_status["defaultreplicaset"]["topology"].values():
         assert member["status"] == "online"
 
-    async with ops_test.fast_forward():
-        logger.info("Ensure all units have incrementing continuous writes")
-        await ensure_all_units_continuous_writes_incrementing(ops_test)
+    logger.info("Ensure all units have incrementing continuous writes")
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
 
 
 @pytest.mark.group(6)
 @pytest.mark.abort_on_fail
-async def test_single_unit_pod_delete(ops_test: OpsTest, highly_available_cluster) -> None:
+async def test_single_unit_pod_delete(
+    ops_test: OpsTest, highly_available_cluster, credentials
+) -> None:
     """Delete the pod in a single unit deployment and write data to new pod."""
     mysql_application_name = get_application_name(ops_test, "mysql")
+    assert mysql_application_name, "mysql application name is not set"
 
     logger.info("Scale mysql application to 1 unit that is active")
     async with ops_test.fast_forward("60s"):
@@ -479,6 +492,10 @@ async def test_single_unit_pod_delete(ops_test: OpsTest, highly_available_cluste
     logger.info("Write data to unit and verify that data was written")
     database_name, table_name = "test-single-pod-delete", "data"
     await insert_data_into_mysql_and_validate_replication(
-        ops_test, database_name, table_name, mysql_application_substring="mysql-k8s"
+        ops_test,
+        database_name=database_name,
+        table_name=table_name,
+        credentials=credentials,
+        mysql_application_substring="mysql-k8s",
     )
-    await clean_up_database_and_table(ops_test, database_name, table_name)
+    await clean_up_database_and_table(ops_test, database_name, table_name, credentials)

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -92,7 +92,7 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
 @pytest.mark.group(1)
 @markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
-async def test_upgrade_from_stable(ops_test: OpsTest):
+async def test_upgrade_from_stable(ops_test: OpsTest, credentials):
     """Test updating from stable channel."""
     application = ops_test.model.applications[MYSQL_APP_NAME]
     logger.info("Build charm locally")
@@ -138,4 +138,4 @@ async def test_upgrade_from_stable(ops_test: OpsTest):
     )
 
     logger.info("Ensure continuous_writes")
-    await ensure_all_units_continuous_writes_incrementing(ops_test)
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)

--- a/tests/integration/relations/test_mysql_root.py
+++ b/tests/integration/relations/test_mysql_root.py
@@ -180,7 +180,7 @@ async def test_osm_pol_operations(ops_test: OpsTest) -> None:
                     unit_address = await get_unit_address(ops_test, unit.name)
 
                     # test that the `keystone` and `pol` databases exist
-                    output = await execute_queries_on_unit(
+                    output = execute_queries_on_unit(
                         unit_address,
                         server_config_credentials["username"],
                         server_config_credentials["password"],
@@ -190,7 +190,7 @@ async def test_osm_pol_operations(ops_test: OpsTest) -> None:
                     assert "pol" in output
 
                     # test that osm-pol successfully creates tables
-                    output = await execute_queries_on_unit(
+                    output = execute_queries_on_unit(
                         unit_address,
                         server_config_credentials["username"],
                         server_config_credentials["password"],

--- a/tests/integration/test_backup_aws.py
+++ b/tests/integration/test_backup_aws.py
@@ -111,7 +111,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_backup(ops_test: OpsTest, cloud_credentials, cloud_configs) -> None:
+async def test_backup(ops_test: OpsTest, cloud_credentials, cloud_configs, credentials) -> None:
     """Test to create a backup and list backups."""
     # TODO: deploy 3 units when bug https://bugs.launchpad.net/juju/+bug/1995466 is resolved
     mysql_application_name = await deploy_and_scale_mysql(ops_test, num_units=1)
@@ -127,6 +127,7 @@ async def test_backup(ops_test: OpsTest, cloud_credentials, cloud_configs) -> No
         ops_test,
         DATABASE_NAME,
         TABLE_NAME,
+        credentials,
     )
 
     logger.info("Setting s3 config")
@@ -172,13 +173,14 @@ async def test_backup(ops_test: OpsTest, cloud_credentials, cloud_configs) -> No
         ops_test,
         DATABASE_NAME,
         TABLE_NAME,
+        credentials,
     )
 
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_restore_on_same_cluster(
-    ops_test: OpsTest, cloud_credentials, cloud_configs
+    ops_test: OpsTest, cloud_credentials, cloud_configs, credentials
 ) -> None:
     """Test to restore a backup to the same mysql cluster."""
     # TODO: deploy 3 units when bug https://bugs.launchpad.net/juju/+bug/1995466 is resolved
@@ -187,7 +189,6 @@ async def test_restore_on_same_cluster(
     mysql_unit = ops_test.model.units[f"{mysql_application_name}/0"]
     assert mysql_unit
     mysql_unit_address = await get_unit_address(ops_test, mysql_unit.name)
-    server_config_credentials = await get_server_config_credentials(mysql_unit)
 
     # set the s3 config and credentials
     logger.info("Syncing credentials")
@@ -216,10 +217,10 @@ async def test_restore_on_same_cluster(
     )
     select_values_sql = [f"SELECT id FROM `{DATABASE_NAME}`.`{TABLE_NAME}`"]
 
-    values = await execute_queries_on_unit(
+    values = execute_queries_on_unit(
         mysql_unit_address,
-        server_config_credentials["username"],
-        server_config_credentials["password"],
+        credentials["username"],
+        credentials["password"],
         select_values_sql,
     )
     assert values == [value_before_backup]
@@ -230,14 +231,15 @@ async def test_restore_on_same_cluster(
         ops_test,
         DATABASE_NAME,
         TABLE_NAME,
+        credentials,
     )
 
     logger.info("Ensuring that pre-backup and post-restore values exist in the database")
 
-    values = await execute_queries_on_unit(
+    values = execute_queries_on_unit(
         mysql_unit_address,
-        server_config_credentials["username"],
-        server_config_credentials["password"],
+        credentials["username"],
+        credentials["password"],
         select_values_sql,
     )
     assert value_before_backup
@@ -250,10 +252,10 @@ async def test_restore_on_same_cluster(
     for unit in ops_test.model.applications[mysql_application_name].units:
         unit_address = await get_unit_address(ops_test, unit.name)
 
-        values = await execute_queries_on_unit(
+        values = execute_queries_on_unit(
             unit_address,
-            server_config_credentials["username"],
-            server_config_credentials["password"],
+            credentials["username"],
+            credentials["password"],
             select_values_sql,
         )
 
@@ -326,7 +328,7 @@ async def test_restore_on_new_cluster(ops_test: OpsTest, cloud_credentials, clou
     )
     select_values_sql = [f"SELECT id FROM `{DATABASE_NAME}`.`{TABLE_NAME}`"]
 
-    values = await execute_queries_on_unit(
+    values = execute_queries_on_unit(
         primary_unit_address,
         server_config_credentials["username"],
         server_config_credentials["password"],
@@ -340,12 +342,13 @@ async def test_restore_on_new_cluster(ops_test: OpsTest, cloud_credentials, clou
         ops_test,
         DATABASE_NAME,
         TABLE_NAME,
+        server_config_credentials,
         mysql_application_substring="another-mysql",
     )
 
     logger.info("Ensuring that pre-backup and post-restore values exist in the database")
 
-    values = await execute_queries_on_unit(
+    values = execute_queries_on_unit(
         primary_unit_address,
         server_config_credentials["username"],
         server_config_credentials["password"],
@@ -361,7 +364,7 @@ async def test_restore_on_new_cluster(ops_test: OpsTest, cloud_credentials, clou
     for unit in ops_test.model.applications[new_mysql_application_name].units:
         unit_address = await get_unit_address(ops_test, unit.name)
 
-        values = await execute_queries_on_unit(
+        values = execute_queries_on_unit(
             unit_address,
             server_config_credentials["username"],
             server_config_credentials["password"],

--- a/tests/integration/test_backup_gcp.py
+++ b/tests/integration/test_backup_gcp.py
@@ -111,7 +111,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_backup(ops_test: OpsTest, cloud_credentials, cloud_configs) -> None:
+async def test_backup(ops_test: OpsTest, cloud_credentials, cloud_configs, credentials) -> None:
     """Test to create a backup and list backups."""
     # TODO: deploy 3 units when bug https://bugs.launchpad.net/juju/+bug/1995466 is resolved
     mysql_application_name = await deploy_and_scale_mysql(ops_test, num_units=1)
@@ -127,6 +127,7 @@ async def test_backup(ops_test: OpsTest, cloud_credentials, cloud_configs) -> No
         ops_test,
         DATABASE_NAME,
         TABLE_NAME,
+        credentials,
     )
 
     logger.info("Setting s3 config")
@@ -172,13 +173,14 @@ async def test_backup(ops_test: OpsTest, cloud_credentials, cloud_configs) -> No
         ops_test,
         DATABASE_NAME,
         TABLE_NAME,
+        credentials,
     )
 
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_restore_on_same_cluster(
-    ops_test: OpsTest, cloud_credentials, cloud_configs
+    ops_test: OpsTest, cloud_credentials, cloud_configs, credentials
 ) -> None:
     """Test to restore a backup to the same mysql cluster."""
     # TODO: deploy 3 units when bug https://bugs.launchpad.net/juju/+bug/1995466 is resolved
@@ -187,7 +189,6 @@ async def test_restore_on_same_cluster(
     mysql_unit = ops_test.model.units[f"{mysql_application_name}/0"]
     assert mysql_unit
     mysql_unit_address = await get_unit_address(ops_test, mysql_unit.name)
-    server_config_credentials = await get_server_config_credentials(mysql_unit)
 
     # set the s3 config and credentials
     logger.info("Syncing credentials")
@@ -216,10 +217,10 @@ async def test_restore_on_same_cluster(
     )
     select_values_sql = [f"SELECT id FROM `{DATABASE_NAME}`.`{TABLE_NAME}`"]
 
-    values = await execute_queries_on_unit(
+    values = execute_queries_on_unit(
         mysql_unit_address,
-        server_config_credentials["username"],
-        server_config_credentials["password"],
+        credentials["username"],
+        credentials["password"],
         select_values_sql,
     )
     assert values == [value_before_backup]
@@ -230,14 +231,15 @@ async def test_restore_on_same_cluster(
         ops_test,
         DATABASE_NAME,
         TABLE_NAME,
+        credentials,
     )
 
     logger.info("Ensuring that pre-backup and post-restore values exist in the database")
 
-    values = await execute_queries_on_unit(
+    values = execute_queries_on_unit(
         mysql_unit_address,
-        server_config_credentials["username"],
-        server_config_credentials["password"],
+        credentials["username"],
+        credentials["password"],
         select_values_sql,
     )
     assert value_before_backup
@@ -250,10 +252,10 @@ async def test_restore_on_same_cluster(
     for unit in ops_test.model.applications[mysql_application_name].units:
         unit_address = await get_unit_address(ops_test, unit.name)
 
-        values = await execute_queries_on_unit(
+        values = execute_queries_on_unit(
             unit_address,
-            server_config_credentials["username"],
-            server_config_credentials["password"],
+            credentials["username"],
+            credentials["password"],
             select_values_sql,
         )
 
@@ -326,7 +328,7 @@ async def test_restore_on_new_cluster(ops_test: OpsTest, cloud_credentials, clou
     )
     select_values_sql = [f"SELECT id FROM `{DATABASE_NAME}`.`{TABLE_NAME}`"]
 
-    values = await execute_queries_on_unit(
+    values = execute_queries_on_unit(
         primary_unit_address,
         server_config_credentials["username"],
         server_config_credentials["password"],
@@ -340,12 +342,13 @@ async def test_restore_on_new_cluster(ops_test: OpsTest, cloud_credentials, clou
         ops_test,
         DATABASE_NAME,
         TABLE_NAME,
+        server_config_credentials,
         mysql_application_substring="another-mysql",
     )
 
     logger.info("Ensuring that pre-backup and post-restore values exist in the database")
 
-    values = await execute_queries_on_unit(
+    values = execute_queries_on_unit(
         primary_unit_address,
         server_config_credentials["username"],
         server_config_credentials["password"],
@@ -361,7 +364,7 @@ async def test_restore_on_new_cluster(ops_test: OpsTest, cloud_credentials, clou
     for unit in ops_test.model.applications[new_mysql_application_name].units:
         unit_address = await get_unit_address(ops_test, unit.name)
 
-        values = await execute_queries_on_unit(
+        values = execute_queries_on_unit(
             unit_address,
             server_config_credentials["username"],
             server_config_credentials["password"],

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -83,7 +83,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
             assert unit.workload_status == "active"
 
             unit_address = await get_unit_address(ops_test, unit.name)
-            output = await execute_queries_on_unit(
+            output = execute_queries_on_unit(
                 unit_address,
                 server_config_credentials["username"],
                 server_config_credentials["password"],
@@ -114,7 +114,7 @@ async def test_consistent_data_replication_across_cluster(ops_test: OpsTest) -> 
         f"INSERT INTO test.data_replication_table VALUES ('{random_chars}')",
     ]
 
-    await execute_queries_on_unit(
+    execute_queries_on_unit(
         primary_unit_address,
         server_config_credentials["username"],
         server_config_credentials["password"],
@@ -134,7 +134,7 @@ async def test_consistent_data_replication_across_cluster(ops_test: OpsTest) -> 
                 for unit in ops_test.model.applications[APP_NAME].units:
                     unit_address = await get_unit_address(ops_test, unit.name)
 
-                    output = await execute_queries_on_unit(
+                    output = execute_queries_on_unit(
                         unit_address,
                         server_config_credentials["username"],
                         server_config_credentials["password"],
@@ -344,7 +344,7 @@ async def test_log_rotation(ops_test: OpsTest) -> None:
     """Test the log rotation of text files."""
     unit = ops_test.model.applications[APP_NAME].units[0]
 
-    logger.info("Extending update-status-hook-inteval to 60m")
+    logger.info("Extending update-status-hook-interval to 60m")
     await ops_test.model.set_config({"update-status-hook-interval": "60m"})
 
     # Exclude slowquery log files as slowquery logs are not enabled by default

--- a/tests/unit/test_mysql_k8s_helpers.py
+++ b/tests/unit/test_mysql_k8s_helpers.py
@@ -239,14 +239,31 @@ class TestMySQL(unittest.TestCase):
                 "/usr/bin/mysqlsh",
                 "--no-wizard",
                 "--python",
-                "--verbose=1",
+                "--verbose=0",
                 "-f",
                 MYSQLSH_SCRIPT_FILE,
                 ";",
                 "rm",
                 MYSQLSH_SCRIPT_FILE,
             ],
-            timeout=None,
+        )
+
+        _container.reset_mock()
+        self.mysql._run_mysqlsh_script("script", timeout=10)
+        _container.exec.assert_called_once_with(
+            [
+                "timeout",
+                "10",
+                "/usr/bin/mysqlsh",
+                "--no-wizard",
+                "--python",
+                "--verbose=0",
+                "-f",
+                MYSQLSH_SCRIPT_FILE,
+                ";",
+                "rm",
+                MYSQLSH_SCRIPT_FILE,
+            ],
         )
 
     @patch("ops.model.Container")


### PR DESCRIPTION
## Issue

* Freeze DB test fails when waiting for credentials.
* multiple calls for same credentials during testing
* ops's `container.exec` timeout is not consistently working


## Solution

* Fixture for credentials retrieval
* workaround for `container.exec` timeout

## TODO

~~Propagate lib change back to VM~~
