### PR TITLE
[DPE-5659] Update COS alert rules

### DIFF
--- a/src/prometheus_alert_rules/metrics_alert_rules.yaml
+++ b/src/prometheus_alert_rules/metrics_alert_rules.yaml
@@ -9,12 +9,9 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: MySQL down (instance {{ $labels.instance }})
+          summary: MySQL instance {{ $labels.instance }} is down. 
           description: |
-            MySQL instance is down.
-            INSTANCE = {{ $labels.instance }}
-            VALUE = {{ $value }}
-            LABELS = {{ $labels }}
+            LABELS = {{ $labels }}.
 
       # 2.1.2
       # customized: 80% -> 90%
@@ -24,27 +21,10 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: MySQL too many connections (> 90%) (instance {{ $labels.instance }})
+          summary: MySQL instance {{ $labels.instance }} is using > 90% of `max_connections`.
           description: |
-            More than 90% of- MySQL connections are in use.
-            Consider double-checking how many connections the client application is opening.
-            INSTANCE = {{ $labels.instance }}
-            VALUE = {{ $value }}
-            LABELS = {{ $labels }}
-
-      # 2.1.3
-      - alert: MySQLHighPreparedStatementsUtilization(>80%)
-        expr: max_over_time(mysql_global_status_prepared_stmt_count[1m]) / mysql_global_variables_max_prepared_stmt_count * 100 > 80
-        for: 2m
-        labels:
-          severity: warning
-        annotations:
-          summary: MySQL high prepared statements utilization (> 80%) (instance {{ $labels.instance }})
-          description: |
-            High utilization of prepared statements (>80%). Too many prepared statements consumes system memory.
-            INSTANCE = {{ $labels.instance }}
-            VALUE = {{ $value }}
-            LABELS = {{ $labels }}
+            Consider checking the client application responsible for generating those additional connections.
+            LABELS = {{ $labels }}. 
 
       # 2.1.4
       # customized: 60% -> 80%
@@ -54,12 +34,22 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: MySQL high threads running (instance {{ $labels.instance }})
+          summary: MySQL instance {{ $labels.instance }} is actively using > 80% of `max_connections`.
           description: |
-            More than 80% of MySQL connections are in running state. Too many concurrent threads can harm query performance and/or indicate unoptimized queries.
-            INSTANCE = {{ $labels.instance }}
-            VALUE = {{ $value }}
-            LABELS = {{ $labels }}
+            Consider reviewing the value of the `max-connections` config parameter or allocate more resources to your database server. 
+            LABELS = {{ $labels }}. 
+            
+      # 2.1.3
+      - alert: MySQLHighPreparedStatementsUtilization(>80%)
+        expr: max_over_time(mysql_global_status_prepared_stmt_count[1m]) / mysql_global_variables_max_prepared_stmt_count * 100 > 80
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary:  MySQL instance {{ $labels.instance }} is using > 80% of `max_prepared_stmt_count`.
+          description: |
+            Too many prepared statements might consume a lot of memory. 
+            LABELS = {{ $labels }}. 
 
       # 2.1.8
       # customized: warning -> info
@@ -69,12 +59,10 @@ groups:
         labels:
           severity: info
         annotations:
-          summary: MySQL slow queries (instance {{ $labels.instance }})
+          summary: MySQL instance {{ $labels.instance }} has a slow query.
           description: |
-            MySQL server has a new slow query.
-            Check the application for query optimizations, lack of indexes or queries without filtering (`WHERE` clause).
-            VALUE = {{ $value }}
-            LABELS = {{ $labels }}
+            Consider optimizing the query by reviewing its execution plan, then rewrite the query and add any relevant indexes. 
+            LABELS = {{ $labels }}.
 
       # 2.1.9
       - alert: MySQLInnoDBLogWaits
@@ -83,12 +71,11 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: MySQL InnoDB log waits (instance {{ $labels.instance }})
+          summary: MySQL instance {{ $labels.instance }} has long InnoDB log waits. 
           description: |
