### PR TITLE
Remove misleading guidance from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,6 @@ poetry install
 tox run -e format        # update your code according to linting rules
 tox run -e lint          # code style
 tox run -e unit          # unit tests
-charmcraft test lxd-vm:  # integration tests
 tox                      # runs 'lint' and 'unit' environments
 ```
 


### PR DESCRIPTION
Removing the only part of the `CONTRIBUTING.md` that didn't work out of the box.

`charmcraft test lxd-vm:` does run, but it takes a very long time (notice the timestamps):

```
2025-10-20 17:05:54 Preparing lxd-vm:ubuntu-24.04 (lxd-vm:ubuntu-24.04)...
2025-10-20 17:09:26 Preparing lxd-vm:ubuntu-24.04:tests/spread/test_vm_reboot.py:juju29 (lxd-vm:ubuntu-24.04)...
2025-10-20 17:09:55 Executing lxd-vm:ubuntu-24.04:tests/spread/test_vm_reboot.py:juju29 (lxd-vm:ubuntu-24.04) (1/64)...
2025-10-20 17:14:55 WARNING: lxd-vm:ubuntu-24.04 (lxd-vm:ubuntu-24.04:tests/spread/test_vm_reboot.py:juju29) running late. Current output:
-----
(... 123 lines above ...)
  mysql/1 [executing] maintenance: Installing MySQL
  mysql/2 [executing] maintenance: Installing MySQL
INFO     juju.model:model.py:2631 Waiting for model:
...
```

And also, it is not the way we run our integration tests on CI:

https://github.com/canonical/mysql-k8s-operator/blob/2ff9860b10449ebd812a9ad32ca6708feb86d895/.github/workflows/integration_test.yaml#L115-L121

(unfortunately, https://github.com/canonical/charmcraft/issues/2105 and https://github.com/canonical/charmcraft/issues/2130 are indeed not resolved yet)

My understanding is that team members mostly don't execute integration tests locally, but if anybody has better guidance, I'm happy to include it instead.

## Issue

## Solution

## Checklist
- [x] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
