### PR TITLE
DPE-5582 Timeout node count query

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -134,7 +134,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 74
+LIBPATCH = 75
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1937,7 +1937,7 @@ class MySQLBase(ABC):
         )
 
         try:
-            output = self._run_mysqlsh_script("\n".join(size_commands))
+            output = self._run_mysqlsh_script("\n".join(size_commands), timeout=30)
         except MySQLClientError:
             logger.warning("Failed to get node count")
             return 0

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -812,3 +812,11 @@ class MySQL(MySQLBase):
     def fetch_error_log(self) -> Optional[str]:
         """Fetch the MySQL error log."""
         return self.read_file_content("/var/log/mysql/error.log")
+
+    def _file_exists(self, path: str) -> bool:
+        """Check if a file exists.
+
+        Args:
+            path: Path to the file to check
+        """
+        return self.container.exists(path)

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -495,10 +495,9 @@ async def ensure_all_units_continuous_writes_incrementing(
     )
 
     async with ops_test.fast_forward(fast_interval="15s"):
-        for attempt in Retrying(stop=stop_after_delay(15 * 60), wait=wait_fixed(10)):
-            with attempt:
-                # ensure that all units are up to date (including the previous primary)
-                for unit in mysql_units:
+        for unit in mysql_units:
+            for attempt in Retrying(stop=stop_after_delay(15 * 60), wait=wait_fixed(10)):
+                with attempt:
                     # ensure the max written value is incrementing (continuous writes is active)
                     max_written_value = await get_max_written_value_in_database(
                         ops_test, unit, credentials

--- a/tests/integration/high_availability/test_node_drain.py
+++ b/tests/integration/high_availability/test_node_drain.py
@@ -55,7 +55,7 @@ async def test_pod_eviction_and_pvc_deletion(
     delete_pvcs(primary_pod_pvcs)
     delete_pvs(primary_pod_pvs)
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("90s"):
         logger.info("Waiting for evicted primary pod to be rescheduled")
         await ops_test.model.wait_for_idle(
             apps=[mysql_application_name],

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -109,7 +109,6 @@ async def test_kill_db_process(
 
 @pytest.mark.group(2)
 @pytest.mark.abort_on_fail
-@pytest.mark.unstable
 async def test_freeze_db_process(
     ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
 ) -> None:

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -83,7 +83,7 @@ async def test_upgrade_to_failling(ops_test: OpsTest) -> None:
     logger.info("Build charm locally")
 
     sub_regex_failing_rejoin = (
-        's/logger.debug("Recovering unit")'
+        's/logger.info("Recovering unit")'
         '/self.charm._mysql.set_instance_offline_mode(True); raise RetryError("dummy")/'
     )
     src_patch(sub_regex=sub_regex_failing_rejoin, file_name="src/upgrade.py")


### PR DESCRIPTION
## Issue

Recent PR #499 introduced new method on update status for the k8s charm.
The method calls node_count method that fails on all units if there's one unresponsive unit, causing regression in
freeze db tests, due responsive units not being able to relabel pods.  

## Solution

Add timeout on node_count method to avoid hanging due unresponsive unit(s).