-            MySQL innodb log writes are stalling.
-            Check storage for I/O performance.
-            VALUE = {{ $value }}
-            LABELS = {{ $labels }}
+            MySQL InnoDB log writes might be stalling. 
+            Check I/O activity on your nodes to find the responsible process or query. Consider using iotop and the performance_schema. 
+            LABELS = {{ $labels }}.
 
       # 2.1.10
       - alert: MySQLRestarted
@@ -97,10 +84,8 @@ groups:
         labels:
           severity: info
         annotations:
-          summary: MySQL restarted (instance {{ $labels.instance }})
+          summary: MySQL instance {{ $labels.instance }} restarted.
           description: |
-            MySQL restarted less than one minute ago.
-            If restarts are frequent, check `error.log` from Loki for diagnosis.
-            INSTANCE = {{ $labels.instance }}.
-            VALUE = {{ $value }}
-            LABELS = {{ $labels }}
+            MySQL restarted less than one minute ago. 
+            If the restart was unplanned or frequent, check Loki logs (e.g. `error.log`). 
+            LABELS = {{ $labels }}.

--- a/src/prometheus_alert_rules/metrics_alert_rules.yaml
+++ b/src/prometheus_alert_rules/metrics_alert_rules.yaml
@@ -102,5 +102,5 @@ groups:
             MySQL restarted less than one minute ago.
             If restarts are frequent, check `error.log` from Loki for diagnosis.
             INSTANCE = {{ $labels.instance }}.
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/metrics_alert_rules.yaml
+++ b/src/prometheus_alert_rules/metrics_alert_rules.yaml
@@ -1,5 +1,5 @@
 groups:
-  - name: MySQLExporter
+  - name: MySQLExporterK8s
 
     rules:
       # 2.1.1

--- a/src/prometheus_alert_rules/metrics_alert_rules.yaml
+++ b/src/prometheus_alert_rules/metrics_alert_rules.yaml
@@ -11,10 +11,10 @@ groups:
         annotations:
           summary: MySQL down (instance {{ $labels.instance }})
           description: |
-          MySQL instance is down
-          INSTANCE = {{ $labels.instance }}
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
+            MySQL instance is down.
+            INSTANCE = {{ $labels.instance }}
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
 
       # 2.1.2
       # customized: 80% -> 90%
@@ -26,10 +26,11 @@ groups:
         annotations:
           summary: MySQL too many connections (> 90%) (instance {{ $labels.instance }})
           description: |
-          More than 90% of- MySQL connections are in use
-          INSTANCE = {{ $labels.instance }}
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
+            More than 90% of- MySQL connections are in use.
+            Consider double-checking how many connections the client application is opening.
+            INSTANCE = {{ $labels.instance }}
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
 
       # 2.1.3
       - alert: MySQLHighPreparedStatementsUtilization(>80%)
@@ -40,11 +41,10 @@ groups:
         annotations:
           summary: MySQL high prepared statements utilization (> 80%) (instance {{ $labels.instance }})
           description: |
-          High utilization of prepared statements (>80%).
-          Too much prepared statements consumes system memory.
-          INSTANCE = {{ $labels.instance }}
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
+            High utilization of prepared statements (>80%). Too many prepared statements consumes system memory.
+            INSTANCE = {{ $labels.instance }}
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
 
       # 2.1.4
       # customized: 60% -> 80%
@@ -56,11 +56,10 @@ groups:
         annotations:
           summary: MySQL high threads running (instance {{ $labels.instance }})
           description: |
-          More than 80% of MySQL connections are in running state.
-          Too many concurrent threads can harm query performance and/or indicate unoptimized queries.
-          INSTANCE = {{ $labels.instance }}
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
+            More than 80% of MySQL connections are in running state. Too many concurrent threads can harm query performance and/or indicate unoptimized queries.
+            INSTANCE = {{ $labels.instance }}
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
 
       # 2.1.8
       # customized: warning -> info
