### PR TITLE
[MISC] Remove legacy test helper

### DIFF
--- a/tests/integration/backups.py
+++ b/tests/integration/backups.py
@@ -10,7 +10,6 @@ from . import juju_
 from .helpers import (
     execute_queries_on_unit,
     get_primary_unit,
-    get_unit_address,
     rotate_credentials,
 )
 from .high_availability.high_availability_helpers import (
@@ -111,14 +110,14 @@ async def pitr_operations(
 ) -> None:
     first_mysql_unit = ops_test.model.units[f"{MYSQL_APPLICATION_NAME}/0"]
     assert first_mysql_unit
-    first_mysql_ip = await get_unit_address(ops_test, first_mysql_unit.name)
+    first_mysql_ip = await first_mysql_unit.get_public_address()
     primary_unit = await get_primary_unit(ops_test, first_mysql_unit, MYSQL_APPLICATION_NAME)
     non_primary_units = [
         unit
         for unit in ops_test.model.applications[MYSQL_APPLICATION_NAME].units
         if unit.name != primary_unit.name
     ]
-    primary_ip = await get_unit_address(ops_test, primary_unit.name)
+    primary_ip = await primary_unit.get_public_address()
 
     credentials = {"username": SERVER_CONFIG_USER, "password": SERVER_CONFIG_PASSWORD}
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -472,13 +472,10 @@ async def start_mysqld_service(ops_test: OpsTest, unit_name: str) -> None:
     )
 
 
