### PR TITLE
[MISC] Pin grafana-agent-k8s channel to `1/stable`

### DIFF
--- a/tests/integration/bundle_templates/grafana_agent_integration.j2
+++ b/tests/integration/bundle_templates/grafana_agent_integration.j2
@@ -10,7 +10,7 @@ applications:
       mysql-image: {{ mysql_image_source }}
   grafana-agent-k8s:
     charm: grafana-agent-k8s
-    channel: latest/stable
+    channel: 1/stable
     scale: 1
 relations:
   - [mysql-k8s:metrics-endpoint, grafana-agent-k8s:metrics-endpoint]


### PR DESCRIPTION
The Observability team removed the `latest/stable` track as of Friday June 20. Channels will now be prefixed by the charm major versions (i.e. `1/...`, `2/...`). See:

- June 20th: Last [CI run](https://github.com/canonical/mysql-k8s-operator/actions/runs/15769113011) where cos integration tests passed.
- June 21th: First [CI run](https://github.com/canonical/mysql-k8s-operator/actions/runs/15790585750) where cos integration tests failed.