### PR TITLE
fix: enabling trust for deployments

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "mysql_server" {
   name  = var.app_name
   model = var.model_name
+  trust = true
 
   charm {
     name     = "mysql-k8s"


### PR DESCRIPTION
## Issue

If there is no `trust`, the mysql deployment hangs. 

## Solution

Just adding the `trust=true` flag in the tf module

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
