### PR TITLE
[MISC] Adopt packaging standards

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2465,4 +2465,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.10"
-content-hash = "d95ff1df82f23b185af21aea250362af0f2dd31acc826c07469275ef5252e465"
+content-hash = "a914a89c31c4705d529b3c0c8f201b2d13c0946e6788cd03a9961e11262fe50b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ name = "mysql-k8s-operator"  # Charm is not meant to be packaged
 dependencies = [
   "ops~=2.15",
   "lightkube~=0.15.0",
-  "tenacity>=8.2.2,<9",
-  "boto3>=1.28.22,<2",
-  "jinja2>=3.1.2,<4",
-  "pyyaml>=6.0.2,<7",
+  "tenacity~=8.2",
+  "boto3~=1.28",
+  "jinja2~=3.1",
+  "pyyaml~=6.0",
 ]
 requires-python = "~=3.10"
 
@@ -33,17 +33,17 @@ charm-libs = [
     "opentelemetry-exporter-otlp-proto-http==1.21.0",
 ]
 format = [
-    "ruff>=0.12.7,<0.13",
+    "ruff~=0.12.7",
 ]
 lint = [
-    "ruff>=0.12.7,<0.13",
+    "ruff~=0.12.7",
     "codespell~=2.3",
-    "shellcheck-py>=0.9.0.5,<0.10",
+    "shellcheck-py~=0.9.0",
 ]
 unit = [
     "pytest~=7.4",
-    "pytest-mock>=3.11.1,<4",
-    "coverage[toml]>=7.2.7,<8",
+    "pytest-mock~=3.11",
+    "coverage[toml]~=7.2",
     "parameterized~=0.9.0",
 ]
 integration = [
@@ -52,15 +52,15 @@ integration = [
     "juju~=3.6",
     "ops~=2.15",
     "mysql-connector-python~=9.1.0",
-    "tenacity>=8.2.2,<9",
-    "boto3>=1.28.22,<2",
-    "pyyaml>=6.0.1,<7",
+    "tenacity~=8.2",
+    "boto3~=1.28",
+    "pyyaml~=6.0",
     "urllib3~=2.0",
     "lightkube~=0.15.0",
     "kubernetes~=27.2.0",
-    "allure-pytest>=2.13.2,<3",
-    "allure-pytest-default-results>=0.1.2,<0.2",
-    "pytest-asyncio>=0.21.1,<0.22",
+    "allure-pytest~=2.13",
+    "allure-pytest-default-results~=0.1.2",
+    "pytest-asyncio~=0.21.1",
     "jubilant-backports~=1.4",
 ]
 


### PR DESCRIPTION
PEP 621 ([project] table) and PEP 735 (dependency groups). Requires newer Poetry version.

Notice that this is similar to #613, but it's much less disruptive because it doesn't change our workflow tool (still Poetry). As such, everything should continue working as before. Still, the change is significant because it helps adopt other workflow tools locally.

## Issue

## Solution

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
