### PR TITLE
fix: DPE-6521 Add missing check and wait for pebble calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ Makefile
 
 # local pyright settings
 pyrightconfig.json
+
+wt*/

--- a/src/charm.py
+++ b/src/charm.py
@@ -274,6 +274,18 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         }
         return self.unit_peer_data.keys() == _default_unit_data_keys
 
+    @property
+    def unit_initialized(self) -> bool:
+        """Return whether a unit is started.
+
+        Oveerride parent class method to include container accessibility check.
+        """
+        container = self.unit.get_container(CONTAINER_NAME)
+        if container.can_connect():
+            return super().unit_initialized
+        else:
+            return False
+
     def get_unit_hostname(self, unit_name: Optional[str] = None) -> str:
         """Get the hostname.localdomain for a unit.
 

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -186,12 +186,13 @@ class MySQL(MySQLBase):
         if paths[0].user != MYSQL_SYSTEM_USER or paths[0].group != MYSQL_SYSTEM_GROUP:
             logger.debug(f"Changing ownership to {MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP}")
             try:
-                container.exec([
+                process = container.exec([
                     "chown",
                     "-R",
                     f"{MYSQL_SYSTEM_USER}:{MYSQL_SYSTEM_GROUP}",
                     MYSQL_DATA_DIR,
                 ])
+                process.wait()
             except ExecError as e:
                 logger.error(f"Exited with code {e.exit_code}. Stderr:\n{e.stderr}")
                 raise MySQLInitialiseMySQLDError(e.stderr or "")


### PR DESCRIPTION
## Issue

1. Call to pebble fails due to missing readiness check
2. Call to pebble exec without a `wait` for the process (call is not executed)

## Solution

Add said calls.
