### PR TITLE
[DPE-7648] Fix access to not populated instance label

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -133,7 +133,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 88
+LIBPATCH = 89
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -795,6 +795,11 @@ class MySQLCharmBase(CharmBase, ABC):
         rw_endpoints = set()
 
         for k, v in repl_topology.items():
+            # When a replica instance is catching up with the primary instance,
+            # the custom label assigned by the operator code has not yet been applied.
+            if v["status"] == MySQLMemberState.RECOVERING:
+                continue
+
             address = f"{self.get_unit_address(unit_labels[k], relation_name)}:3306"
 
             if v["status"] != MySQLMemberState.ONLINE:


### PR DESCRIPTION
This PR is a port of [its counterpart](https://github.com/canonical/mysql-operator/pull/650) in MySQL VM operator.

The CI runs associated to this PR are expected to be flaky on every integration test depending on `8.0/edge` until this fix gets merged, and the published version in the `8.0/edge` channel gets updated. We must retry a few times after we get lucky, and merge as is, before defaulting to more extreme measures as commenting integration tests.