@@ -72,9 +71,10 @@ groups:
         annotations:
           summary: MySQL slow queries (instance {{ $labels.instance }})
           description: |
-          MySQL server mysql has some new slow query. Check application for query optimizations, lack of indexes or queries without filtering (`WHERE` clause).
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
+            MySQL server has a new slow query.
+            Check the application for query optimizations, lack of indexes or queries without filtering (`WHERE` clause).
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
 
       # 2.1.9
       - alert: MySQLInnoDBLogWaits
@@ -85,9 +85,10 @@ groups:
         annotations:
           summary: MySQL InnoDB log waits (instance {{ $labels.instance }})
           description: |
-          MySQL innodb log writes stalling. Check storage for I/O performance.
-          VALUE = {{ $value }}
-          LABELS = {{ $labels }}
+            MySQL innodb log writes are stalling.
+            Check storage for I/O performance.
+            VALUE = {{ $value }}
+            LABELS = {{ $labels }}
 
       # 2.1.10
       - alert: MySQLRestarted
@@ -98,7 +99,8 @@ groups:
         annotations:
           summary: MySQL restarted (instance {{ $labels.instance }})
           description: |
-          MySQL restarted less than one minute ago. If restarts are frequent, check `error.log` from loki for diagnosis.
-          INSTANCE = {{ $labels.instance }}.
+            MySQL restarted less than one minute ago.
+            If restarts are frequent, check `error.log` from Loki for diagnosis.
+            INSTANCE = {{ $labels.instance }}.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/metrics_alert_rules.yaml
+++ b/src/prometheus_alert_rules/metrics_alert_rules.yaml
@@ -40,7 +40,8 @@ groups:
         annotations:
           summary: MySQL high prepared statements utilization (> 80%) (instance {{ $labels.instance }})
           description: |
-          High utilization of prepared statements (>80%)
+          High utilization of prepared statements (>80%).
+          Too much prepared statements consumes system memory.
           INSTANCE = {{ $labels.instance }}
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
@@ -56,6 +57,7 @@ groups:
           summary: MySQL high threads running (instance {{ $labels.instance }})
           description: |
           More than 80% of MySQL connections are in running state.
+          Too many concurrent threads can harm query performance and/or indicate unoptimized queries.
           INSTANCE = {{ $labels.instance }}
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
@@ -70,7 +72,7 @@ groups:
         annotations:
           summary: MySQL slow queries (instance {{ $labels.instance }})
           description: |
-          MySQL server mysql has some new slow query.
+          MySQL server mysql has some new slow query. Check application for query optimizations, lack of indexes or queries without filtering (`WHERE` clause).
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
@@ -83,7 +85,7 @@ groups:
         annotations:
           summary: MySQL InnoDB log waits (instance {{ $labels.instance }})
           description: |
-          MySQL innodb log writes stalling
+          MySQL innodb log writes stalling. Check storage for I/O performance.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}
 
@@ -96,7 +98,7 @@ groups:
         annotations:
           summary: MySQL restarted (instance {{ $labels.instance }})
           description: |
-          MySQL restarted less than one minute ago.
+          MySQL restarted less than one minute ago. If restarts are frequent, check `error.log` from loki for diagnosis.
           INSTANCE = {{ $labels.instance }}.
           VALUE = {{ $value }}
           LABELS = {{ $labels }}

--- a/src/prometheus_alert_rules/metrics_alert_rules.yaml
+++ b/src/prometheus_alert_rules/metrics_alert_rules.yaml
@@ -9,8 +9,12 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: MySQL Down (instance {{ $labels.instance }})
-          description: "MySQL instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          summary: MySQL down (instance {{ $labels.instance }})
+          description: |
+          MySQL instance is down
+          INSTANCE = {{ $labels.instance }}
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
       # 2.1.2
       # customized: 80% -> 90%
