### PR TITLE
misc: rollback data-workflows to v31.x

### DIFF
--- a/.github/workflows/approve_renovate_pr.yaml
+++ b/.github/workflows/approve_renovate_pr.yaml
@@ -10,6 +10,6 @@ on:
 jobs:
   approve-pr:
     name: Approve Renovate pull request
-    uses: canonical/data-platform-workflows/.github/workflows/approve_renovate_pr.yaml@v32.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/approve_renovate_pr.yaml@v31.1.1
     permissions:
       pull-requests: write  # Needed to approve PR

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -15,4 +15,4 @@ on:
 jobs:
   check-pr:
     name: Check pull request
-    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v32.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v31.1.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v32.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v31.1.1
 
   unit-test:
     name: Unit test charm
@@ -44,7 +44,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v31.1.1
 
   integration-test:
     name: Integration test charm

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   promote:
     name: Promote charm
-    uses: canonical/data-platform-workflows/.github/workflows/_promote_charm.yaml@v32.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charm.yaml@v31.1.1
     with:
       track: '8.0'
       from-risk: ${{ inputs.from-risk }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Check libs
         uses: canonical/charming-actions/check-libraries@2.6.3
         with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }} # FIXME: current token will expire in 2023-07-04
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   ci-tests:
@@ -44,9 +44,9 @@ jobs:
     needs:
       - lib-check
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v31.1.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v31.1.1
     with:
-      track: '8.0'
+      channel: '8.0/edge'
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
     needs:
       - lib-check
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v31.1.1
     with:
       track: '8.0'
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v32.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v31.1.1
     with:
       reviewers: a-velasco
     permissions:


### PR DESCRIPTION
## Issue

v32.x of data-platform-workflows [breaks compatibility](https://github.com/canonical/data-platform-workflows/pull/295#issue-3031537057) for promote action in charms not migrated to refresh-v3.

## Solution

Stay with v31.x while charm is not migrated to refresh-v3

