### PR TITLE
[DPE-5481] Ensure that uninitialized variable not referenced in _is_cluster_blocked helper

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -811,15 +811,15 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # We need to query member state from the server since member state would
         # be 'offline' if pod rescheduled during cluster creation, however
         # member-state in the unit peer databag will be 'waiting'
-        member_state_exists = True
         try:
             member_state, _ = self._mysql.get_member_state()
+            member_state_exists = True
         except MySQLUnableToGetMemberStateError:
             logger.error("Error getting member state while checking if cluster is blocked")
             self.unit.status = MaintenanceStatus("Unable to get member state")
             return True
         except MySQLNoMemberStateError:
-            member_state_exists = False
+            member_state_exists, member_state = False, None
 
         if not member_state_exists or member_state == "restarting":
             # avoid changing status while tls is being set up or charm is being initialized

--- a/src/charm.py
+++ b/src/charm.py
@@ -813,18 +813,17 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # member-state in the unit peer databag will be 'waiting'
         try:
             member_state, _ = self._mysql.get_member_state()
-            member_state_exists = True
         except MySQLUnableToGetMemberStateError:
             logger.error("Error getting member state while checking if cluster is blocked")
             self.unit.status = MaintenanceStatus("Unable to get member state")
             return True
         except MySQLNoMemberStateError:
-            member_state_exists, member_state = False, None
+            member_state = None
 
-        if not member_state_exists or member_state == "restarting":
+        if not member_state or member_state == "restarting":
             # avoid changing status while tls is being set up or charm is being initialized
             logger.info("Unit is waiting or restarting")
-            logger.debug(f"{member_state_exists=}, {member_state=}")
+            logger.debug(f"{member_state=}")
             return True
 
         # avoid changing status while async replication is setting up


### PR DESCRIPTION
## Issue
In a debug statement, we are possibly referencing the `member_state` variable which may not be initialized if a `MySQLNoMemberStateError` exception is raised

## Solution
Ensure that the `member_state` and `member_state_exists` variables (both logged) are always initialized if the code execution gets to the logger statement
