### PR TITLE
[DPE-7322] Support predefined roles

### DIFF
--- a/docs/reference/software-testing.md
+++ b/docs/reference/software-testing.md
@@ -41,13 +41,13 @@ juju run mysql-test-app/leader get-inserted-data
 # Start "continuous write" test:
 juju run mysql-test-app/leader start-continuous-writes
 export password=$(juju run mysql-k8s/leader get-password username=root | yq '.. | select(. | has("password")).password')
-watch -n1 -x juju ssh --container mysql mysql-k8s/leader "mysql -h 127.0.0.1 -uroot -p${password} -e \"select count(*) from continuous_writes_database.data\""
+watch -n1 -x juju ssh --container mysql mysql-k8s/leader "mysql -h 127.0.0.1 -uroot -p${password} -e \"select count(*) from continuous_writes.data\""
 
 # Watch the counter is growing!
 ```
 Expected results:
 
-* mysql-test-app continuously inserts records in database `continuous_writes_database` table `data`.
+* mysql-test-app continuously inserts records in database `continuous_writes` table `data`.
 * the counters (amount of records in table) are growing on all cluster members
 
 Hints:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1510,12 +1510,9 @@ class MySQLBase(ABC):
         """Create an application database."""
         role_name = f"charmed_dba_{database}"
 
-        if len(database) >= ROLE_MAX_LENGTH:
-            logger.error(f"Failed to create application database {database}")
-            raise MySQLCreateApplicationDatabaseError("Name longer than 32 characters")
         if len(role_name) >= ROLE_MAX_LENGTH:
-            logger.warning(f"Pruning application database role name {role_name}")
-            role_name = role_name[:ROLE_MAX_LENGTH]
+            logger.error(f"Failed to create application database {database}")
+            raise MySQLCreateApplicationDatabaseError("Role name longer than 32 characters")
 
         create_database_commands = (
             "shell.connect_to_primary()",

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -146,6 +146,24 @@ ADMIN_PORT = 33062
 SECRET_INTERNAL_LABEL = "secret-id"  # noqa: S105
 SECRET_DELETED_LABEL = "None"  # noqa: S105
 
+ROLE_DBA = "charmed_dba"
+ROLE_DDL = "charmed_ddl"
+ROLE_DML = "charmed_dml"
+ROLE_READ = "charmed_read"
+ROLE_STATS = "charmed_stats"
+ROLE_BACKUP = "charmed_backup"
+ROLE_MAX_LENGTH = 32
+
+# TODO:
+#   Remove legacy role when migrating to MySQL 8.4
+#   (when breaking changes are allowed)
+LEGACY_ROLE_ROUTER = "mysqlrouter"
+MODERN_ROLE_ROUTER = "charmed_router"
+
+FORBIDDEN_EXTRA_ROLES = {
+    ROLE_BACKUP,
+}
+
 APP_SCOPE = "app"
 UNIT_SCOPE = "unit"
 Scopes = Literal["app", "unit"]
@@ -173,8 +191,16 @@ class Error(Exception):
         return f"<{type(self).__module__}.{type(self).__name__}>"
 
 
+class MySQLConfigureMySQLRolesError(Error):
+    """Exception raised when creating a role fails."""
+
+
 class MySQLConfigureMySQLUsersError(Error):
     """Exception raised when creating a user fails."""
+
+
+class MySQLListMySQLRolesError(Error):
+    """Exception raised when there is an issue listing database roles."""
 
 
 class MySQLCheckUserExistenceError(Error):
@@ -185,8 +211,12 @@ class MySQLConfigureRouterUserError(Error):
     """Exception raised when configuring the MySQLRouter user."""
 
 
-class MySQLCreateApplicationDatabaseAndScopedUserError(Error):
-    """Exception raised when creating application database and scoped user."""
+class MySQLCreateApplicationDatabaseError(Error):
+    """Exception raised when creating application database."""
+
+
+class MySQLCreateApplicationScopedUserError(Error):
+    """Exception raised when creating application scoped user."""
 
 
 class MySQLGetRouterUsersError(Error):
@@ -268,10 +298,6 @@ class MySQLGetClusterPrimaryAddressError(Error):
 
 class MySQLSetClusterPrimaryError(Error):
     """Exception raised when there is an issue setting the primary instance."""
-
-
-class MySQLGrantPrivilegesToUserError(Error):
-    """Exception raised when there is an issue granting privileges to user."""
 
 
 class MySQLNoMemberStateError(Error):
@@ -874,11 +900,7 @@ class MySQLCharmBase(CharmBase, ABC):
             if v["status"] == MySQLMemberState.RECOVERING:
                 continue
 
-            # skip if unit not available in unit_labels
-            if unit_label := unit_labels.get(k):
-                address = f"{self.get_unit_address(unit_label, relation_name)}:3306"
-            else:
-                continue
+            address = f"{self.get_unit_address(unit_labels[k], relation_name)}:3306"
 
             if v["status"] != MySQLMemberState.ONLINE:
                 no_endpoints.add(address)
@@ -1036,6 +1058,7 @@ class MySQLBase(ABC):
         self.socket_uri = f"({socket_path})"
         self.cluster_name = cluster_name
         self.cluster_set_name = cluster_set_name
+        self.root_user = ROOT_USERNAME
         self.root_password = root_password
         self.server_config_user = server_config_user
         self.server_config_password = server_config_password
@@ -1137,8 +1160,8 @@ class MySQLBase(ABC):
         # the admin enables them manually
         config["mysqld"] = {
             # All interfaces bind expected
-            "bind-address": "0.0.0.0",  # noqa: S104
-            "mysqlx-bind-address": "0.0.0.0",  # noqa: S104
+            "bind_address": "0.0.0.0",  # noqa: S104
+            "mysqlx_bind_address": "0.0.0.0",  # noqa: S104
             "admin_address": self.instance_address,
             "report_host": self.instance_address,
             "max_connections": str(max_connections),
@@ -1154,6 +1177,7 @@ class MySQLBase(ABC):
             "loose-audit_log_file": f"{snap_common}/var/log/mysql/audit.log",
             "gtid_mode": "ON",
             "enforce_gtid_consistency": "ON",
+            "activate_all_roles_on_login": "ON",
         }
 
         if audit_log_enabled:
@@ -1178,51 +1202,138 @@ class MySQLBase(ABC):
             config.write(string_io)
             return string_io.getvalue(), dict(config["mysqld"])
 
-    def configure_mysql_users(self) -> None:
-        """Configure the MySQL users for the instance."""
+    def configure_mysql_router_roles(self) -> None:
+        """Configure the MySQL Router roles for the instance."""
+        for role in (LEGACY_ROLE_ROUTER, MODERN_ROLE_ROUTER):
+            existing_roles = self.list_mysql_roles(role)
+            if role in existing_roles:
+                continue
+
+            logger.debug(f"Missing MySQL role {role}")
+            configure_role_commands = [
+                f"CREATE ROLE {role}",
+                f"GRANT CREATE ON *.* TO {role}",
+                f"GRANT CREATE USER ON *.* TO {role}",
+                # The granting of all privileges to the MySQL Router role
+                # can only be restricted when the privileges to the users
+                # created by such role are restricted as well
+                # https://github.com/canonical/mysql-router-operator/blob/main/src/mysql_shell/__init__.py#L134-L136
+                f"GRANT ALL ON *.* TO {role} WITH GRANT OPTION",
+            ]
+
+            try:
+                logger.debug(f"Configuring Router role for {self.instance_address}")
+                self._run_mysqlcli_script(
+                    configure_role_commands,
+                    user=self.root_user,
+                    password=self.root_password,
+                )
+            except MySQLClientError as e:
+                logger.error(f"Failed to configure Router role for {self.instance_address}")
+                raise MySQLConfigureMySQLRolesError from e
+
+    def configure_mysql_system_roles(self) -> None:
+        """Configure the MySQL system roles for the instance."""
+        role_to_queries = {
+            ROLE_READ: [
+                f"CREATE ROLE {ROLE_READ}",
+            ],
+            ROLE_DML: [
+                f"CREATE ROLE {ROLE_DML}",
+            ],
+            ROLE_STATS: [
+                f"CREATE ROLE {ROLE_STATS}",
+                f"GRANT SELECT ON performance_schema.* TO {ROLE_STATS}",
+                f"GRANT PROCESS, RELOAD, REPLICATION CLIENT ON *.* TO {ROLE_STATS}",
+            ],
+            ROLE_BACKUP: [
+                f"CREATE ROLE {ROLE_BACKUP}",
+                f"GRANT charmed_stats TO {ROLE_BACKUP}",
+                f"GRANT EXECUTE, LOCK TABLES, PROCESS, RELOAD ON *.* TO {ROLE_BACKUP}",
+                f"GRANT BACKUP_ADMIN, CONNECTION_ADMIN ON *.* TO {ROLE_BACKUP}",
+            ],
+            ROLE_DDL: [
+                f"CREATE ROLE {ROLE_DDL}",
+                f"GRANT charmed_dml TO {ROLE_DDL}",
+                f"GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TABLESPACE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, SHOW_ROUTINE, SHOW VIEW, TRIGGER ON *.* TO {ROLE_DDL}",
+            ],
+            ROLE_DBA: [
+                f"CREATE ROLE {ROLE_DBA}",
+                f"GRANT charmed_dml TO {ROLE_DBA}",
+                f"GRANT charmed_stats TO {ROLE_DBA}",
+                f"GRANT charmed_backup TO {ROLE_DBA}",
+                f"GRANT charmed_ddl TO {ROLE_DBA}",
+                f"GRANT EVENT, SHOW DATABASES, SHUTDOWN ON *.* TO {ROLE_DBA}",
+                f"GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON *.* TO {ROLE_DBA}",
+                f"GRANT AUDIT_ADMIN, CONNECTION_ADMIN, SYSTEM_VARIABLES_ADMIN ON *.* TO {ROLE_DBA}",
+            ],
+        }
+
+        configure_roles_commands = []
+        existing_roles = self.list_mysql_roles("charmed_%")
+
+        for role, queries in role_to_queries.items():
+            if role not in existing_roles:
+                logger.debug(f"Missing MySQL role {role}")
+                configure_roles_commands.extend(queries)
+
+        try:
+            logger.debug(f"Configuring MySQL roles for {self.instance_address}")
+            self._run_mysqlcli_script(
+                configure_roles_commands,
+                user=self.root_user,
+                password=self.root_password,
+            )
+        except MySQLClientError as e:
+            logger.error(f"Failed to configure roles for {self.instance_address}")
+            raise MySQLConfigureMySQLRolesError from e
+
+    def configure_mysql_system_users(self) -> None:
+        """Configure the MySQL system users for the instance."""
+        configure_users_commands = [
+            f"UPDATE mysql.user SET authentication_string=null WHERE User='{self.root_user}' and Host='localhost'",  # noqa: S608
+            f"ALTER USER '{self.root_user}'@'localhost' IDENTIFIED BY '{self.root_password}'",
+            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}'",
+            f"CREATE USER '{self.monitoring_user}'@'%' IDENTIFIED BY '{self.monitoring_password}' WITH MAX_USER_CONNECTIONS 3",
+            f"CREATE USER '{self.backups_user}'@'%' IDENTIFIED BY '{self.backups_password}'",
+        ]
+
         # SYSTEM_USER and SUPER privileges to revoke from the root users
         # Reference: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_super
-        privileges_to_revoke = (
-            "SYSTEM_USER",
-            "SYSTEM_VARIABLES_ADMIN",
-            "SUPER",
-            "REPLICATION_SLAVE_ADMIN",
-            "GROUP_REPLICATION_ADMIN",
-            "BINLOG_ADMIN",
-            "SET_USER_ID",
-            "ENCRYPTION_KEY_ADMIN",
-            "VERSION_TOKEN_ADMIN",
-            "CONNECTION_ADMIN",
-        )
-
-        # privileges for the backups user:
-        #   https://docs.percona.com/percona-xtrabackup/8.0/using_xtrabackup/privileges.html#permissions-and-privileges-needed
-        # CONNECTION_ADMIN added to provide it privileges to connect to offline_mode node
-        configure_users_commands = (
-            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}'",
+        configure_users_commands.extend([
             f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION",
-            f"CREATE USER '{self.monitoring_user}'@'%' IDENTIFIED BY '{self.monitoring_password}' WITH MAX_USER_CONNECTIONS 3",
-            f"GRANT SYSTEM_USER, SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD ON *.* TO '{self.monitoring_user}'@'%'",
-            f"CREATE USER '{self.backups_user}'@'%' IDENTIFIED BY '{self.backups_password}'",
-            f"GRANT CONNECTION_ADMIN, BACKUP_ADMIN, PROCESS, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO '{self.backups_user}'@'%'",
-            f"GRANT SELECT ON performance_schema.log_status TO '{self.backups_user}'@'%'",
-            f"GRANT SELECT ON performance_schema.keyring_component_status TO '{self.backups_user}'@'%'",
-            f"GRANT SELECT ON performance_schema.replication_group_members TO '{self.backups_user}'@'%'",
-            "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost'",
-            f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{self.root_password}'",
-            f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM 'root'@'localhost'",
+            f"GRANT charmed_stats TO '{self.monitoring_user}'@'%'",
+            f"GRANT charmed_backup TO '{self.backups_user}'@'%'",
+            f"REVOKE BINLOG_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, REPLICATION_SLAVE_ADMIN, SET_USER_ID, SUPER, SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, VERSION_TOKEN_ADMIN ON *.* FROM '{self.root_user}'@'localhost'",
             "FLUSH PRIVILEGES",
-        )
+        ])
 
         try:
             logger.debug(f"Configuring MySQL users for {self.instance_address}")
             self._run_mysqlcli_script(
                 configure_users_commands,
+                user=self.root_user,
                 password=self.root_password,
             )
         except MySQLClientError as e:
             logger.error(f"Failed to configure users for: {self.instance_address}")
             raise MySQLConfigureMySQLUsersError from e
+
+    def list_mysql_roles(self, name_pattern: str) -> set[str]:
+        """Returns a set with the MySQL roles."""
+        try:
+            query_commands = (
+                f"SELECT User FROM mysql.user WHERE User LIKE '{name_pattern}'",  # noqa: S608
+            )
+            output = self._run_mysqlcli_script(
+                query_commands,
+                user=self.root_user,
+                password=self.root_password,
+            )
+            return {row[0] for row in output}
+        except MySQLClientError as e:
+            logger.error("Failed to list roles")
+            raise MySQLListMySQLRolesError from e
 
     def _plugin_file_exists(self, plugin_file_name: str) -> bool:
         """Check if the plugin file exists.
@@ -1324,6 +1435,7 @@ class MySQLBase(ABC):
         try:
             output = self._run_mysqlcli_script(
                 ("select name from mysql.plugin",),
+                user=self.root_user,
                 password=self.root_password,
             )
             return {
@@ -1394,51 +1506,89 @@ class MySQLBase(ABC):
             logger.error(f"Failed to configure mysqlrouter {username=}")
             raise MySQLConfigureRouterUserError from e
 
-    def create_application_database_and_scoped_user(
-        self,
-        database_name: str,
-        username: str,
-        password: str,
-        hostname: str,
-        *,
-        unit_name: str | None = None,
-        create_database: bool = True,
-    ) -> None:
-        """Create an application database and a user scoped to the created database."""
-        attributes = {}
-        if unit_name is not None:
-            attributes["unit_name"] = unit_name
+    def create_database(self, database: str) -> None:
+        """Create an application database."""
+        role_name = f"charmed_dba_{database}"
+
+        if len(database) >= ROLE_MAX_LENGTH:
+            logger.error(f"Failed to create application database {database}")
+            raise MySQLCreateApplicationDatabaseError("Name longer than 32 characters")
+        if len(role_name) >= ROLE_MAX_LENGTH:
+            logger.warning(f"Pruning application database role name {role_name}")
+            role_name = role_name[:ROLE_MAX_LENGTH]
+
+        create_database_commands = (
+            "shell.connect_to_primary()",
+            f'session.run_sql("CREATE DATABASE IF NOT EXISTS `{database}`;")',
+            f'session.run_sql("GRANT SELECT ON `{database}`.* TO {ROLE_READ};")',
+            f'session.run_sql("GRANT SELECT, INSERT, DELETE, UPDATE ON `{database}`.* TO {ROLE_DML};")',
+        )
+        create_dba_role_commands = (
+            f'session.run_sql("CREATE ROLE IF NOT EXISTS `{role_name}`;")',
+            f'session.run_sql("GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE ON `{database}`.* TO {role_name};")',
+            f'session.run_sql("GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `{database}`.* TO {role_name};")',
+        )
+
         try:
-            # Using server_config_user as we are sure it has create database grants
-            connect_command = ("shell.connect_to_primary()",)
-            create_database_commands = (
-                f'session.run_sql("CREATE DATABASE IF NOT EXISTS `{database_name}`;")',
-            )
-
-            escaped_user_attributes = json.dumps(attributes).replace('"', r"\"")
-            # Using server_config_user as we are sure it has create user grants
-            create_scoped_user_commands = (
-                f"session.run_sql(\"CREATE USER `{username}`@`{hostname}` IDENTIFIED BY '{password}' ATTRIBUTE '{escaped_user_attributes}';\")",
-                f'session.run_sql("GRANT USAGE ON *.* TO `{username}`@`{hostname}`;")',
-                f'session.run_sql("GRANT ALL PRIVILEGES ON `{database_name}`.* TO `{username}`@`{hostname}`;")',
-            )
-
-            if create_database:
-                commands = connect_command + create_database_commands + create_scoped_user_commands
-            else:
-                commands = connect_command + create_scoped_user_commands
-
             self._run_mysqlsh_script(
-                "\n".join(commands),
+                "\n".join(create_database_commands + create_dba_role_commands),
                 user=self.server_config_user,
                 password=self.server_config_password,
                 host=self.instance_def(self.server_config_user),
             )
         except MySQLClientError as e:
-            logger.error(
-                f"Failed to create application database {database_name} and scoped user {username}@{hostname}"
+            logger.error(f"Failed to create application database {database}")
+            raise MySQLCreateApplicationDatabaseError(e.message) from e
+
+    def create_scoped_user(
+        self,
+        database: str,
+        username: str,
+        password: str,
+        hostname: str,
+        *,
+        unit_name: str | None = None,
+        extra_roles: list[str] | None = None,
+    ) -> None:
+        """Create an application user scoped to the created database."""
+        if extra_roles is not None and set(extra_roles) & FORBIDDEN_EXTRA_ROLES:
+            logger.error(f"Invalid extra user roles: {extra_roles}")
+            raise MySQLCreateApplicationScopedUserError("invalid role(s) for extra user roles")
+
+        attributes = {}
+        if unit_name is not None:
+            attributes = {"unit_name": unit_name}
+        if extra_roles is not None:
+            extra_roles = ", ".join(extra_roles)
+
+        create_scoped_user_attributes = json.dumps(attributes).replace('"', r"\"")
+        create_scoped_user_commands = (
+            "shell.connect_to_primary()",
+            f"session.run_sql(\"CREATE USER `{username}`@`{hostname}` IDENTIFIED BY '{password}' ATTRIBUTE '{create_scoped_user_attributes}';\")",
+        )
+
+        if extra_roles:
+            grant_scoped_user_commands = (
+                f'session.run_sql("GRANT {extra_roles} TO `{username}`@`{hostname}`;")',
             )
-            raise MySQLCreateApplicationDatabaseAndScopedUserError(e.message) from e
+        else:
+            # Legacy behaviour when no explicit roles were assigned to users
+            # (before system roles were introduced).
+            grant_scoped_user_commands = (
+                f'session.run_sql("GRANT USAGE ON *.* TO `{username}`@`{hostname}`;")',
+                f'session.run_sql("GRANT ALL PRIVILEGES ON `{database}`.* TO `{username}`@`{hostname}`;")',
+            )
+
+        try:
+            self._run_mysqlsh_script(
+                "\n".join(create_scoped_user_commands + grant_scoped_user_commands),
+                user=self.server_config_user,
+                password=self.server_config_password,
+                host=self.instance_def(self.server_config_user),
+            )
+        except MySQLClientError as e:
+            logger.error(f"Failed to create application scoped user {username}@{hostname}")
+            raise MySQLCreateApplicationScopedUserError(e.message) from e
 
     @staticmethod
     def _get_statements_to_delete_users_with_attribute(
@@ -1870,7 +2020,7 @@ class MySQLBase(ABC):
         try:
             output = self._run_mysqlcli_script(
                 (get_clusters_query,),
-                user=ROOT_USERNAME,
+                user=self.root_user,
                 password=self.root_password,
                 timeout=60,
                 exception_as_warning=True,
@@ -2747,29 +2897,6 @@ class MySQLBase(ABC):
             return None
 
         return matches.group(1)
-
-    def grant_privileges_to_user(
-        self, username, hostname, privileges, with_grant_option=False
-    ) -> None:
-        """Grants specified privileges to the provided database user."""
-        grant_privileges_commands = (
-            "shell.connect_to_primary()",
-            (
-                f"session.run_sql(\"GRANT {', '.join(privileges)} ON *.* TO '{username}'@'{hostname}'"
-                f'{" WITH GRANT OPTION" if with_grant_option else ""}")'
-            ),
-        )
-
-        try:
-            self._run_mysqlsh_script(
-                "\n".join(grant_privileges_commands),
-                user=self.server_config_user,
-                password=self.server_config_password,
-                host=self.instance_def(self.server_config_user),
-            )
-        except MySQLClientError as e:
-            logger.warning(f"Failed to grant privileges to user {username}@{hostname}")
-            raise MySQLGrantPrivilegesToUserError(e.message) from e
 
     def update_user_password(self, username: str, new_password: str, host: str = "%") -> None:
         """Updates user password in MySQL database."""
@@ -3765,7 +3892,7 @@ class MySQLBase(ABC):
     def _run_mysqlcli_script(
         self,
         script: tuple[Any, ...] | list[Any],
-        user: str = "root",
+        user: str = ROOT_USERNAME,
         password: str | None = None,
         timeout: int | None = None,
         exception_as_warning: bool = False,

--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -449,7 +449,7 @@ class MySQL(MySQLBase):
         if unit_address in members_in_cluster:
             raise MySQLWaitUntilUnitRemovedFromClusterError("Remove member still in cluster")
 
-    def create_database(self, database_name: str) -> None:
+    def create_database_legacy(self, database_name: str) -> None:
         """Creates a database.
 
         Args:
@@ -474,7 +474,9 @@ class MySQL(MySQLBase):
             logger.exception(f"Failed to create database {database_name}", exc_info=e)
             raise MySQLCreateDatabaseError(e.message) from None
 
-    def create_user(self, username: str, password: str, label: str, hostname: str = "%") -> None:
+    def create_user_legacy(
+        self, username: str, password: str, label: str, hostname: str = "%"
+    ) -> None:
         """Creates a new user.
 
         Args:

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -9,7 +9,8 @@ import typing
 
 from charms.mysql.v0.mysql import (
     MySQLCheckUserExistenceError,
-    MySQLCreateApplicationDatabaseAndScopedUserError,
+    MySQLCreateApplicationDatabaseError,
+    MySQLCreateApplicationScopedUserError,
     MySQLDeleteUsersForUnitError,
 )
 from ops.charm import RelationBrokenEvent, RelationChangedEvent, RelationCreatedEvent
@@ -246,14 +247,18 @@ class MySQLRelation(Object):
 
         try:
             logger.info("Creating application database and scoped user")
-            self.charm._mysql.create_application_database_and_scoped_user(
+            self.charm._mysql.create_database(database)
+            self.charm._mysql.create_scoped_user(
                 database,
                 username,
                 password,
                 "%",
                 unit_name="mysql-legacy-relation",
             )
-        except MySQLCreateApplicationDatabaseAndScopedUserError:
+        except (
+            MySQLCreateApplicationDatabaseError,
+            MySQLCreateApplicationScopedUserError,
+        ):
             self.charm.unit.status = BlockedStatus(
                 "Failed to create application database and scoped user"
             )

--- a/src/relations/mysql_root.py
+++ b/src/relations/mysql_root.py
@@ -203,12 +203,13 @@ class MySQLRootRelation(Object):
             root_password = self.charm.get_secret("app", ROOT_PASSWORD_KEY)
             if not root_password:
                 raise MySQLCreateUserError("MySQL root password not found in peer secrets")
-            self.charm._mysql.create_database(database)
-            self.charm._mysql.create_user(username, password, "mysql-root-legacy-relation")
+
+            self.charm._mysql.create_database_legacy(database)
+            self.charm._mysql.create_user_legacy(username, password, "mysql-root-legacy-relation")
             if not self.charm._mysql.does_mysql_user_exist("root", "%"):
                 # create `root@%` user if it doesn't exist
                 # this is needed for the `mysql-root` interface to work
-                self.charm._mysql.create_user(
+                self.charm._mysql.create_user_legacy(
                     "root",
                     root_password,
                     "mysql-root-legacy-relation",

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -32,7 +32,7 @@ from ..helpers import (
 )
 
 # Copied these values from high_availability.application_charm.src.charm
-DATABASE_NAME = "continuous_writes_database"
+DATABASE_NAME = "continuous_writes"
 TABLE_NAME = "data"
 
 CLUSTER_NAME = "test_cluster"

--- a/tests/integration/relations/test_mysql_root.py
+++ b/tests/integration/relations/test_mysql_root.py
@@ -29,7 +29,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm):
     config = {
         "profile": "testing",
         "mysql-root-interface-user": "test-user",
-        "mysql-root-interface-database": "continuous_writes_database",
+        "mysql-root-interface-database": "continuous_writes",
     }
     resources = {
         "mysql-image": DB_METADATA["resources"]["mysql-image"]["upstream-source"],

--- a/tests/integration/roles/__init__.py
+++ b/tests/integration/roles/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/integration/roles/test_database_dba_role.py
+++ b/tests/integration/roles/test_database_dba_role.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from mysql.connector.errors import ProgrammingError
+from pytest_operator.plugin import OpsTest
+
+from .. import juju_
+from ..helpers import (
+    execute_queries_on_unit,
+    get_primary_unit,
+    get_unit_address,
+)
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+DATABASE_APP_NAME = METADATA["name"]
+INTEGRATOR_APP_NAME = "data-integrator"
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
+    """Simple test to ensure that the mysql and data-integrator charms get deployed."""
+    resources = {"mysql-image": METADATA["resources"]["mysql-image"]["upstream-source"]}
+
+    async with ops_test.fast_forward("10s"):
+        await asyncio.gather(
+            ops_test.model.deploy(
+                charm,
+                application_name=DATABASE_APP_NAME,
+                num_units=3,
+                resources=resources,
+                base="ubuntu@22.04",
+                config={"profile": "testing"},
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                application_name=f"{INTEGRATOR_APP_NAME}1",
+                base="ubuntu@24.04",
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                application_name=f"{INTEGRATOR_APP_NAME}2",
+                base="ubuntu@24.04",
+            ),
+        )
+
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME],
+        status="active",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"],
+        status="blocked",
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_charmed_dba_role(ops_test: OpsTest):
+    """Test the database-level DBA role."""
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
+        "database-name": "preserved",
+        "extra-user-roles": "",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].set_config({
+        "database-name": "throwaway",
+        "extra-user-roles": "charmed_dba_preserved",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    mysql_unit = ops_test.model.applications[DATABASE_APP_NAME].units[0]
+    primary_unit = await get_primary_unit(ops_test, mysql_unit, DATABASE_APP_NAME)
+    primary_unit_address = await get_unit_address(ops_test, primary_unit.name)
+
+    data_integrator_2_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].units[0]
+    results = await juju_.run_action(data_integrator_2_unit, "get-credentials")
+
+    logger.info("Checking that the database-level DBA role cannot create new databases")
+    with pytest.raises(ProgrammingError):
+        execute_queries_on_unit(
+            primary_unit_address,
+            results["mysql"]["username"],
+            results["mysql"]["password"],
+            ["CREATE DATABASE IF NOT EXISTS test"],
+            commit=True,
+        )
+
+    logger.info("Checking that the database-level DBA role can see all databases")
+    execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        ["SHOW DATABASES"],
+        commit=True,
+    )
+
+    logger.info("Checking that the database-level DBA role can create a new table")
+    execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "CREATE TABLE preserved.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+        ],
+        commit=True,
+    )
+
+    logger.info("Checking that the database-level DBA role can write into an existing table")
+    execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "INSERT INTO preserved.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+        ],
+        commit=True,
+    )
+
+    logger.info("Checking that the database-level DBA role can read from an existing table")
+    rows = execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "SELECT `data` FROM preserved.test_table",
+        ],
+        commit=True,
+    )
+    assert sorted(rows) == sorted([
+        "test_data_1",
+        "test_data_2",
+    ]), "Unexpected data in preserved with charmed_dba_preserved role"

--- a/tests/integration/roles/test_instance_dba_role.py
+++ b/tests/integration/roles/test_instance_dba_role.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+from .. import juju_
+from ..helpers import (
+    execute_queries_on_unit,
+    get_primary_unit,
+    get_server_config_credentials,
+    get_unit_address,
+)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+DATABASE_APP_NAME = METADATA["name"]
+INTEGRATOR_APP_NAME = "data-integrator"
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
+    """Simple test to ensure that the mysql and data-integrator charms get deployed."""
+    resources = {"mysql-image": METADATA["resources"]["mysql-image"]["upstream-source"]}
+
+    async with ops_test.fast_forward("10s"):
+        await asyncio.gather(
+            ops_test.model.deploy(
+                charm,
+                application_name=DATABASE_APP_NAME,
+                num_units=3,
+                resources=resources,
+                base="ubuntu@22.04",
+                config={"profile": "testing"},
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                base="ubuntu@24.04",
+            ),
+        )
+
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active")
+    await ops_test.model.wait_for_idle(apps=[INTEGRATOR_APP_NAME], status="blocked")
+
+
+@pytest.mark.abort_on_fail
+async def test_charmed_dba_role(ops_test: OpsTest):
+    """Test the DBA predefined role."""
+    await ops_test.model.applications[INTEGRATOR_APP_NAME].set_config({
+        "database-name": "charmed_dba_database",
+        "extra-user-roles": "charmed_dba",
+    })
+    await ops_test.model.add_relation(INTEGRATOR_APP_NAME, DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[INTEGRATOR_APP_NAME, DATABASE_APP_NAME], status="active"
+    )
+
+    mysql_unit = ops_test.model.applications[DATABASE_APP_NAME].units[0]
+    primary_unit = await get_primary_unit(ops_test, mysql_unit, DATABASE_APP_NAME)
+    primary_unit_address = await get_unit_address(ops_test, primary_unit.name)
+    server_config_credentials = await get_server_config_credentials(primary_unit)
+
+    execute_queries_on_unit(
+        primary_unit_address,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+        ["CREATE DATABASE IF NOT EXISTS test"],
+        commit=True,
+    )
+
+    data_integrator_unit = ops_test.model.applications[INTEGRATOR_APP_NAME].units[0]
+    results = await juju_.run_action(data_integrator_unit, "get-credentials")
+
+    rows = execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        ["SHOW DATABASES"],
+        commit=True,
+    )
+
+    assert "test" in rows, "Database is not visible to DBA user"

--- a/tests/integration/roles/test_instance_dba_role.py
+++ b/tests/integration/roles/test_instance_dba_role.py
@@ -52,7 +52,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
 async def test_charmed_dba_role(ops_test: OpsTest):
     """Test the DBA predefined role."""
     await ops_test.model.applications[INTEGRATOR_APP_NAME].set_config({
-        "database-name": "charmed_dba_database",
+        "database-name": "charmed_dba_db",
         "extra-user-roles": "charmed_dba",
     })
     await ops_test.model.add_relation(INTEGRATOR_APP_NAME, DATABASE_APP_NAME)

--- a/tests/integration/roles/test_instance_roles.py
+++ b/tests/integration/roles/test_instance_roles.py
@@ -68,7 +68,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
 async def test_charmed_read_role(ops_test: OpsTest):
     """Test the charmed_read predefined role."""
     await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
-        "database-name": "charmed_read_database",
+        "database-name": "charmed_read_db",
         "extra-user-roles": "charmed_read",
     })
     await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
@@ -87,8 +87,8 @@ async def test_charmed_read_role(ops_test: OpsTest):
         server_config_credentials["username"],
         server_config_credentials["password"],
         [
-            "CREATE TABLE charmed_read_database.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
-            "INSERT INTO charmed_read_database.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+            "CREATE TABLE charmed_read_db.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            "INSERT INTO charmed_read_db.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
         ],
         commit=True,
     )
@@ -102,14 +102,14 @@ async def test_charmed_read_role(ops_test: OpsTest):
         results["mysql"]["username"],
         results["mysql"]["password"],
         [
-            "SELECT `data` FROM charmed_read_database.test_table",
+            "SELECT `data` FROM charmed_read_db.test_table",
         ],
         commit=True,
     )
     assert sorted(rows) == sorted([
         "test_data_1",
         "test_data_2",
-    ]), "Unexpected data in charmed_read_database with charmed_read role"
+    ]), "Unexpected data in charmed_read_db with charmed_read role"
 
     logger.info("Checking that the charmed_read role cannot write into an existing table")
     with pytest.raises(ProgrammingError):
@@ -118,7 +118,7 @@ async def test_charmed_read_role(ops_test: OpsTest):
             results["mysql"]["username"],
             results["mysql"]["password"],
             [
-                "INSERT INTO charmed_read_database.test_table (`data`) VALUES ('test_data_3')",
+                "INSERT INTO charmed_read_db.test_table (`data`) VALUES ('test_data_3')",
             ],
             commit=True,
         )
@@ -130,7 +130,7 @@ async def test_charmed_read_role(ops_test: OpsTest):
             results["mysql"]["username"],
             results["mysql"]["password"],
             [
-                "CREATE TABLE charmed_read_database.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+                "CREATE TABLE charmed_read_db.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
             ],
             commit=True,
         )
@@ -149,7 +149,7 @@ async def test_charmed_read_role(ops_test: OpsTest):
 async def test_charmed_dml_role(ops_test: OpsTest):
     """Test the charmed_dml role."""
     await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
-        "database-name": "charmed_dml_database",
+        "database-name": "charmed_dml_db",
         "extra-user-roles": "",
     })
     await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
@@ -181,16 +181,16 @@ async def test_charmed_dml_role(ops_test: OpsTest):
         results["mysql"]["username"],
         results["mysql"]["password"],
         [
-            "CREATE TABLE charmed_dml_database.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
-            "INSERT INTO charmed_dml_database.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
-            "SELECT `data` FROM charmed_dml_database.test_table",
+            "CREATE TABLE charmed_dml_db.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            "INSERT INTO charmed_dml_db.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+            "SELECT `data` FROM charmed_dml_db.test_table",
         ],
         commit=True,
     )
     assert sorted(rows) == sorted([
         "test_data_1",
         "test_data_2",
-    ]), "Unexpected data in charmed_dml_database with charmed_dml role"
+    ]), "Unexpected data in charmed_dml_db with charmed_dml role"
 
     data_integrator_2_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].units[0]
     results = await juju_.run_action(data_integrator_2_unit, "get-credentials")
@@ -201,14 +201,14 @@ async def test_charmed_dml_role(ops_test: OpsTest):
         results["mysql"]["username"],
         results["mysql"]["password"],
         [
-            "SELECT `data` FROM charmed_dml_database.test_table",
+            "SELECT `data` FROM charmed_dml_db.test_table",
         ],
         commit=True,
     )
     assert sorted(rows) == sorted([
         "test_data_1",
         "test_data_2",
-    ]), "Unexpected data in charmed_dml_database with charmed_dml role"
+    ]), "Unexpected data in charmed_dml_db with charmed_dml role"
 
     logger.info("Checking that the charmed_dml role can write into an existing table")
     execute_queries_on_unit(
@@ -216,7 +216,7 @@ async def test_charmed_dml_role(ops_test: OpsTest):
         results["mysql"]["username"],
         results["mysql"]["password"],
         [
-            "INSERT INTO charmed_dml_database.test_table (`data`) VALUES ('test_data_3')",
+            "INSERT INTO charmed_dml_db.test_table (`data`) VALUES ('test_data_3')",
         ],
         commit=True,
     )
@@ -228,7 +228,7 @@ async def test_charmed_dml_role(ops_test: OpsTest):
             results["mysql"]["username"],
             results["mysql"]["password"],
             [
-                "CREATE TABLE charmed_dml_database.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+                "CREATE TABLE charmed_dml_db.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
             ],
             commit=True,
         )

--- a/tests/integration/roles/test_instance_roles.py
+++ b/tests/integration/roles/test_instance_roles.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from mysql.connector.errors import ProgrammingError
+from pytest_operator.plugin import OpsTest
+
+from .. import juju_
+from ..helpers import (
+    execute_queries_on_unit,
+    get_primary_unit,
+    get_server_config_credentials,
+    get_unit_address,
+)
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+DATABASE_APP_NAME = METADATA["name"]
+INTEGRATOR_APP_NAME = "data-integrator"
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
+    """Simple test to ensure that the mysql and data-integrator charms get deployed."""
+    resources = {"mysql-image": METADATA["resources"]["mysql-image"]["upstream-source"]}
+
+    async with ops_test.fast_forward("10s"):
+        await asyncio.gather(
+            ops_test.model.deploy(
+                charm,
+                application_name=DATABASE_APP_NAME,
+                num_units=3,
+                resources=resources,
+                base="ubuntu@22.04",
+                config={"profile": "testing"},
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                application_name=f"{INTEGRATOR_APP_NAME}1",
+                base="ubuntu@24.04",
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                application_name=f"{INTEGRATOR_APP_NAME}2",
+                base="ubuntu@24.04",
+            ),
+        )
+
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME],
+        status="active",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"],
+        status="blocked",
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_charmed_read_role(ops_test: OpsTest):
+    """Test the charmed_read predefined role."""
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
+        "database-name": "charmed_read_database",
+        "extra-user-roles": "charmed_read",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    mysql_unit = ops_test.model.applications[DATABASE_APP_NAME].units[0]
+    primary_unit = await get_primary_unit(ops_test, mysql_unit, DATABASE_APP_NAME)
+    primary_unit_address = await get_unit_address(ops_test, primary_unit.name)
+    server_config_credentials = await get_server_config_credentials(primary_unit)
+
+    execute_queries_on_unit(
+        primary_unit_address,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+        [
+            "CREATE TABLE charmed_read_database.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            "INSERT INTO charmed_read_database.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+        ],
+        commit=True,
+    )
+
+    data_integrator_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].units[0]
+    results = await juju_.run_action(data_integrator_unit, "get-credentials")
+
+    logger.info("Checking that the charmed_read role can read from an existing table")
+    rows = execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "SELECT `data` FROM charmed_read_database.test_table",
+        ],
+        commit=True,
+    )
+    assert sorted(rows) == sorted([
+        "test_data_1",
+        "test_data_2",
+    ]), "Unexpected data in charmed_read_database with charmed_read role"
+
+    logger.info("Checking that the charmed_read role cannot write into an existing table")
+    with pytest.raises(ProgrammingError):
+        execute_queries_on_unit(
+            primary_unit_address,
+            results["mysql"]["username"],
+            results["mysql"]["password"],
+            [
+                "INSERT INTO charmed_read_database.test_table (`data`) VALUES ('test_data_3')",
+            ],
+            commit=True,
+        )
+
+    logger.info("Checking that the charmed_read role cannot create a new table")
+    with pytest.raises(ProgrammingError):
+        execute_queries_on_unit(
+            primary_unit_address,
+            results["mysql"]["username"],
+            results["mysql"]["password"],
+            [
+                "CREATE TABLE charmed_read_database.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            ],
+            commit=True,
+        )
+
+    await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+        f"{DATABASE_APP_NAME}:database",
+        f"{INTEGRATOR_APP_NAME}1:mysql",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1"],
+        status="blocked",
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_charmed_dml_role(ops_test: OpsTest):
+    """Test the charmed_dml role."""
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
+        "database-name": "charmed_dml_database",
+        "extra-user-roles": "",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].set_config({
+        "database-name": "throwaway",
+        "extra-user-roles": "charmed_dml",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    mysql_unit = ops_test.model.applications[DATABASE_APP_NAME].units[0]
+    primary_unit = await get_primary_unit(ops_test, mysql_unit, DATABASE_APP_NAME)
+    primary_unit_address = await get_unit_address(ops_test, primary_unit.name)
+
+    data_integrator_1_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].units[0]
+    results = await juju_.run_action(data_integrator_1_unit, "get-credentials")
+
+    logger.info("Checking that when no role is specified the created user can do everything")
+    rows = execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "CREATE TABLE charmed_dml_database.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            "INSERT INTO charmed_dml_database.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+            "SELECT `data` FROM charmed_dml_database.test_table",
+        ],
+        commit=True,
+    )
+    assert sorted(rows) == sorted([
+        "test_data_1",
+        "test_data_2",
+    ]), "Unexpected data in charmed_dml_database with charmed_dml role"
+
+    data_integrator_2_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].units[0]
+    results = await juju_.run_action(data_integrator_2_unit, "get-credentials")
+
+    logger.info("Checking that the charmed_dml role can read from an existing table")
+    rows = execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "SELECT `data` FROM charmed_dml_database.test_table",
+        ],
+        commit=True,
+    )
+    assert sorted(rows) == sorted([
+        "test_data_1",
+        "test_data_2",
+    ]), "Unexpected data in charmed_dml_database with charmed_dml role"
+
+    logger.info("Checking that the charmed_dml role can write into an existing table")
+    execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "INSERT INTO charmed_dml_database.test_table (`data`) VALUES ('test_data_3')",
+        ],
+        commit=True,
+    )
+
+    logger.info("Checking that the charmed_dml role cannot create a new table")
+    with pytest.raises(ProgrammingError):
+        execute_queries_on_unit(
+            primary_unit_address,
+            results["mysql"]["username"],
+            results["mysql"]["password"],
+            [
+                "CREATE TABLE charmed_dml_database.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            ],
+            commit=True,
+        )
+
+    await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+        f"{DATABASE_APP_NAME}:database",
+        f"{INTEGRATOR_APP_NAME}1:mysql",
+    )
+    await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+        f"{DATABASE_APP_NAME}:database",
+        f"{INTEGRATOR_APP_NAME}2:mysql",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"],
+        status="blocked",
+    )

--- a/tests/spread/test_database_dba_role.py/task.yaml
+++ b/tests/spread/test_database_dba_role.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_database_dba_role.py
+environment:
+  TEST_MODULE: roles/test_database_dba_role.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_instance_dba_role.py/task.yaml
+++ b/tests/spread/test_instance_dba_role.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_instance_dba_role.py
+environment:
+  TEST_MODULE: roles/test_instance_dba_role.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_instance_roles.py/task.yaml
+++ b/tests/spread/test_instance_roles.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_instance_roles.py
+environment:
+  TEST_MODULE: roles/test_instance_roles.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -147,7 +147,9 @@ class TestCharm(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.initialize_juju_units_operations_table")
     @patch("mysql_k8s_helpers.MySQL.get_mysql_version", return_value="8.0.0")
     @patch("mysql_k8s_helpers.MySQL.wait_until_mysql_connection")
-    @patch("mysql_k8s_helpers.MySQL.configure_mysql_users")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_router_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_roles")
+    @patch("mysql_k8s_helpers.MySQL.configure_mysql_system_users")
     @patch("mysql_k8s_helpers.MySQL.configure_instance")
     @patch("mysql_k8s_helpers.MySQL.create_cluster")
     @patch("mysql_k8s_helpers.MySQL.initialise_mysqld")
@@ -173,7 +175,9 @@ class TestCharm(unittest.TestCase):
         _fix_data_dir,
         _create_cluster,
         _configure_instance,
-        _configure_mysql_users,
+        _configure_mysql_router_roles,
+        _configure_mysql_system_roles,
+        _configure_mysql_system_users,
         _wait_until_mysql_connection,
         _get_mysql_version,
         _initialize_juju_units_operations_table,

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -62,14 +62,16 @@ class TestDatabase(unittest.TestCase):
     @patch("mysql_k8s_helpers.MySQL.update_endpoints")
     @patch("k8s_helpers.KubernetesHelpers.create_endpoint_services")
     @patch("mysql_k8s_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")
-    @patch("mysql_k8s_helpers.MySQL.create_application_database_and_scoped_user")
+    @patch("mysql_k8s_helpers.MySQL.create_database")
+    @patch("mysql_k8s_helpers.MySQL.create_scoped_user")
     @patch(
         "relations.mysql_provider.generate_random_password", return_value="super_secure_password"
     )
     def test_database_requested(
         self,
         _generate_random_password,
-        _create_application_database_and_scoped_user,
+        _create_scoped_user,
+        _create_database,
         _get_mysql_version,
         _create_endpoint_services,
         _update_endpoints,
@@ -116,7 +118,8 @@ class TestDatabase(unittest.TestCase):
         )
 
         _generate_random_password.assert_called_once()
-        _create_application_database_and_scoped_user.assert_called_once()
+        _create_database.assert_called_once()
+        _create_scoped_user.assert_called_once()
         _get_mysql_version.assert_called_once()
         _create_endpoint_services.assert_called_once()
         _update_endpoints.assert_called()

--- a/tests/unit/test_mysql_k8s_helpers.py
+++ b/tests/unit/test_mysql_k8s_helpers.py
@@ -104,14 +104,14 @@ class TestMySQL(unittest.TestCase):
         self.assertTrue(not self.mysql.wait_until_mysql_connection(check_port=False))
 
     @patch("mysql_k8s_helpers.MySQL._run_mysqlsh_script")
-    def test_create_database(self, _run_mysqlsh_script):
-        """Test successful execution of create_database."""
+    def test_create_database_legacy(self, _run_mysqlsh_script):
+        """Test successful execution of create_database_legacy."""
         _expected_create_database_commands = (
             "shell.connect_to_primary()",
             'session.run_sql("CREATE DATABASE IF NOT EXISTS `test_database`;")',
         )
 
-        self.mysql.create_database("test_database")
+        self.mysql.create_database_legacy("test_database")
 
         _run_mysqlsh_script.assert_called_once_with(
             "\n".join(_expected_create_database_commands),
@@ -121,23 +121,23 @@ class TestMySQL(unittest.TestCase):
         )
 
     @patch("mysql_k8s_helpers.MySQL._run_mysqlsh_script")
-    def test_create_database_exception(self, _run_mysqlsh_script):
-        """Test exception while executing create_database."""
+    def test_create_database_legacy_exception(self, _run_mysqlsh_script):
+        """Test exception while executing create_database_legacy."""
         _run_mysqlsh_script.side_effect = MySQLClientError("Error creating database")
 
         with self.assertRaises(MySQLCreateDatabaseError):
-            self.mysql.create_database("test_database")
+            self.mysql.create_database_legacy("test_database")
 
     @patch("mysql_k8s_helpers.MySQL._run_mysqlsh_script")
-    def test_create_user(self, _run_mysqlsh_script):
-        """Test successful execution of create_user."""
+    def test_create_user_legacy(self, _run_mysqlsh_script):
+        """Test successful execution of create_user_legacy."""
         _escaped_attributes = json.dumps({"label": "test_label"}).replace('"', r"\"")
         _expected_create_user_commands = (
             "shell.connect_to_primary()",
             f"session.run_sql(\"CREATE USER `test_user`@`%` IDENTIFIED BY 'test_password' ATTRIBUTE '{_escaped_attributes}';\")",
         )
 
-        self.mysql.create_user("test_user", "test_password", "test_label")
+        self.mysql.create_user_legacy("test_user", "test_password", "test_label")
 
         _run_mysqlsh_script.assert_called_once_with(
             "\n".join(_expected_create_user_commands),
@@ -147,12 +147,12 @@ class TestMySQL(unittest.TestCase):
         )
 
     @patch("mysql_k8s_helpers.MySQL._run_mysqlsh_script")
-    def test_create_user_exception(self, _run_mysqlsh_script):
-        """Test exception while executing create_user."""
+    def test_create_user_legacy_exception(self, _run_mysqlsh_script):
+        """Test exception while executing create_user_legacy."""
         _run_mysqlsh_script.side_effect = MySQLClientError("Error creating user")
 
         with self.assertRaises(MySQLCreateUserError):
-            self.mysql.create_user("test_user", "test_password", "test_label")
+            self.mysql.create_user_legacy("test_user", "test_password", "test_label")
 
     @patch("mysql_k8s_helpers.MySQL._run_mysqlsh_script")
     def test_escalate_user_privileges(self, _run_mysqlsh_script):


### PR DESCRIPTION
This PR implements the set of predefined roles proposed in [this specification](https://docs.google.com/document/d/1U1tAWx9a7eb0HvdiS7lnSJS8oHqcl6F9PnAoRdcMjmc/edit?tab=t.0).

### Additional changes:
- Implemented MySQL lib [function](https://github.com/canonical/mysql-operator/blob/52b2c8fc3367e67fd0cdf750bda61e25b103d0a2/lib/charms/mysql/v0/mysql.py#L2693-L2709) to fully support the usage of `extra-user-roles` config argument.
- Harmonized MySQL config arguments to all user underscore (`_`) instead of mixing dashes and underscores.
