### PR TITLE
[DPE-5063] Update MySQL to v8.0.40

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,7 +32,7 @@ resources:
   mysql-image:
     type: oci-image
     description: Ubuntu LTS Docker image for MySQL
-    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:aa4d9b21673d2c6e4db3dc943179bae95dd8d355790b68e4e0610da9513ee6c9
+    upstream-source: ghcr.io/canonical/charmed-mysql@sha256:dbba2661ebc38463ca1b9d16edb73cf2575d7da937274d863492a3dfb288c5b7
 
 peers:
   database-peers:

--- a/src/dependency.json
+++ b/src/dependency.json
@@ -9,6 +9,6 @@
     "dependencies": {},
     "name": "charmed-mysql",
     "upgrade_supported": ">8.0.31",
-    "version": "8.0.39"
+    "version": "8.0.40"
   }
 }


### PR DESCRIPTION
## Issue
There is a new ROCK with an update of MySQL to v8.0.40

## Solution
Update the ROCK tag and also update MySQL to v8.0.40