### PR TITLE
Avoid using incompatible juju debug-log options in test helper

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -376,7 +376,7 @@ async def get_model_logs(ops_test: OpsTest, log_level: str, log_lines: int = 100
         "debug-log",
         f"--model={ops_test.model.info.name}",
         f"--level={log_level}",
-        f"--lines={log_lines}",
+        f"--limit={log_lines}",
         "--no-tail",
     )
 


### PR DESCRIPTION
## Issue
```
$ juju debug-log --model=test-upgrade-rollback-incompat-pz5a --level=WARNING --lines=100 --no-tail
ERROR setting --no-tail and --lines not valid
```

## Solution
Avoid using `juju debug-log --lines --no-tail`. Replace `--lines` with `--limit`