### PR TITLE
fix: dpe-5164 ensure failed bootstrap cleanup

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -50,7 +50,7 @@ from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer
-from ops import EventBase, RelationBrokenEvent, RelationCreatedEvent
+from ops import EventBase, ModelError, RelationBrokenEvent, RelationCreatedEvent
 from ops.charm import RelationChangedEvent, UpdateStatusEvent
 from ops.model import (
     ActiveStatus,
@@ -60,7 +60,7 @@ from ops.model import (
     Unit,
     WaitingStatus,
 )
-from ops.pebble import Layer
+from ops.pebble import ChangeError, Layer
 from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
 from config import CharmConfig, MySQLConfig
@@ -703,6 +703,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             MySQLServiceNotRunningError,
             MySQLConfigureMySQLUsersError,
             MySQLConfigureInstanceError,
+            ChangeError,
+            TimeoutError,
+            ModelError,
         ):
             # On any error, reset the data directory so hook is retried
             # on empty data directory


### PR DESCRIPTION
## Issue

When pebble related errors happen during mysqld bootstrap, charm code skips cleanup process that ensure method is idempotent.

## Solution

Catch said errors to trigger cleanup process.

fixes #482 #535
