### PR TITLE
feature: DPE-7534 use absolute fqdn for replication and consumers

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -100,7 +100,7 @@ from relations.mysql_provider import MySQLProvider
 from relations.mysql_root import MySQLRootRelation
 from rotate_mysql_logs import RotateMySQLLogs, RotateMySQLLogsCharmEvents
 from upgrade import MySQLK8sUpgrade, get_mysql_k8s_dependencies_model
-from utils import compare_dictionaries, generate_random_password
+from utils import compare_dictionaries, dotappend, generate_random_password
 
 logger = logging.getLogger(__name__)
 
@@ -361,14 +361,15 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         # Fully propagated: mysql-k8s-0.mysql-k8s-endpoints.dev.svc.cluster.local
         # Not propagated yet: 10-1-142-191.mysql-k8s.dev.svc.cluster.local
         if unit_hostname not in unit_dns_domain:
-            logger.error(
+            logger.warning(
                 "get_unit_address: unit DNS domain name is not fully propagated yet, trying again"
             )
             raise RuntimeError("unit DNS domain name is not fully propagated yet")
         if unit_dns_domain == unit_hostname:
-            logger.error("Can't get fully qualified domain name for unit. IS DNS not ready?")
+            logger.warning("Can't get fully qualified domain name for unit. IS DNS not ready?")
             raise RuntimeError("Can't get unit fqdn")
-        return unit_dns_domain
+
+        return dotappend(unit_dns_domain)
 
     def is_unit_busy(self) -> bool:
         """Returns whether the unit is busy."""

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -22,7 +22,7 @@ from ops.model import ActiveStatus, BlockedStatus
 
 from constants import CONTAINER_NAME, CONTAINER_RESTARTS, DB_RELATION_NAME, PASSWORD_LENGTH, PEER
 from k8s_helpers import KubernetesClientError
-from utils import generate_random_password
+from utils import dotappend, generate_random_password
 
 logger = logging.getLogger(__name__)
 
@@ -125,8 +125,8 @@ class MySQLProvider(Object):
             # create k8s services for endpoints
             self.charm.k8s_helpers.create_endpoint_services(["primary", "replicas"])
 
-            primary_endpoint = socket.getfqdn(f"{self.charm.app.name}-primary")
-            replicas_endpoint = socket.getfqdn(f"{self.charm.app.name}-replicas")
+            primary_endpoint = dotappend(socket.getfqdn(f"{self.charm.app.name}-primary"))
+            replicas_endpoint = dotappend(socket.getfqdn(f"{self.charm.app.name}-replicas"))
 
             db_version = self.charm._mysql.get_mysql_version()
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -75,3 +75,10 @@ def compare_dictionaries(dict1: dict, dict2: dict) -> set:
     different_keys = different_keys | dict2.keys() ^ dict1.keys()
 
     return different_keys
+
+
+def dotappend(string: str) -> str:
+    """Append a dot to a string if it does not already end with one."""
+    if not string.endswith("."):
+        string += "."
+    return string

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -108,9 +108,9 @@ class TestDatabase(unittest.TestCase):
                 "data": '{"database": "test_db"}',
                 "password": "super_secure_password",
                 "username": username,
-                "endpoints": "mysql-k8s-primary:3306",
+                "endpoints": "mysql-k8s-primary.:3306",
                 "version": "8.0.29-0ubuntu0.20.04.3",
-                "read-only-endpoints": "mysql-k8s-replicas:3306",
+                "read-only-endpoints": "mysql-k8s-replicas.:3306",
                 "database": "test_db",
             },
         )


### PR DESCRIPTION
## Issue

Related to router issue [#444](https://github.com/canonical/mysql-router-k8s-operator/issues/444)

## Solution

Use absolute fqdn so DNS name search is skip, saving time and resources.

## Checklist

- [x] I have cleaned any remaining cloud resources from my accounts.
