### PR TITLE
[DPE-4375] Add cluster manual re-join handler

### DIFF
--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -12,9 +12,11 @@ from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
 from ..helpers import (
+    execute_queries_on_unit,
     get_cluster_status,
     get_primary_unit,
     get_process_pid,
+    get_unit_address,
     scale_application,
     start_mysqld_service,
     stop_mysqld_service,
@@ -498,3 +500,67 @@ async def test_single_unit_pod_delete(
         mysql_application_substring="mysql-k8s",
     )
     await clean_up_database_and_table(ops_test, database_name, table_name, credentials)
+
+
+@pytest.mark.group(7)
+@pytest.mark.abort_on_fail
+async def test_cluster_manual_rejoin(
+    ops_test: OpsTest, highly_available_cluster, continuous_writes, credentials
+) -> None:
+    """The cluster manual re-join test.
+
+    A graceful restart is performed in one of the instances (choosing Primary to make it painful).
+    In order to verify that the instance can come back ONLINE, after disabling automatic re-join
+    """
+    # Ensure continuous writes still incrementing for all units
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)
+
+    mysql_app_name = get_application_name(ops_test, "mysql")
+    mysql_units = ops_test.model.applications[mysql_app_name].units
+
+    primary_unit = await get_primary_unit(ops_test, mysql_units[0], mysql_app_name)
+    primary_unit_ip = await get_unit_address(ops_test, primary_unit.name)
+
+    queries = [
+        "SET PERSIST group_replication_autorejoin_tries=0",
+    ]
+
+    # Disable automatic re-join procedure
+    execute_queries_on_unit(
+        unit_address=primary_unit_ip,
+        username=credentials["username"],
+        password=credentials["password"],
+        queries=queries,
+        commit=True,
+    )
+
+    logger.info(f"Stopping mysqld on {primary_unit.name}")
+    await stop_mysqld_service(ops_test, primary_unit.name)
+
+    logger.info(f"Wait until mysqld stopped on {primary_unit.name}")
+    await ensure_process_not_running(
+        ops_test=ops_test,
+        unit_name=primary_unit.name,
+        container_name=MYSQL_CONTAINER_NAME,
+        process=MYSQLD_PROCESS_NAME,
+    )
+
+    logger.info(f"Starting mysqld on {primary_unit.name}")
+    await start_mysqld_service(ops_test, primary_unit.name)
+
+    # Verify unit comes back active
+    async with ops_test.fast_forward():
+        logger.info("Waiting unit to enter in maintenance.")
+        await ops_test.model.block_until(
+            lambda: primary_unit.workload_status == "maintenance",
+            timeout=TIMEOUT,
+        )
+
+        logger.info("Waiting unit to be back online.")
+        await ops_test.model.block_until(
+            lambda: primary_unit.workload_status == "active",
+            timeout=TIMEOUT,
+        )
+
+    # Ensure continuous writes still incrementing for all units
+    await ensure_all_units_continuous_writes_incrementing(ops_test, credentials=credentials)

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -550,12 +550,6 @@ async def test_cluster_manual_rejoin(
 
     # Verify unit comes back active
     async with ops_test.fast_forward():
-        logger.info("Waiting unit to enter in maintenance.")
-        await ops_test.model.block_until(
-            lambda: primary_unit.workload_status == "maintenance",
-            timeout=TIMEOUT,
-        )
-
         logger.info("Waiting unit to be back online.")
         await ops_test.model.block_until(
             lambda: primary_unit.workload_status == "active",


### PR DESCRIPTION
This PR adds logic to manually re-join a MySQL replica that has gone `OFFLINE`, to the cluster, whenever MySQL 8.0.21+ [auto re-join](https://dev.mysql.com/doc/refman/8.0/en/group-replication-responses-failure-rejoin.html) attempts have been exhausted.

### Description

There are edge cases where a MySQL instance that has lost connection to the cluster it originally belong to (i.e. `OFFLINE`), exhaust its automatic retries (by default 3 retries, with 5 mins between each, starting with MySQL 8.0.21). For those cases, a manual re-join should be performed.

---

Depends on https://github.com/canonical/mysql-k8s-operator/pull/563.