### PR TITLE
[DPE-4861] Avoid ambiguous service selector when multiple mysql apps in a model have the same cluster-name

### DIFF
--- a/src/k8s_helpers.py
+++ b/src/k8s_helpers.py
@@ -54,7 +54,11 @@ class KubernetesHelpers:
             roles: List of roles to append on the service name
         """
         for role in roles:
-            selector = {"cluster-name": self.cluster_name, "role": role}
+            selector = {
+                "cluster-name": self.cluster_name,
+                "application_name": self.app_name,
+                "role": role,
+            }
             service_name = f"{self.app_name}-{role}"
             pod0 = self.client.get(
                 res=Pod,
@@ -128,6 +132,7 @@ class KubernetesHelpers:
             logger.debug(f"Patching {pod_name=} with {role=}")
 
             pod.metadata.labels["cluster-name"] = self.cluster_name
+            pod.metadata.labels["application-name"] = self.app_name
             pod.metadata.labels["role"] = role
             self.client.patch(Pod, pod_name, pod)
         except ApiError as e:

--- a/src/k8s_helpers.py
+++ b/src/k8s_helpers.py
@@ -56,7 +56,7 @@ class KubernetesHelpers:
         for role in roles:
             selector = {
                 "cluster-name": self.cluster_name,
-                "application_name": self.app_name,
+                "application-name": self.app_name,
                 "role": role,
             }
             service_name = f"{self.app_name}-{role}"


### PR DESCRIPTION
## Issue
When 2 mysql applications exist in the same model with the same cluster-name, it is possible that traffic for one cluster gets routed to the other cluster

Example: https://github.com/canonical/mysql-k8s-operator/actions/runs/10730746555/job/29759894942#step:37:1051
Possibly related: https://github.com/canonical/mysql-k8s-operator/issues/459

This is because our selector for service endpoint is `cluster-name` and `role`

## Solution
Add `application-name` as a label to pods, and use this as a selector for the service endpoint as well