-async def retrieve_database_variable_value(
-    ops_test: OpsTest, unit: Unit, variable_name: str
-) -> str:
+async def retrieve_database_variable_value(unit: Unit, variable_name: str) -> str:
     """Retrieve a database variable value as a string.
 
     Args:
-        ops_test: The ops test framework instance
         unit: The unit to retrieve the variable
         variable_name: The name of the variable to retrieve
     Returns:

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -20,7 +20,6 @@ from ..helpers import (
     execute_queries_on_unit,
     get_cluster_status,
     get_leader_unit,
-    get_unit_address,
 )
 from .high_availability_helpers import (
     DATABASE_NAME,
@@ -404,9 +403,12 @@ async def get_max_written_value(first_model: Model, second_model: Model) -> list
 
     logger.info("Querying max value on all units")
     for unit in first_model_units + second_model_units:
-        address = await get_unit_address(None, unit.name, unit.model)
+        address = await unit.get_public_address()
         values = execute_queries_on_unit(
-            address, credentials["username"], credentials["password"], select_max_written_value_sql
+            address,
+            credentials["username"],
+            credentials["password"],
+            select_max_written_value_sql,
         )
         results.append(values[0])
 

--- a/tests/integration/high_availability/test_replication_data_isolation.py
+++ b/tests/integration/high_availability/test_replication_data_isolation.py
@@ -9,7 +9,6 @@ from ..helpers import (
     execute_queries_on_unit,
     get_primary_unit,
     get_server_config_credentials,
-    get_unit_address,
     scale_application,
 )
 from .high_availability_helpers import (
@@ -62,7 +61,7 @@ async def test_no_replication_across_clusters(
     ]
 
     for unit in ops_test.model.applications[another_mysql_application_name].units:
-        unit_address = await get_unit_address(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         output = execute_queries_on_unit(
             unit_address,

--- a/tests/integration/high_availability/test_replication_scaling.py
+++ b/tests/integration/high_availability/test_replication_scaling.py
@@ -9,7 +9,6 @@ from tenacity import Retrying, stop_after_delay, wait_fixed
 from ..helpers import (
     execute_queries_on_unit,
     get_primary_unit,
-    get_unit_address,
     scale_application,
 )
 from .high_availability_helpers import (
@@ -62,7 +61,7 @@ async def test_scaling_without_data_loss(
     for attempt in Retrying(stop=stop_after_delay(10), wait=wait_fixed(2)):
         with attempt:
             for unit in ops_test.model.applications[mysql_application_name].units:
-                unit_address = await get_unit_address(ops_test, unit.name)
+                unit_address = await unit.get_public_address()
 
                 output = execute_queries_on_unit(
                     unit_address,
@@ -90,7 +89,7 @@ async def test_scaling_without_data_loss(
 
     # ensure data written before scale down is persisted
     for unit in ops_test.model.applications[mysql_application_name].units:
-        unit_address = await get_unit_address(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         output = execute_queries_on_unit(
             unit_address,

--- a/tests/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/tests/integration/high_availability/test_self_healing_restart_graceful.py
@@ -8,7 +8,6 @@ from pytest_operator.plugin import OpsTest
 from ..helpers import (
     execute_queries_on_unit,
     get_primary_unit,
-    get_unit_address,
     start_mysqld_service,
     stop_mysqld_service,
 )
@@ -40,7 +39,7 @@ async def test_cluster_manual_rejoin(
     mysql_units = ops_test.model.applications[mysql_app_name].units
 
     primary_unit = await get_primary_unit(ops_test, mysql_units[0], mysql_app_name)
-    primary_unit_ip = await get_unit_address(ops_test, primary_unit.name)
+    primary_address = await primary_unit.get_public_address()
 
     queries = [
         "SET PERSIST group_replication_autorejoin_tries=0",
@@ -48,7 +47,7 @@ async def test_cluster_manual_rejoin(
 
     # Disable automatic re-join procedure
     execute_queries_on_unit(
-        unit_address=primary_unit_ip,
+        unit_address=primary_address,
         username=credentials["username"],
         password=credentials["password"],
         queries=queries,

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -81,7 +81,7 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
 
     logger.info("Assert slow shutdown is enabled")
     for unit in mysql_units:
-        value = await retrieve_database_variable_value(ops_test, unit, "innodb_fast_shutdown")
+        value = await retrieve_database_variable_value(unit, "innodb_fast_shutdown")
         assert value == 0, f"innodb_fast_shutdown not 0 at {unit.name}"
 
     primary_unit = await get_primary_unit(ops_test, leader_unit, MYSQL_APP_NAME)

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -76,7 +76,7 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
 
     logger.info("Assert slow shutdown is enabled")
     for unit in mysql_units:
-        value = await retrieve_database_variable_value(ops_test, unit, "innodb_fast_shutdown")
+        value = await retrieve_database_variable_value(unit, "innodb_fast_shutdown")
         assert value == 0, f"innodb_fast_shutdown not 0 at {unit.name}"
 
     primary_unit = await get_primary_unit(ops_test, leader_unit, MYSQL_APP_NAME)

--- a/tests/integration/relations/test_mysql_root.py
+++ b/tests/integration/relations/test_mysql_root.py
@@ -15,7 +15,6 @@ from .. import markers
 from ..helpers import (
     execute_queries_on_unit,
     get_server_config_credentials,
-    get_unit_address,
     is_relation_joined,
 )
 from ..juju_ import juju_major_version
@@ -190,7 +189,7 @@ async def test_osm_pol_operations(ops_test: OpsTest) -> None:
         async for attempt in AsyncRetrying(stop=stop_after_attempt(30), wait=wait_fixed(30)):
             with attempt:
                 for unit in ops_test.model.applications[APP_NAME].units:
-                    unit_address = await get_unit_address(ops_test, unit.name)
+                    unit_address = await unit.get_public_address()
 
                     # test that the `keystone` and `pol` databases exist
                     output = execute_queries_on_unit(

--- a/tests/integration/test_backup_aws.py
+++ b/tests/integration/test_backup_aws.py
@@ -16,7 +16,6 @@ from . import juju_
 from .helpers import (
     execute_queries_on_unit,
     get_server_config_credentials,
-    get_unit_address,
     rotate_credentials,
 )
 from .high_availability.high_availability_helpers import (
@@ -192,7 +191,7 @@ async def test_restore_on_same_cluster(
 
     mysql_unit = ops_test.model.units[f"{mysql_application_name}/0"]
     assert mysql_unit
-    mysql_unit_address = await get_unit_address(ops_test, mysql_unit.name)
+    mysql_unit_address = await mysql_unit.get_public_address()
 
     # set the s3 config and credentials
     logger.info("Syncing credentials")
@@ -264,7 +263,7 @@ async def test_restore_on_same_cluster(
             timeout=TIMEOUT,
         )
 
-        unit_address = await get_unit_address(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         values = execute_queries_on_unit(
             unit_address,
@@ -309,7 +308,7 @@ async def test_restore_on_new_cluster(
 
     primary_mysql = ops_test.model.units[f"{new_mysql_application_name}/0"]
     assert primary_mysql
-    primary_unit_address = await get_unit_address(ops_test, primary_mysql.name)
+    primary_unit_address = await primary_mysql.get_public_address()
 
     await rotate_credentials(
         primary_mysql, username="clusteradmin", password=CLUSTER_ADMIN_PASSWORD
@@ -398,7 +397,7 @@ async def test_restore_on_new_cluster(
             timeout=TIMEOUT,
         )
 
-        unit_address = await get_unit_address(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         values = execute_queries_on_unit(
             unit_address,

--- a/tests/integration/test_backup_ceph.py
+++ b/tests/integration/test_backup_ceph.py
@@ -20,7 +20,6 @@ from . import juju_
 from .helpers import (
     execute_queries_on_unit,
     get_server_config_credentials,
-    get_unit_address,
     rotate_credentials,
 )
 from .high_availability.high_availability_helpers import (
@@ -248,7 +247,7 @@ async def test_restore_on_same_cluster(
 
     mysql_unit = ops_test.model.units[f"{mysql_application_name}/0"]
     assert mysql_unit
-    mysql_unit_address = await get_unit_address(ops_test, mysql_unit.name)
+    mysql_unit_address = await mysql_unit.get_public_address()
 
     # set the s3 config and credentials
     logger.info("Syncing credentials")
@@ -320,7 +319,7 @@ async def test_restore_on_same_cluster(
             timeout=TIMEOUT,
         )
 
-        unit_address = await get_unit_address(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         values = execute_queries_on_unit(
             unit_address,
@@ -365,7 +364,7 @@ async def test_restore_on_new_cluster(
 
     primary_mysql = ops_test.model.units[f"{new_mysql_application_name}/0"]
     assert primary_mysql
-    primary_unit_address = await get_unit_address(ops_test, primary_mysql.name)
+    primary_unit_address = await primary_mysql.get_public_address()
 
     await rotate_credentials(
         primary_mysql, username="clusteradmin", password=CLUSTER_ADMIN_PASSWORD
@@ -454,7 +453,7 @@ async def test_restore_on_new_cluster(
             timeout=TIMEOUT,
         )
 
-        unit_address = await get_unit_address(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         values = execute_queries_on_unit(
             unit_address,

--- a/tests/integration/test_backup_gcp.py
+++ b/tests/integration/test_backup_gcp.py
@@ -16,7 +16,6 @@ from . import juju_
 from .helpers import (
     execute_queries_on_unit,
     get_server_config_credentials,
-    get_unit_address,
     rotate_credentials,
 )
 from .high_availability.high_availability_helpers import (
@@ -192,7 +191,7 @@ async def test_restore_on_same_cluster(
 
     mysql_unit = ops_test.model.units[f"{mysql_application_name}/0"]
     assert mysql_unit
-    mysql_unit_address = await get_unit_address(ops_test, mysql_unit.name)
+    mysql_unit_address = await mysql_unit.get_public_address()
 
     # set the s3 config and credentials
     logger.info("Syncing credentials")
@@ -264,7 +263,7 @@ async def test_restore_on_same_cluster(
             timeout=TIMEOUT,
         )
 
-        unit_address = await get_unit_address(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         values = execute_queries_on_unit(
             unit_address,
@@ -309,7 +308,7 @@ async def test_restore_on_new_cluster(
 
     primary_mysql = ops_test.model.units[f"{new_mysql_application_name}/0"]
     assert primary_mysql
-    primary_unit_address = await get_unit_address(ops_test, primary_mysql.name)
+    primary_unit_address = await primary_mysql.get_public_address()
 
     await rotate_credentials(
         primary_mysql, username="clusteradmin", password=CLUSTER_ADMIN_PASSWORD
@@ -398,7 +397,7 @@ async def test_restore_on_new_cluster(
             timeout=TIMEOUT,
         )
 
-        unit_address = await get_unit_address(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         values = execute_queries_on_unit(
             unit_address,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -334,5 +334,5 @@ async def test_custom_variables(ops_test: OpsTest) -> None:
     for unit in application.units:
         for k, v in custom_vars.items():
             logger.info(f"Checking that {k} is set to {v} on {unit.name}")
-            value = await retrieve_database_variable_value(ops_test, unit, k)
+            value = await retrieve_database_variable_value(unit, k)
             assert int(value) == v, f"Variable {k} is not set to {v}"

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -16,7 +16,6 @@ from .helpers import (
     app_name,
     fetch_credentials,
     get_tls_ca,
-    get_unit_address,
     is_connection_possible,
     scale_application,
     unit_file_md5,
@@ -102,8 +101,7 @@ async def test_connection_before_tls(ops_test: OpsTest) -> None:
     # Before relating to TLS charm both encrypted and unencrypted connection should be possible
     logger.info("Asserting connections before relation")
     for unit in all_units:
-        unit_ip = await get_unit_address(ops_test, unit.name)
-        config["host"] = unit_ip
+        config["host"] = unit.get_public_address()
 
         assert is_connection_possible(
             config, **{"ssl_disabled": False}
@@ -138,8 +136,7 @@ async def test_enable_tls(ops_test: OpsTest) -> None:
     # After relating to only encrypted connection should be possible
     logger.info("Asserting connections after relation")
     for unit in all_units:
-        unit_ip = await get_unit_address(ops_test, unit.name)
-        config["host"] = unit_ip
+        config["host"] = unit.get_public_address()
         assert is_connection_possible(
             config, **{"ssl_disabled": False}
         ), f"❌ Encrypted connection not possible to unit {unit.name} with enabled TLS"
@@ -191,8 +188,7 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
     # Asserting only encrypted connection should be possible
     logger.info("Asserting connections after relation")
     for unit in all_units:
-        unit_ip = await get_unit_address(ops_test, unit.name)
-        config["host"] = unit_ip
+        config["host"] = unit.get_public_address()
         assert is_connection_possible(
             config, **{"ssl_disabled": False}
         ), f"❌ Encrypted connection not possible to unit {unit.name} with enabled TLS"
@@ -218,8 +214,7 @@ async def test_disable_tls(ops_test: OpsTest) -> None:
 
     # After relation removal both encrypted and unencrypted connection should be possible
     for unit in all_units:
-        unit_ip = await get_unit_address(ops_test, unit.name)
-        config["host"] = unit_ip
+        config["host"] = unit.get_public_address()
         assert is_connection_possible(
             config, **{"ssl_disabled": False}
         ), f"❌ Encrypted connection not possible to unit {unit.name} after relation removal"


### PR DESCRIPTION
This PR removes the legacy `get_unit_address` test helper, in order to rely on Juju's `get_public_address` method ([source](https://github.com/juju/python-libjuju/blob/d61ea7dde28f41766a917fd818816d53aa73e8c2/juju/unit.py#L118-L131)).

Judging by GIT blame, the `get_unit_address` helper was defined a long time ago, in 2022, probably in a time where the Juju lib did not have a method to get the public address of a unit object. We should use the mechanisms that Juju natively provides in order to avoid doing something unexpected.
