### PR TITLE
[MISC] Bump mysql charm lib version

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,7 @@ options:
   profile:
     description: |
       profile representing the scope of deployment, and used to be able to enable high-level
-      high-level customisation of sysconfigs, resource checks/allocation, warning levels, etc.
+      customisation of sysconfigs, resource checks/allocation, warning levels, etc.
       Allowed values are: “production” and “testing”.
     type: string
     default: production

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -134,7 +134,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 78
+LIBPATCH = 79
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1003,10 +1003,11 @@ class MySQLBase(ABC):
             "innodb_buffer_pool_size": str(innodb_buffer_pool_size),
             "log_error_services": "log_filter_internal;log_sink_internal",
             "log_error": f"{snap_common}/var/log/mysql/error.log",
-            "general_log": "ON",
+            "general_log": "OFF",
             "general_log_file": f"{snap_common}/var/log/mysql/general.log",
             "slow_query_log_file": f"{snap_common}/var/log/mysql/slow.log",
             "binlog_expire_logs_seconds": f"{binlog_retention_seconds}",
+            "loose-audit_log_filter": "OFF",
             "loose-audit_log_policy": "LOGINS",
             "loose-audit_log_file": f"{snap_common}/var/log/mysql/audit.log",
         }

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -29,8 +29,8 @@ nocopytruncate
     olddir archive_general
 }
 
-/var/log/mysql/slowquery.log {
-    olddir archive_slowquery
+/var/log/mysql/slow.log {
+    olddir archive_slow
 }
 
 /var/log/mysql/audit.log {

--- a/tests/integration/high_availability/test_log_rotation.py
+++ b/tests/integration/high_availability/test_log_rotation.py
@@ -40,13 +40,13 @@ async def test_log_rotation(
     logger.info("Extending update-status-hook-interval to 60m")
     await ops_test.model.set_config({"update-status-hook-interval": "60m"})
 
-    # Exclude slowquery log files as slowquery logs are not enabled by default
+    # Exclude slow log files as slow logs are not enabled by default
     log_types = ["error", "general", "audit"]
     log_files = ["error.log", "general.log", "audit.log"]
     archive_directories = [
         "archive_error",
         "archive_general",
-        "archive_slowquery",
+        "archive_slow",
         "archive_audit",
     ]
 
@@ -105,7 +105,7 @@ async def test_log_rotation(
         ), f"❌ unexpected files/directories in log directory: {ls_output}"
 
     logger.info("Ensuring log files were rotated")
-    # Exclude checking slowquery log rotation as slowquery logs are disabled by default
+    # Exclude checking slow log rotation as slow logs are disabled by default
     for log in set(log_types):
         file_contents = read_contents_from_file_in_unit(
             ops_test, unit, f"/var/log/mysql/{log}.log"

--- a/tests/integration/high_availability/test_log_rotation.py
+++ b/tests/integration/high_availability/test_log_rotation.py
@@ -41,11 +41,10 @@ async def test_log_rotation(
     await ops_test.model.set_config({"update-status-hook-interval": "60m"})
 
     # Exclude slow log files as slow logs are not enabled by default
-    log_types = ["error", "general", "audit"]
-    log_files = ["error.log", "general.log", "audit.log"]
+    log_types = ["error", "audit"]
+    log_files = ["error.log", "audit.log"]
     archive_directories = [
         "archive_error",
-        "archive_general",
         "archive_slow",
         "archive_audit",
     ]

--- a/tests/unit/test_mysql_k8s_helpers.py
+++ b/tests/unit/test_mysql_k8s_helpers.py
@@ -326,8 +326,9 @@ class TestMySQL(unittest.TestCase):
             " rotation\nhourly\nmaxage 7\nrotate 10800\n\n# Naming of rotated files should be in"
             " the format:\ndateext\ndateformat -%Y%m%d_%H%M\n\n# Settings to prevent"
             " misconfigurations and unwanted behaviours\nifempty\nmissingok\nnocompress\nnomail\n"
-            "nosharedscripts\nnocopytruncate\n\n/var/log/mysql/error.log {\n    olddir"
-            " archive_error\n}\n\n/var/log/mysql/general.log {\n    olddir archive_general\n}\n\n"
+            "nosharedscripts\nnocopytruncate\n\n"
+            "/var/log/mysql/error.log {\n    olddir archive_error\n}\n\n"
+            "/var/log/mysql/general.log {\n    olddir archive_general\n}\n\n"
             "/var/log/mysql/slow.log {\n    olddir archive_slow\n}\n\n"
             "/var/log/mysql/audit.log {\n    olddir archive_audit\n}"
         )

--- a/tests/unit/test_mysql_k8s_helpers.py
+++ b/tests/unit/test_mysql_k8s_helpers.py
@@ -328,7 +328,7 @@ class TestMySQL(unittest.TestCase):
             " misconfigurations and unwanted behaviours\nifempty\nmissingok\nnocompress\nnomail\n"
             "nosharedscripts\nnocopytruncate\n\n/var/log/mysql/error.log {\n    olddir"
             " archive_error\n}\n\n/var/log/mysql/general.log {\n    olddir archive_general\n}\n\n"
-            "/var/log/mysql/slowquery.log {\n    olddir archive_slowquery\n}\n\n"
+            "/var/log/mysql/slow.log {\n    olddir archive_slow\n}\n\n"
             "/var/log/mysql/audit.log {\n    olddir archive_audit\n}"
         )
 


### PR DESCRIPTION
This PR bumps the `mysql` charm lib to its latest version. It does so by cherry picking changes from the following PRs:

- [Remove leftover MySQLBase methods](https://github.com/canonical/mysql-operator/pull/553).
- [\[DPE-5355\] Ensure logs flush](https://github.com/canonical/mysql-operator/pull/543).
- [\[DPE-6235\] Disable general_log and plugin audit_log_filter](https://github.com/canonical/mysql-operator/pull/574).

### Additional notes

The cherry picked changes from the referenced PRs are those that affect the `mysql` charm lib itself, and all the necessary test changes to make integration tests pass. Additional improvements set on those PRs have been ignored.

[DPE-5355]: https://warthogs.atlassian.net/browse/DPE-5355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-6235]: https://warthogs.atlassian.net/browse/DPE-6235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