### PR TITLE
[DPE-6523] Remove AMD64-only test markers

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -365,6 +365,25 @@ def is_connection_possible(credentials: Dict, **extra_opts) -> bool:
         return False
 
 
+async def get_model_logs(ops_test: OpsTest, log_level: str, log_lines: int = 100) -> str:
+    """Return the juju logs from a specific model.
+
+    Args:
+        ops_test: The ops test object passed into every test case
+        log_level: The logging level to return messages from
+        log_lines: The maximum lines to return at once
+    """
+    _, output, _ = await ops_test.juju(
+        "debug-log",
+        f"--model={ops_test.model.info.name}",
+        f"--level={log_level}",
+        f"--lines={log_lines}",
+        "--no-tail",
+    )
+
+    return output
+
+
 async def get_process_pid(
     ops_test: OpsTest, unit_name: str, container_name: str, process: str, full_match: bool = False
 ) -> Optional[int]:

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -70,7 +70,6 @@ async def second_model(ops_test: OpsTest, first_model, request) -> Model:  # pyr
 
 @pytest.mark.group(1)
 @markers.juju3
-@markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(
     ops_test: OpsTest, first_model: Model, second_model: Model
@@ -122,7 +121,6 @@ async def test_build_and_deploy(
 
 @pytest.mark.group(1)
 @markers.juju3
-@markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_async_relate(ops_test: OpsTest, first_model: Model, second_model: Model) -> None:
     """Relate the two mysql clusters."""
@@ -160,7 +158,6 @@ async def test_async_relate(ops_test: OpsTest, first_model: Model, second_model:
 
 @pytest.mark.group(1)
 @markers.juju3
-@markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_create_replication(first_model: Model, second_model: Model) -> None:
     """Run the create replication and wait for the applications to settle."""
@@ -191,7 +188,6 @@ async def test_create_replication(first_model: Model, second_model: Model) -> No
 
 @pytest.mark.group(1)
 @markers.juju3
-@markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_deploy_router_and_app(first_model: Model) -> None:
     """Deploy the router and the test application."""
@@ -229,7 +225,6 @@ async def test_deploy_router_and_app(first_model: Model) -> None:
 
 @pytest.mark.group(1)
 @markers.juju3
-@markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_data_replication(
     first_model: Model, second_model: Model, continuous_writes
@@ -243,7 +238,6 @@ async def test_data_replication(
 
 @pytest.mark.group(1)
 @markers.juju3
-@markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_standby_promotion(
     ops_test: OpsTest, first_model: Model, second_model: Model, continuous_writes
@@ -272,7 +266,6 @@ async def test_standby_promotion(
 
 @pytest.mark.group(1)
 @markers.juju3
-@markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_failover(ops_test: OpsTest, first_model: Model, second_model: Model) -> None:
     """Test switchover on primary cluster fail."""
@@ -311,7 +304,6 @@ async def test_failover(ops_test: OpsTest, first_model: Model, second_model: Mod
 
 @pytest.mark.group(1)
 @markers.juju3
-@markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_rejoin_invalidated_cluster(
     first_model: Model, second_model: Model, continuous_writes
@@ -332,7 +324,6 @@ async def test_rejoin_invalidated_cluster(
 
 @pytest.mark.group(1)
 @markers.juju3
-@markers.amd64_only  # TODO: remove after mysql-router-k8s arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_remove_relation_and_relate(
     first_model: Model, second_model: Model, continuous_writes

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -8,7 +8,7 @@ from time import sleep
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from .. import juju_, markers
+from .. import juju_
 from ..helpers import (
     get_leader_unit,
     get_primary_unit,
@@ -31,7 +31,6 @@ TEST_APP_NAME = "test-app"
 
 
 @pytest.mark.group(1)
-@markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_deploy_stable(ops_test: OpsTest) -> None:
     """Simple test to ensure that the mysql and application charms get deployed."""
@@ -65,7 +64,6 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
-@markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
     """Test that the pre-upgrade-check action runs successfully."""
@@ -92,7 +90,6 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
-@markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_upgrade_from_stable(ops_test: OpsTest, credentials):
     """Test updating from stable channel."""

--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -14,7 +14,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 from .. import juju_, markers
-from ..helpers import get_leader_unit, get_unit_by_index
+from ..helpers import get_leader_unit, get_model_logs, get_unit_by_index
 from .high_availability_helpers import get_sts_partition
 
 logger = logging.getLogger(__name__)
@@ -151,6 +151,11 @@ async def test_rollback(ops_test) -> None:
         timeout=TIMEOUT,
         wait_period=5,
     )
+
+    logger.info("Ensure rollback has taken place")
+    message = "Downgrade is incompatible. Resetting workload"
+    warnings = await get_model_logs(ops_test, log_level="WARNING")
+    assert message in warnings
 
     logger.info("Resume upgrade")
     while get_sts_partition(ops_test, MYSQL_APP_NAME) == 2:


### PR DESCRIPTION
This PR cleans up multiple `@amd64_only` markers from the integration tests. There is an ARM64 stable release already.

### Additional notes:
- Not all `@amd64_only` markers could be removed, as there is no ARM64 MySQL snap breaking compatibility.
- Tests related to _rolling back when incompatibility_ have been improved to actually fail when they do not rollback.