### PR TITLE
fix: tests fixes #74

### DIFF
--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -124,13 +124,17 @@ async def test_build_and_deploy(
 @markers.juju3
 @markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
-async def test_async_relate(first_model: Model, second_model: Model) -> None:
+async def test_async_relate(ops_test: OpsTest, first_model: Model, second_model: Model) -> None:
     """Relate the two mysql clusters."""
     logger.info("Creating offers in first model")
-    await first_model.create_offer(f"{MYSQL_APP1}:replication-offer")
+    offer_command = f"offer {MYSQL_APP1}:replication-offer"
+    await ops_test.juju(*offer_command.split())
 
     logger.info("Consume offer in second model")
-    await second_model.consume(endpoint=f"admin/{first_model.info.name}.{MYSQL_APP1}")
+    consume_command = (
+        f"consume -m {second_model.info.name} admin/{first_model.info.name}.{MYSQL_APP1}"
+    )
+    await ops_test.juju(*consume_command.split())
 
     logger.info("Relating the two mysql clusters")
     await second_model.integrate(f"{MYSQL_APP1}", f"{MYSQL_APP2}:replication")

--- a/tests/integration/high_availability/test_crash_during_setup.py
+++ b/tests/integration/high_availability/test_crash_during_setup.py
@@ -8,8 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from ..helpers import delete_file_or_directory_in_unit, write_content_to_file_in_unit
-from .high_availability_helpers import CLUSTER_NAME, delete_pod
+from .high_availability_helpers import CLUSTER_NAME, delete_pod, scale_application
 
 logger = logging.getLogger(__name__)
 
@@ -21,76 +20,44 @@ TIMEOUT = 15 * 60
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_crash_during_cluster_setup(ops_test) -> None:
+    """Test primary crash during startup.
+
+    It must recover/end setup when the primary got offline.
+    """
     mysql_charm = await ops_test.build_charm(".")
 
     config = {"cluster-name": CLUSTER_NAME, "profile": "testing"}
     resources = {"mysql-image": METADATA["resources"]["mysql-image"]["upstream-source"]}
 
-    logger.info("Deploying 3 units of mysql-k8s")
+    logger.info("Deploying 1 units of mysql-k8s")
     mysql_application = await ops_test.model.deploy(
         mysql_charm,
         application_name=APP_NAME,
         config=config,
         resources=resources,
-        num_units=3,
+        num_units=1,
         base="ubuntu@22.04",
         trust=True,
     )
 
-    logger.info("Waiting until application enters maintenance status")
+    logger.info("Waiting for single unit to be ready")
+    await ops_test.model.block_until(lambda: mysql_application.status == "active", timeout=TIMEOUT)
+
+    # leader unit is the 1st unit
+    leader_unit = mysql_application.units[0]
+
+    logger.info("Scale to 3 units")
+    await scale_application(ops_test, APP_NAME, 3, False)
+
+    logger.info("Waiting until application enters waiting status")
     await ops_test.model.block_until(
-        lambda: mysql_application.status == "maintenance", timeout=TIMEOUT
+        lambda: mysql_application.status == "waiting", timeout=TIMEOUT
     )
-
-    leader_unit = None
-    non_leader_units = []
-
-    for unit in mysql_application.units:
-        if not await unit.is_leader_from_status():
-            non_leader_units.append(unit)
-        else:
-            leader_unit = unit
-
-    logger.info("Waiting until leader unit is creating cluster")
-    await ops_test.model.block_until(
-        lambda: leader_unit.workload_status == "maintenance"
-        and leader_unit.agent_status == "executing"
-        and "Creating cluster" in leader_unit.workload_status_message,
-        timeout=TIMEOUT,
-    )
-
-    logger.info("Disabling non-leader units to avoid joining the cluster")
-    for unit in non_leader_units:
-        unit_label = unit.name.replace("/", "-")
-        await write_content_to_file_in_unit(
-            ops_test,
-            unit,
-            f"/var/lib/juju/agents/unit-{unit_label}/charm/disable",
-            "",
-            container_name="charm",
-        )
 
     logger.info("Deleting pod")
     delete_pod(ops_test, leader_unit)
 
-    logger.info("Waiting until pod rescheduled and cluster is set up again")
     async with ops_test.fast_forward("60s"):
-        await ops_test.model.block_until(
-            lambda: leader_unit.workload_status == "active"
-            and leader_unit.workload_status_message == "Primary",
-            timeout=TIMEOUT,
-        )
-
-        logger.info("Removing disabled flag from non-leader units")
-        for unit in non_leader_units:
-            unit_label = unit.name.replace("/", "-")
-            await delete_file_or_directory_in_unit(
-                ops_test,
-                unit.name,
-                f"/var/lib/juju/agents/unit-{unit_label}/charm/disable",
-                container_name="charm",
-            )
-
         logger.info("Waiting until cluster is fully active")
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],


### PR DESCRIPTION
test async and crash during setup consistently failing.

- **model calls for consume/offer breaking in tests**
- **use scaling strategy to reproduce crash of primary previous to secondaries join**