@@ -21,7 +25,11 @@ groups:
           severity: warning
         annotations:
           summary: MySQL too many connections (> 90%) (instance {{ $labels.instance }})
-          description: "More than 90% of MySQL connections are in use on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          description: |
+          More than 90% of- MySQL connections are in use
+          INSTANCE = {{ $labels.instance }}
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
       # 2.1.3
       - alert: MySQLHighPreparedStatementsUtilization(>80%)
@@ -31,7 +39,11 @@ groups:
           severity: warning
         annotations:
           summary: MySQL high prepared statements utilization (> 80%) (instance {{ $labels.instance }})
-          description: "High utilization of prepared statements (>80%) on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          description: |
+          High utilization of prepared statements (>80%)
+          INSTANCE = {{ $labels.instance }}
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
       # 2.1.4
       # customized: 60% -> 80%
@@ -42,7 +54,11 @@ groups:
           severity: warning
         annotations:
           summary: MySQL high threads running (instance {{ $labels.instance }})
-          description: "More than 80% of MySQL connections are in running state on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          description: |
+          More than 80% of MySQL connections are in running state.
+          INSTANCE = {{ $labels.instance }}
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
       # 2.1.8
       # customized: warning -> info
@@ -53,7 +69,10 @@ groups:
           severity: info
         annotations:
           summary: MySQL slow queries (instance {{ $labels.instance }})
-          description: "MySQL server mysql has some new slow query.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          description: |
+          MySQL server mysql has some new slow query.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
       # 2.1.9
       - alert: MySQLInnoDBLogWaits
@@ -63,7 +82,10 @@ groups:
           severity: warning
         annotations:
           summary: MySQL InnoDB log waits (instance {{ $labels.instance }})
-          description: "MySQL innodb log writes stalling\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          description: |
+          MySQL innodb log writes stalling
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}
 
       # 2.1.10
       - alert: MySQLRestarted
@@ -73,4 +95,8 @@ groups:
           severity: info
         annotations:
           summary: MySQL restarted (instance {{ $labels.instance }})
-          description: "MySQL has just been restarted, less than one minute ago on {{ $labels.instance }}.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+          description: |
+          MySQL restarted less than one minute ago.
+          INSTANCE = {{ $labels.instance }}.
+          VALUE = {{ $value }}
+          LABELS = {{ $labels }}

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands_pre =
     poetry install --only lint
 commands =
     poetry check --lock
-    poetry run codespell {[vars]all_path} --skip {tox_root}/src/prometheus_alert_rules
+    poetry run codespell {[vars]all_path}
     poetry run ruff check {[vars]all_path}
     poetry run ruff format --check --diff {[vars]all_path}
     find {[vars]all_path} -type f \( -name "*.sh" -o -name "*.bash" \) -exec poetry run shellcheck --color=always \{\} +

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands_pre =
     poetry install --only lint
 commands =
     poetry check --lock
-    poetry run codespell {[vars]all_path}
+    poetry run codespell {[vars]all_path} --skip {tox_root}/src/prometheus_alert_rules
     poetry run ruff check {[vars]all_path}
     poetry run ruff format --check --diff {[vars]all_path}
     find {[vars]all_path} -type f \( -name "*.sh" -o -name "*.bash" \) -exec poetry run shellcheck --color=always \{\} +


### PR DESCRIPTION
## Issue
Alert rule descriptions do not provide much guidance about what actions the user can take.

## Solution
Improve the descriptions of the COS alert rule expressions.

The format should be:
1. What happened, or what is the problem
2. What can the user do to recover, or investigate further _(this is the part that's usually missing)_

Here is a good example:
```yaml
summary: PostgresSQL SSL compression active (instance {{ $labels.instance }})
description: |
Database connections have SSL compression enabled. This may add significant jitter in replication delay.
Replicas can turn off SSL compression via `sslcompression=0` in `recovery.conf`.
```