### PR TITLE
[DPE-5480] Add base in test_multi_relations to workaround libjuju bug

### DIFF
--- a/tests/integration/test_multi_relations.py
+++ b/tests/integration/test_multi_relations.py
@@ -50,6 +50,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
             num_units=1,
             channel="8.0/edge",
             trust=True,
+            base="ubuntu@22.04",
         )
 
 

--- a/tests/integration/test_multi_relations.py
+++ b/tests/integration/test_multi_relations.py
@@ -42,6 +42,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
             num_units=1,
             channel="latest/edge",
             config=config,
+            base="ubuntu@22.04",
         )
         await ops_test.model.deploy(
             "mysql-router-k8s",


### PR DESCRIPTION
## Issue

The test test_multi_relations.py is randomly failing on libjuju 3.5.2.0 with Juju 3.6-beta2:

> juju.errors.JujuError: base "ubuntu@20.04/stable" is not supported, supported bases are: ubuntu@22.04

 it is a known issue reported as https://github.com/juju/python-libjuju/issues/1090

## Solution

As a (temporary?) workaround lets add a base here.
