### PR TITLE
fix: [DPE-6733] test for DNS availability

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -365,6 +365,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                 "get_unit_address: unit DNS domain name is not fully propagated yet, trying again"
             )
             raise RuntimeError("unit DNS domain name is not fully propagated yet")
+        if unit_dns_domain == unit_hostname:
+            logger.error("Can't get fully qualified domain name for unit. IS DNS not ready?")
+            raise RuntimeError("Can't get unit fqdn")
         return unit_dns_domain
 
     def is_unit_busy(self) -> bool:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -135,6 +135,7 @@ class TestCharm(unittest.TestCase):
                 secret_data[password].isalnum() and len(secret_data[password]) == PASSWORD_LENGTH
             )
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("mysql_k8s_helpers.MySQL.install_plugins")
     @patch("mysql_k8s_helpers.MySQL.cluster_metadata_exists", return_value=False)
     @patch("mysql_k8s_helpers.MySQL.rescan_cluster")
@@ -184,6 +185,7 @@ class TestCharm(unittest.TestCase):
         _rescan_cluster,
         _cluster_metadata_exists,
         _install_plugins,
+        _get_unit_address,
     ):
         # Check if initial plan is empty
         self.harness.set_can_connect("mysql", True)
@@ -254,8 +256,9 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.charm.unit_peer_data["member-role"], "secondary")
         self.assertEqual(self.charm.unit_peer_data["member-state"], "waiting")
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("charm.MySQLOperatorCharm._mysql", new_callable=PropertyMock)
-    def test_mysql_pebble_ready_non_leader(self, _mysql_mock):
+    def test_mysql_pebble_ready_non_leader(self, _mysql_mock, mock_get_unit_address):
         # Test pebble ready when not leader
         # Expect unit to be in waiting status
         self.harness.update_relation_data(
@@ -266,8 +269,9 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("mysql")
         self.assertTrue(isinstance(self.charm.unit.status, WaitingStatus))
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("charm.MySQLOperatorCharm._mysql")
-    def test_mysql_pebble_ready_exception(self, _mysql_mock):
+    def test_mysql_pebble_ready_exception(self, _mysql_mock, mock_get_unit_address):
         # Test exception raised in bootstrapping
         self.harness.set_leader()
         self.charm._mysql = _mysql_mock
@@ -294,8 +298,9 @@ class TestCharm(unittest.TestCase):
             self.charm.peers.data[self.charm.app]["cluster-name"], "not_valid_cluster_name"
         )
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("mysql_k8s_helpers.MySQL.is_data_dir_initialised", return_value=False)
-    def test_mysql_property(self, _):
+    def test_mysql_property(self, _, mock_get_unit_address):
         # Test mysql property instance of mysql_k8s_helpers.MySQL
         # set leader and populate peer relation data
         self.harness.set_leader()
@@ -356,6 +361,7 @@ class TestCharm(unittest.TestCase):
             == "test-password"
         )
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
     @patch("charms.mysql.v0.mysql.MySQLBase.is_cluster_replica", return_value=False)
     @patch("mysql_k8s_helpers.MySQL.remove_instance")
@@ -370,6 +376,7 @@ class TestCharm(unittest.TestCase):
         mock_remove_instance,
         mock_is_cluster_replica,
         mock_unit_initialized,
+        mock_get_unit_address,
     ):
         self.harness.update_relation_data(
             self.peer_relation_id,

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -55,6 +55,7 @@ class TestDatabase(unittest.TestCase):
     def tearDown(self) -> None:
         self.patcher.stop()
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("mysql_k8s_helpers.MySQL.cluster_metadata_exists", return_value=True)
     @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
     @patch("k8s_helpers.KubernetesHelpers.wait_service_ready")
@@ -75,6 +76,7 @@ class TestDatabase(unittest.TestCase):
         _wait_service_ready,
         _,
         _cluster_metadata_exists,
+        _get_unit_address,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -62,12 +62,18 @@ class TestUpgrade(unittest.TestCase):
         """Test the highest ordinal."""
         self.assertEqual(1, self.charm.upgrade.highest_ordinal)
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
     @patch("mysql_k8s_helpers.MySQL.rescan_cluster")
     @patch("upgrade.MySQLK8sUpgrade._pre_upgrade_prepare")
     @patch("mysql_k8s_helpers.MySQL.get_cluster_status", return_value=MOCK_STATUS_ONLINE)
     def test_pre_upgrade_check(
-        self, mock_get_cluster_status, mock_pre_upgrade_prepare, mock_rescan_cluster, _
+        self,
+        mock_get_cluster_status,
+        mock_pre_upgrade_prepare,
+        mock_rescan_cluster,
+        _,
+        mock_get_unit_address,
     ):
         """Test the pre upgrade check."""
         self.harness.set_leader(True)
@@ -128,6 +134,7 @@ class TestUpgrade(unittest.TestCase):
         ]
         mock_logging.assert_has_calls(calls)
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
     @patch("mysql_k8s_helpers.MySQL.set_dynamic_variable")
     @patch("mysql_k8s_helpers.MySQL.get_primary_label", return_value="mysql-k8s-1")
@@ -140,6 +147,7 @@ class TestUpgrade(unittest.TestCase):
         mock_get_primary_label,
         mock_set_dynamic_variable,
         _,
+        mock_get_unit_address,
     ):
         """Test the pre upgrade prepare."""
         self.harness.set_leader(True)
@@ -151,6 +159,7 @@ class TestUpgrade(unittest.TestCase):
         mock_set_rolling_update_partition.assert_called_once()
         assert mock_set_dynamic_variable.call_count == 2
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("charm.MySQLOperatorCharm.recover_unit_after_restart")
     @patch("mysql_k8s_helpers.MySQL.install_plugins")
     @patch("mysql_k8s_helpers.MySQL.cluster_metadata_exists", return_value=True)
@@ -171,6 +180,7 @@ class TestUpgrade(unittest.TestCase):
         mock_cluster_metadata_exists,
         mock_install_plugins,
         mock_recover_unit_after_restart,
+        mock_get_unit_address,
     ):
         """Test the pebble ready."""
         self.charm.on.config_changed.emit()
@@ -221,8 +231,11 @@ class TestUpgrade(unittest.TestCase):
         with self.assertRaises(KubernetesClientError):
             self.charm.upgrade._set_rolling_update_partition(partition=1)
 
+    @patch("charm.MySQLOperatorCharm.get_unit_address", return_value="mysql-k8s.somedomain")
     @patch("mysql_k8s_helpers.MySQL.verify_server_upgradable")
-    def test_check_server_upgradeability(self, mock_verify_server_upgradeable):
+    def test_check_server_upgradeability(
+        self, mock_verify_server_upgradeable, mock_get_unit_address
+    ):
         """Test the server upgradeability check."""
         self.charm.upgrade._check_server_upgradeability()
         mock_verify_server_upgradeable.assert_not_called()


### PR DESCRIPTION
## Issue

If charm pebble ready hooks run before k8s DNS is ready, the charm will configure mysql's `report_host` to `pod-name.<app-name>-endpoints`.
When the unit tries the recovery through mysqlsh api's `reboot_from_complete_outage`, shell will check the report_host against instances in the cluster metadata, which where previously
configured to the fully qualified domain name of the pod, failing the check and causing the recovery to fail.

## Solution

Solution is fail whatever hook call the method for retrieving unit address, if address is not a valid fqdn.
By erroring out, juju should retry the hook, until k8s DNS is ready.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.

Fixes #597 #436
