### PR TITLE
fix: DPE-6485 Manage mysqld directly

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1961,6 +1961,7 @@ class MySQLBase(ABC):
                 user=self.server_config_user,
                 password=self.server_config_password,
                 host=self.instance_def(self.server_config_user),
+                exception_as_warning=True,
             )
             return (
                 MySQLMemberState.ONLINE in output.lower()

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1462,16 +1462,14 @@ class MySQLBase(ABC):
         rows = json.loads(output)
         return rows[0][1]
 
-    def configure_instance(self, create_cluster_admin: bool = True, restart: bool = True) -> None:
+    def configure_instance(self, create_cluster_admin: bool = True) -> None:
         """Configure the instance to be used in an InnoDB cluster.
 
         Args:
             create_cluster_admin: Whether to create the cluster admin user.
-            restart: Daemon should be restarted automatically after configuration.
-                     If false, manual restart is required.
         """
         options = {
-            "restart": restart,
+            "restart": "true",
         }
 
         if create_cluster_admin:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -133,7 +133,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 81
+LIBPATCH = 82
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1462,10 +1462,16 @@ class MySQLBase(ABC):
         rows = json.loads(output)
         return rows[0][1]
 
-    def configure_instance(self, create_cluster_admin: bool = True) -> None:
-        """Configure the instance to be used in an InnoDB cluster."""
+    def configure_instance(self, create_cluster_admin: bool = True, restart: bool = True) -> None:
+        """Configure the instance to be used in an InnoDB cluster.
+
+        Args:
+            create_cluster_admin: Whether to create the cluster admin user.
+            restart: Daemon should be restarted automatically after configuration.
+                     If false, manual restart is required.
+        """
         options = {
-            "restart": "true",
+            "restart": restart,
         }
 
         if create_cluster_admin:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -133,7 +133,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 82
+LIBPATCH = 83
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"

--- a/src/charm.py
+++ b/src/charm.py
@@ -652,9 +652,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                 self._mysql.install_plugins(["audit_log", "audit_log_filter"])
 
             # Configure instance as a cluster node
-            # Explicit restart required to apply changes
-            self._mysql.configure_instance(restart=False)
-            container.restart(MYSQLD_SERVICE)
+            self._mysql.configure_instance()
         except (
             MySQLInitialiseMySQLDError,
             MySQLServiceNotRunningError,

--- a/src/charm.py
+++ b/src/charm.py
@@ -245,6 +245,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                     "user": MYSQL_SYSTEM_USER,
                     "group": MYSQL_SYSTEM_GROUP,
                     "kill-delay": "24h",
+                    "environment": {
+                        "MYSQLD_PARENT_PID": 1,
+                    },
                 },
                 MYSQLD_EXPORTER_SERVICE: {
                     "override": "replace",

--- a/src/charm.py
+++ b/src/charm.py
@@ -77,7 +77,8 @@ from constants import (
     MYSQLD_CONFIG_FILE,
     MYSQLD_EXPORTER_PORT,
     MYSQLD_EXPORTER_SERVICE,
-    MYSQLD_SAFE_SERVICE,
+    MYSQLD_LOCATION,
+    MYSQLD_SERVICE,
     PASSWORD_LENGTH,
     PEER,
     ROOT_PASSWORD_KEY,
@@ -222,14 +223,23 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
     @property
     def _pebble_layer(self) -> Layer:
         """Return a layer for the mysqld pebble service."""
+        mysqld_cmd = [
+            MYSQLD_LOCATION,
+            "--basedir=/usr",
+            "--datadir=/var/lib/mysql",
+            "--plugin-dir=/usr/lib/mysql/plugin",
+            "--log-error=/var/log/mysql/error.log",
+            f"--pid-file={self.unit_label}.pid",
+        ]
+
         layer = {
             "summary": "mysqld services layer",
             "description": "pebble config layer for mysqld safe and exporter",
             "services": {
-                MYSQLD_SAFE_SERVICE: {
+                MYSQLD_SERVICE: {
                     "override": "replace",
                     "summary": "mysqld safe",
-                    "command": MYSQLD_SAFE_SERVICE,
+                    "command": " ".join(mysqld_cmd),
                     "startup": "enabled",
                     "user": MYSQL_SYSTEM_USER,
                     "group": MYSQL_SYSTEM_GROUP,
@@ -425,7 +435,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if new_layer.services != current_layer.services:
             logger.info("Reconciling the pebble layer")
 
-            container.add_layer(MYSQLD_SAFE_SERVICE, new_layer, combine=True)
+            container.add_layer(MYSQLD_SERVICE, new_layer, combine=True)
             container.replan()
             self._mysql.wait_until_mysql_connection()
 
@@ -462,7 +472,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         container = self.unit.get_container(CONTAINER_NAME)
         if container.can_connect():
             logger.debug("Restarting mysqld")
-            container.pebble.restart_services([MYSQLD_SAFE_SERVICE], timeout=3600)
+            container.pebble.restart_services([MYSQLD_SERVICE], timeout=3600)
             sleep(10)
             self._on_update_status(None)
 
@@ -627,8 +637,8 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
             # Add the pebble layer
             logger.info("Adding pebble layer")
-            container.add_layer(MYSQLD_SAFE_SERVICE, self._pebble_layer, combine=True)
-            container.restart(MYSQLD_SAFE_SERVICE)
+            container.add_layer(MYSQLD_SERVICE, self._pebble_layer, combine=True)
+            container.restart(MYSQLD_SERVICE)
 
             logger.info("Waiting for instance to be ready")
             self._mysql.wait_until_mysql_connection(check_port=False)
@@ -642,7 +652,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                 self._mysql.install_plugins(["audit_log", "audit_log_filter"])
 
             # Configure instance as a cluster node
-            self._mysql.configure_instance()
+            # Explicit restart required to apply changes
+            self._mysql.configure_instance(restart=False)
+            container.restart(MYSQLD_SERVICE)
         except (
             MySQLInitialiseMySQLDError,
             MySQLServiceNotRunningError,

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,8 +6,8 @@
 PASSWORD_LENGTH = 24
 PEER = "database-peers"
 CONTAINER_NAME = "mysql"
-MYSQLD_LOCATION = "mysqld"
-MYSQLD_SAFE_SERVICE = "mysqld_safe"
+MYSQLD_SERVICE = "mysqld"
+MYSQLD_LOCATION = f"/usr/sbin/{MYSQLD_SERVICE}"
 ROOT_USERNAME = "root"
 CLUSTER_ADMIN_USERNAME = "clusteradmin"
 SERVER_CONFIG_USERNAME = "serverconfig"

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -427,6 +427,11 @@ class MySQL(MySQLBase):
             logger.exception(f"Failed to create user {username}@{hostname}")
             raise MySQLCreateUserError(e.message)
 
+    def configure_instance(self, create_cluster_admin: bool = True, restart=False) -> None:
+        """Override parent class method to ensure manual restart."""
+        super().configure_instance(create_cluster_admin, restart=False)
+        self.container.restart(MYSQLD_SERVICE)
+
     def escalate_user_privileges(self, username: str, hostname: str = "%") -> None:
         """Escalates the provided user's privileges.
 

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -41,7 +41,7 @@ from constants import (
     MYSQL_SYSTEM_USER,
     MYSQLD_DEFAULTS_CONFIG_FILE,
     MYSQLD_LOCATION,
-    MYSQLD_SAFE_SERVICE,
+    MYSQLD_SERVICE,
     MYSQLD_SOCK_FILE,
     MYSQLSH_LOCATION,
     ROOT_SYSTEM_USER,
@@ -530,22 +530,22 @@ class MySQL(MySQLBase):
         """Stops the mysqld process."""
         try:
             # call low-level pebble API to access timeout parameter
-            self.container.pebble.stop_services([MYSQLD_SAFE_SERVICE], timeout=5 * 60)
+            self.container.pebble.stop_services([MYSQLD_SERVICE], timeout=5 * 60)
         except ChangeError:
-            error_message = f"Failed to stop service {MYSQLD_SAFE_SERVICE}"
+            error_message = f"Failed to stop service {MYSQLD_SERVICE}"
             logger.exception(error_message)
             raise MySQLStopMySQLDError(error_message)
 
     def start_mysqld(self) -> None:
         """Starts the mysqld process."""
         try:
-            self.container.start(MYSQLD_SAFE_SERVICE)
+            self.container.start(MYSQLD_SERVICE)
             self.wait_until_mysql_connection()
         except (
             ChangeError,
             MySQLServiceNotRunningError,
         ):
-            error_message = f"Failed to start service {MYSQLD_SAFE_SERVICE}"
+            error_message = f"Failed to start service {MYSQLD_SERVICE}"
             logger.exception(error_message)
             raise MySQLStartMySQLDError(error_message)
 
@@ -761,7 +761,7 @@ class MySQL(MySQLBase):
             for line in stdout.strip().split("\n"):
                 [comm, stat] = line.split()
 
-                if comm == MYSQLD_SAFE_SERVICE:
+                if comm == MYSQLD_SERVICE:
                     return "T" in stat
 
             return True

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -427,11 +427,6 @@ class MySQL(MySQLBase):
             logger.exception(f"Failed to create user {username}@{hostname}")
             raise MySQLCreateUserError(e.message)
 
-    def configure_instance(self, create_cluster_admin: bool = True, restart=False) -> None:
-        """Override parent class method to ensure manual restart."""
-        super().configure_instance(create_cluster_admin, restart=False)
-        self.container.restart(MYSQLD_SERVICE)
-
     def escalate_user_privileges(self, username: str, hostname: str = "%") -> None:
         """Escalates the provided user's privileges.
 

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -34,7 +34,7 @@ from tenacity.wait import wait_fixed
 from typing_extensions import override
 
 import k8s_helpers
-from constants import CONTAINER_NAME, MYSQLD_SAFE_SERVICE
+from constants import CONTAINER_NAME, MYSQLD_SERVICE
 
 if TYPE_CHECKING:
     from charm import MySQLOperatorCharm
@@ -346,7 +346,7 @@ class MySQLK8sUpgrade(DataUpgrade):
 
     def _reset_on_unsupported_downgrade(self, container: Container) -> None:
         """Reset the cluster on unsupported downgrade."""
-        container.stop(MYSQLD_SAFE_SERVICE)
+        container.stop(MYSQLD_SERVICE)
         self.charm._mysql.reset_data_dir()
         self.charm._write_mysqld_configuration()
         self.charm._configure_instance(container)

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -40,9 +40,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-RECOVER_ATTEMPTS = 10
-
-
 class MySQLK8sDependenciesModel(BaseModel):
     """MySQL dependencies model."""
 

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -28,9 +28,7 @@ from ops import Container, JujuVersion
 from ops.model import BlockedStatus, MaintenanceStatus, RelationDataContent
 from ops.pebble import ChangeError
 from pydantic import BaseModel
-from tenacity import RetryError, Retrying
-from tenacity.stop import stop_after_attempt
-from tenacity.wait import wait_fixed
+from tenacity import RetryError
 from typing_extensions import override
 
 import k8s_helpers
@@ -231,10 +229,7 @@ class MySQLK8sUpgrade(DataUpgrade):
             self.charm._reconcile_pebble_layer(container)
             self._check_server_upgradeability()
             self.charm.unit.status = MaintenanceStatus("recovering unit after upgrade")
-            if self.charm.app.planned_units() > 1:
-                self._recover_multi_unit_cluster()
-            else:
-                self._recover_single_unit_cluster()
+            self.charm.recover_unit_after_restart()
             if self.charm.config.plugin_audit_enabled:
                 self.charm._mysql.install_plugins(["audit_log", "audit_log_filter"])
             self._complete_upgrade()
@@ -268,28 +263,6 @@ class MySQLK8sUpgrade(DataUpgrade):
             logger.warning("Downgrade is incompatible. Resetting workload")
             self._reset_on_unsupported_downgrade(container)
             self._complete_upgrade()
-
-    def _recover_multi_unit_cluster(self) -> None:
-        logger.info("Recovering unit")
-        try:
-            for attempt in Retrying(
-                stop=stop_after_attempt(RECOVER_ATTEMPTS), wait=wait_fixed(10)
-            ):
-                with attempt:
-                    self.charm._mysql.hold_if_recovering()
-                    if not self.charm._mysql.is_instance_in_cluster(self.charm.unit_label):
-                        logger.debug(
-                            "Instance not yet back in the cluster."
-                            f" Retry {attempt.retry_state.attempt_number}/{RECOVER_ATTEMPTS}"
-                        )
-                        raise Exception
-        except RetryError:
-            raise
-
-    def _recover_single_unit_cluster(self) -> None:
-        """Recover single unit cluster."""
-        logger.debug("Recovering single unit cluster")
-        self.charm._mysql.reboot_from_complete_outage()
 
     def _complete_upgrade(self):
         # complete upgrade for the unit

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -24,7 +24,7 @@ from mysql.connector.errors import (
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, retry, stop_after_attempt, wait_fixed
 
-from constants import CONTAINER_NAME, MYSQLD_SAFE_SERVICE, SERVER_CONFIG_USERNAME
+from constants import CONTAINER_NAME, MYSQLD_SERVICE, SERVER_CONFIG_USERNAME
 
 from . import juju_
 from .connector import MySQLConnector
@@ -461,7 +461,7 @@ async def stop_mysqld_service(ops_test: OpsTest, unit_name: str) -> None:
         unit_name: The name of the unit
     """
     await ops_test.juju(
-        "ssh", "--container", CONTAINER_NAME, unit_name, "pebble", "stop", MYSQLD_SAFE_SERVICE
+        "ssh", "--container", CONTAINER_NAME, unit_name, "pebble", "stop", MYSQLD_SERVICE
     )
 
 
@@ -473,7 +473,7 @@ async def start_mysqld_service(ops_test: OpsTest, unit_name: str) -> None:
         unit_name: The name of the unit
     """
     await ops_test.juju(
-        "ssh", "--container", CONTAINER_NAME, unit_name, "pebble", "start", MYSQLD_SAFE_SERVICE
+        "ssh", "--container", CONTAINER_NAME, unit_name, "pebble", "start", MYSQLD_SERVICE
     )
 
 

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -207,6 +207,7 @@ async def deploy_and_scale_application(
             num_units=1,
             channel="latest/edge",
             base="ubuntu@22.04",
+            config={"sleep_interval": 300},
         )
 
         await ops_test.model.wait_for_idle(

--- a/tests/integration/high_availability/manifests/extend_pebble_restart_delay.yml
+++ b/tests/integration/high_availability/manifests/extend_pebble_restart_delay.yml
@@ -1,5 +1,5 @@
 services:
-  mysqld_safe:
+  mysqld:
     override: merge
     backoff-delay: 300s
     backoff-limit: 300s

--- a/tests/integration/high_availability/manifests/reduce_pebble_restart_delay.yml
+++ b/tests/integration/high_availability/manifests/reduce_pebble_restart_delay.yml
@@ -1,5 +1,5 @@
 services:
-  mysqld_safe:
+  mysqld:
     override: merge
     backoff-delay: 500ms
     backoff-limit: 30s

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -84,7 +84,7 @@ async def test_upgrade_to_failling(ops_test: OpsTest) -> None:
 
     sub_regex_failing_rejoin = (
         's/logger.info("Recovering unit")'
-        '/self.charm._mysql.set_instance_offline_mode(True); raise RetryError("dummy")/'
+        '/self._mysql.set_instance_offline_mode(True); raise RetryError("dummy")/'
     )
     src_patch(sub_regex=sub_regex_failing_rejoin, file_name="src/charm.py")
     new_charm = await charm_local_build(ops_test, refresh=True)

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -39,17 +39,17 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     resources = {
         "mysql-image": "ghcr.io/canonical/charmed-mysql@sha256:0f5fe7d7679b1881afde24ecfb9d14a9daade790ec787087aa5d8de1d7b00b21"
     }
-    async with ops_test.fast_forward("10s"):
-        await ops_test.model.deploy(
-            charm,
-            application_name=MYSQL_APP_NAME,
-            config=config,
-            num_units=3,
-            resources=resources,
-            trust=True,
-            base="ubuntu@22.04",
-        )
+    await ops_test.model.deploy(
+        charm,
+        application_name=MYSQL_APP_NAME,
+        config=config,
+        num_units=3,
+        resources=resources,
+        trust=True,
+        base="ubuntu@22.04",
+    )
 
+    async with ops_test.fast_forward("30s"):
         await ops_test.model.wait_for_idle(
             apps=[MYSQL_APP_NAME],
             status="active",

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -5,7 +5,6 @@ import logging
 import os
 import pathlib
 import shutil
-import subprocess
 from time import sleep
 from zipfile import ZipFile
 
@@ -79,16 +78,16 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
 @markers.amd64_only
 @pytest.mark.abort_on_fail
 async def test_upgrade_to_failling(ops_test: OpsTest) -> None:
+    assert ops_test.model
     application = ops_test.model.applications[MYSQL_APP_NAME]
-    logger.info("Build charm locally")
 
-    sub_regex_failing_rejoin = (
-        's/logger.info("Recovering unit")'
-        '/self._mysql.set_instance_offline_mode(True); raise RetryError("dummy")/'
-    )
-    src_patch(sub_regex=sub_regex_failing_rejoin, file_name="src/charm.py")
-    new_charm = await charm_local_build(ops_test, refresh=True)
-    src_patch(revert=True)
+    with InjectFailure(
+        path="src/upgrade.py",
+        original_str="self.charm.recover_unit_after_restart()",
+        replace_str="raise MySQLServiceNotRunningError",
+    ):
+        logger.info("Build charm with failure injected")
+        new_charm = await charm_local_build(ops_test, refresh=True)
 
     logger.info("Refresh the charm")
     # Current MySQL Image > 8.0.34
@@ -177,15 +176,26 @@ async def test_rollback(ops_test) -> None:
     )
 
 
-def src_patch(sub_regex: str = "", file_name: str = "", revert: bool = False) -> None:
-    """Apply a patch to the source code."""
-    if revert:
-        cmd = "git checkout src/"  # revert changes on src/ dir
-        logger.info("Reverting patch on source")
-    else:
-        cmd = f"sed -i -e '{sub_regex}' {file_name}"
-        logger.info("Applying patch to source")
-    subprocess.run([cmd], shell=True, check=True)
+class InjectFailure(object):
+    def __init__(self, path: str, original_str: str, replace_str: str):
+        self.path = path
+        self.original_str = original_str
+        self.replace_str = replace_str
+        with open(path, "r") as file:
+            self.original_content = file.read()
+
+    def __enter__(self):
+        logger.info("Injecting failure")
+        assert self.original_str in self.original_content, "replace content not found"
+        new_content = self.original_content.replace(self.original_str, self.replace_str)
+        assert self.original_str not in new_content, "original string not replaced"
+        with open(self.path, "w") as file:
+            file.write(new_content)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        logger.info("Reverting failure")
+        with open(self.path, "w") as file:
+            file.write(self.original_content)
 
 
 async def charm_local_build(ops_test: OpsTest, refresh: bool = False):

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -86,7 +86,7 @@ async def test_upgrade_to_failling(ops_test: OpsTest) -> None:
         's/logger.info("Recovering unit")'
         '/self.charm._mysql.set_instance_offline_mode(True); raise RetryError("dummy")/'
     )
-    src_patch(sub_regex=sub_regex_failing_rejoin, file_name="src/upgrade.py")
+    src_patch(sub_regex=sub_regex_failing_rejoin, file_name="src/charm.py")
     new_charm = await charm_local_build(ops_test, refresh=True)
     src_patch(revert=True)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -75,6 +75,7 @@ class TestCharm(unittest.TestCase):
                     "user": "mysql",
                     "group": "mysql",
                     "kill-delay": "24h",
+                    "environment": {"MYSQLD_PARENT_PID": 1},
                 },
                 "mysqld_exporter": {
                     "override": "replace",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,6 +15,7 @@ from constants import (
     BACKUPS_PASSWORD_KEY,
     CLUSTER_ADMIN_PASSWORD_KEY,
     MONITORING_PASSWORD_KEY,
+    MYSQLD_LOCATION,
     PASSWORD_LENGTH,
     ROOT_PASSWORD_KEY,
     SERVER_CONFIG_PASSWORD_KEY,
@@ -54,14 +55,22 @@ class TestCharm(unittest.TestCase):
         self._caplog = caplog
 
     def layer_dict(self, with_mysqld_exporter: bool = False):
+        mysqld_cmd = [
+            MYSQLD_LOCATION,
+            "--basedir=/usr",
+            "--datadir=/var/lib/mysql",
+            "--plugin-dir=/usr/lib/mysql/plugin",
+            "--log-error=/var/log/mysql/error.log",
+            f"--pid-file={self.charm.unit_label}.pid",
+        ]
         return {
             "summary": "mysqld services layer",
             "description": "pebble config layer for mysqld safe and exporter",
             "services": {
-                "mysqld_safe": {
+                "mysqld": {
                     "override": "replace",
                     "summary": "mysqld safe",
-                    "command": "mysqld_safe",
+                    "command": " ".join(mysqld_cmd),
                     "startup": "enabled",
                     "user": "mysql",
                     "group": "mysql",

--- a/tests/unit/test_mysql_k8s_helpers.py
+++ b/tests/unit/test_mysql_k8s_helpers.py
@@ -71,7 +71,7 @@ class TestMySQL(unittest.TestCase):
         self.mysql.initialise_mysqld()
 
         _container.exec.assert_called_once_with(
-            command=["mysqld", "--initialize-insecure", "-u", "mysql"],
+            command=["/usr/sbin/mysqld", "--initialize-insecure", "-u", "mysql"],
             user="mysql",
             group="mysql",
         )


### PR DESCRIPTION
## Issue

Mysqld_safe managed mysqld fails to restart when managed by pebble, due to mysqld_safe trapping SIGTERM, sent by pebble.

## Solution

- ditch mysqld_usage, manage mysqld directly
- override `configure_instance` method to control restart within charm code, as mysql does not recognize pebble as a valid service manager
- refactor restart method to ditch rolling ops event defer and reuse unit recovery method (from upgrade code)

Merge after [PR#607](https://github.com/canonical/mysql-operator/pull/607)
fix #569

