### PR TITLE
[MISC] Fix OSM integration test

### DIFF
--- a/tests/integration/test_osm_integration_bundle.py
+++ b/tests/integration/test_osm_integration_bundle.py
@@ -18,7 +18,6 @@ from .helpers import (
     get_unit_address,
     is_relation_joined,
 )
-from .juju_ import juju_major_version
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +27,7 @@ CLUSTER_NAME = "test_cluster"
 
 
 # TODO: deploy and relate osm-grafana once it can be use with MySQL Group Replication
+@markers.juju3
 @markers.amd64_only  # kafka-k8s charm not available for arm64
 async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest, charm) -> None:
     """Test the deployment and relation with osm bundle with mysql replacing mariadb."""
@@ -49,12 +49,9 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest, charm) -> None:
             "--resource",
             "keystone-image=opensourcemano/keystone:testing-daily",
             "osm-keystone",
+            "--base",
+            "ubuntu@22.04",
         ]
-
-        if juju_major_version >= 3:
-            osm_keystone_deploy_commands.extend(["--base", "ubuntu@22.04"])
-        else:
-            osm_keystone_deploy_commands.extend(["--series", "jammy"])
 
         await asyncio.gather(
             ops_test.model.deploy(
@@ -91,13 +88,11 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest, charm) -> None:
                 channel="latest/stable",
                 base="ubuntu@20.04",
             ),
-            # sticking to revision that support both juju 2.9.x and 3.x
             ops_test.model.deploy(
                 "mongodb-k8s",
                 application_name="mongodb",
-                channel="5/edge",
-                revision=36,
-                series="jammy",
+                channel="6/stable",
+                base="ubuntu@22.04",
             ),
         )
 
@@ -171,6 +166,7 @@ async def test_deploy_and_relate_osm_bundle(ops_test: OpsTest, charm) -> None:
 
 
 @pytest.mark.abort_on_fail
+@markers.juju3
 @markers.amd64_only  # kafka-k8s charm not available for arm64
 async def test_osm_pol_operations(ops_test: OpsTest) -> None:
     """Test the existence of databases and tables created by osm-pol's migrations."""

--- a/tests/spread/test_osm_integration_bundle.py/task.yaml
+++ b/tests/spread/test_osm_integration_bundle.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+variants:
+  - -juju29


### PR DESCRIPTION
This PR fixes the OSM integration test, failing since September 13th (see [CI run](https://github.com/canonical/mysql-k8s-operator/actions/runs/17689695785)), by making the test juju-3 exclusive.

The mongo-k8s `5/...` set of channels have been closed, and there is no current version of the charm supporting both Juju 2 and Juju 3, according to Mehdi.