### PR TITLE
Lock poetry version during charm build to 1.8.5.

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,7 +30,7 @@ parts:
       rustup default stable
 
       # Convert subset of poetry.lock to requirements.txt
-      curl -sSL https://install.python-poetry.org | python3 -
+      curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.8.5 python3 -
       /root/.local/bin/poetry export --only main,charm-libs --output requirements.txt
 
       craftctl default


### PR DESCRIPTION
Fixes #548. This should be the latest 1.x.x poetry release.