### PR TITLE
[MISC] Cleanup MySQL shell timeout workaround

### DIFF
--- a/src/mysql_k8s_helpers.py
+++ b/src/mysql_k8s_helpers.py
@@ -695,7 +695,6 @@ class MySQL(MySQLBase):
         Returns:
             stdout of the script
         """
-        # TODO: remove timeout from _run_mysqlsh_script contract/signature in the mysql lib
         prepend_cmd = "shell.options.set('useWizards', False)\nprint('###')\n"
         script = prepend_cmd + script
 
@@ -710,14 +709,8 @@ class MySQL(MySQLBase):
             script,
         ]
 
-        # workaround for timeout not working on pebble exec
-        # https://github.com/canonical/operator/issues/1329
-        if timeout:
-            cmd.insert(0, str(timeout))
-            cmd.insert(0, "timeout")
-
         try:
-            process = self.container.exec(cmd, stdin=password)
+            process = self.container.exec(cmd, timeout=timeout, stdin=password)
             stdout, _ = process.wait_output()
             return stdout.split("###")[1].strip()
         except (ExecError, ChangeError) as e:

--- a/tests/unit/test_mysql_k8s_helpers.py
+++ b/tests/unit/test_mysql_k8s_helpers.py
@@ -258,25 +258,7 @@ class TestMySQL(unittest.TestCase):
         )
         self.mysql.container = _container
 
-        self.mysql._run_mysqlsh_script(
-            "script", user="serverconfig", password="serverconfigpassword", host="127.0.0.1:3306"
-        )
-
-        call_script = "shell.options.set('useWizards', False)\nprint('###')\nscript"
-        _container.exec.assert_called_once_with(
-            [
-                "/usr/bin/mysqlsh",
-                "--passwords-from-stdin",
-                "--uri=serverconfig@127.0.0.1:3306",
-                "--python",
-                "--verbose=0",
-                "-c",
-                call_script,
-            ],
-            stdin="serverconfigpassword",
-        )
-
-        _container.reset_mock()
+        script = "shell.options.set('useWizards', False)\nprint('###')\nscript"
         output = self.mysql._run_mysqlsh_script(
             "script",
             user="serverconfig",
@@ -288,16 +270,15 @@ class TestMySQL(unittest.TestCase):
 
         _container.exec.assert_called_once_with(
             [
-                "timeout",
-                "10",
                 "/usr/bin/mysqlsh",
                 "--passwords-from-stdin",
                 "--uri=serverconfig@127.0.0.1:3306",
                 "--python",
                 "--verbose=0",
                 "-c",
-                call_script,
+                script,
             ],
+            timeout=10,
             stdin="serverconfigpassword",
         )
 


### PR DESCRIPTION
This PR cleanups up an old workaround for the MySQL shell, where apparently, timeouts were not being applied correctly.

The [linked issue](https://github.com/canonical/operator/issues/1329) describes a misbehavior, but no evidence is provided to backup the claim. In addition, the workaround is not present on the MySQL CLI helper, which calls the same underlying method (see [code](https://github.com/canonical/mysql-k8s-operator/blob/6b91fef5f0915be0b768801a76d370af1bd04579/src/mysql_k8s_helpers.py#L763-L768)). Most probably the misbehavior was due to the version of Juju used at that time, or some other factor.
