### PR TITLE
docs: DPE-8282 Security Event Logging advisory

### DIFF
--- a/docs/explanation/logs/audit-logs.md
+++ b/docs/explanation/logs/audit-logs.md
@@ -1,3 +1,4 @@
+(audit_logs)=
 # Audit Logs
 
 The Audit Log plugin allows all login/logout records to be stored in a log file. It is enabled in Charmed MySQL K8s by default.
@@ -23,14 +24,14 @@ It's recommended to integrate the charm with [COS](/how-to/monitoring-cos/enable
     ```bash
     juju config mysql-k8s plugin-audit-enabled=false
     ```
-    Valid value are `false` and `true`. By setting it to false, existing logs are still kept in the `archive_audit` directory.
+    Valid value are `false` and `true` (default). By setting it to false, existing logs are still kept in the `archive_audit` directory.
 
 1. `logs_audit_policy` - Audit log policy:
 
     ```bash
     juju config mysql-k8s logs_audit_policy=queries
     ```
-    Valid values are: "all", "logins" (default), "queries"
+    Valid values are `logins` (default), `queries` and `all`.
 
 1. `plugin-audit-strategy` - By default the audit plugin writes logs in asynchronous mode for better performance.
     To ensure logs are written to disk on more timely fashion, this configuration can be set to semi-synchronous mode:
@@ -38,5 +39,5 @@ It's recommended to integrate the charm with [COS](/how-to/monitoring-cos/enable
     ```bash
     juju config mysql-k8s plugin-audit-strategy=semi-async
     ```
-    Valid values are `async` and `semi-async`.
+    Valid values are `async` (default) and `semi-async`.
 

--- a/docs/explanation/security/index.md
+++ b/docs/explanation/security/index.md
@@ -81,9 +81,28 @@ Charmed MySQL K8s uses the [caching_sha2_password](https://dev.mysql.com/doc/ref
 
 ### Monitoring and auditing
 
-Charmed MySQL K8s provides native integration with the [Canonical Observability Stack (COS)](https://charmhub.io/topics/canonical-observability-stack). To reduce the blast radius of infrastructure disruptions, the general recommendation is to deploy COS and the observed application into separate environments, isolated from one another. Refer to the [COS production deployments best practices](https://charmhub.io/topics/canonical-observability-stack/reference/best-practices) for more information or see the How to guides for MySQL K8s [monitoring](https://canonical.com/data/docs/mysql/k8s/h-enable-monitoring), [alert rules](https://canonical.com/data/docs/mysql/k8s/h-enable-alert-rules), and [tracing](https://canonical.com/data/docs/mysql/k8s/h-enable-tracing) for practical instructions.
+Charmed MySQL K8s provides native integration with the [Canonical Observability Stack (COS)](https://charmhub.io/topics/canonical-observability-stack). To reduce the blast radius of infrastructure disruptions, the general recommendation is to deploy COS and the observed application into separate environments, isolated from one another. Refer to the [COS production deployments best practices](https://charmhub.io/topics/canonical-observability-stack/reference/best-practices) for more information.
 
-The Audit log plugin is enabled by default and produces login/logout logs. See the [Audit Logs](https://charmhub.io/mysql-k8s/docs/e-audit-logs) guide for further configuration. These logs are stored in the /var/log/mysql directory of the MySQL container and are rotated every minute to the /var/log/mysql/archive_audit directory. It’s recommended to integrate the charm with [COS](https://discourse.charmhub.io/t/9900), from where the logs can be easily persisted and queried using [Loki](https://charmhub.io/loki-k8s)/[Grafana](https://charmhub.io/grafana).
+For instructions, see the [How to enable monitoring](https://canonical.com/data/docs/mysql/k8s/h-enable-monitoring), [How to enable alert rules](https://canonical.com/data/docs/mysql/k8s/h-enable-alert-rules), and [How to enable tracing](https://canonical.com/data/docs/mysql/k8s/h-enable-tracing) guides.
+
+### Security event logging
+
+Charmed MySQL K8s provides [audit log plugin](audit_logs) enabled by default. These logs are stored in the `/var/log/mysql/audit.log` file of each unit, and rotated minutely the `archive_audit` sub directory. If COS is enabled, audit logs are also persisted there.
+
+We recommend setting the retention period to a value greater than the default (three days):
+
+```shell
+juju config mysql-k8s logs_retention_period=14 # days
+```
+
+By default, the audit log records logins and logouts. To include the SQL queries executed by each user:
+
+```shell
+juju config mysql-k8s logs_audit_policy=all
+```
+
+See the [Audit Logs](audit_logs) guide for further configuration.
+
 
 ## Additional Resources
 

--- a/docs/how-to/monitoring-cos/enable-alert-rules.md
+++ b/docs/how-to/monitoring-cos/enable-alert-rules.md
@@ -6,7 +6,7 @@ Charmed MySQL K8s ships a pre-configured and pre-enabled list of Awesome Alert R
 
 ```{seealso}
 * [](/reference/alert-rules)
-* [Observability documentation > Add alert rules](https://documentation.ubuntu.com/observability/how-to/adding-alert-rules/)
+* [Observability documentation > Add alert rules](https://documentation.ubuntu.com/observability/latest/how-to/adding-alert-rules/)
 ```
 
 <details><summary>Screenshot of MySQL alert rules in Grafana web interface


### PR DESCRIPTION
## Issue

As part of SSDLC, we are missing specific advisory for event logging

## Solution

Added text snippet to address event logging advisory.
Same as [PR#688](https://github.com/canonical/mysql-operator/pull/688)
