### PR TITLE
[MISC] Set Jubilant logging to WARNING

### DIFF
--- a/tests/integration/integration/relations/test_database.py
+++ b/tests/integration/integration/relations/test_database.py
@@ -16,14 +16,14 @@ from ...helpers_ha import (
     wait_for_apps_status,
 )
 
-logger = logging.getLogger(__name__)
-
 DATABASE_APP_NAME = CHARM_METADATA["name"]
 DATABASE_ENDPOINT = "database"
 APPLICATION_APP_NAME = "mysql-test-app"
 APPLICATION_ENDPOINT = "database"
 
 APPS = [DATABASE_APP_NAME, APPLICATION_APP_NAME]
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
 @pytest.mark.abort_on_fail
@@ -54,19 +54,19 @@ def test_relation_creation_eager(juju: Juju):
 
     It simulates a Terraform-like deployment strategy
     """
-    logger.info("Creating relation...")
+    logging.info("Creating relation...")
     juju.integrate(
         f"{APPLICATION_APP_NAME}:{APPLICATION_ENDPOINT}",
         f"{DATABASE_APP_NAME}:{DATABASE_ENDPOINT}",
     )
 
-    logger.info("Waiting for application app to be waiting...")
+    logging.info("Waiting for application app to be waiting...")
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
     )
-    logger.info("Waiting for database app to be active...")
+    logging.info("Waiting for database app to be active...")
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,

--- a/tests/integration/integration/relations/test_mysql_root.py
+++ b/tests/integration/integration/relations/test_mysql_root.py
@@ -8,14 +8,18 @@ import jubilant_backports
 import pytest
 from jubilant_backports import Juju
 
-from ...helpers_ha import CHARM_METADATA, MINUTE_SECS, wait_for_apps_status
-
-logger = logging.getLogger(__name__)
+from ...helpers_ha import (
+    CHARM_METADATA,
+    MINUTE_SECS,
+    wait_for_apps_status,
+)
 
 DATABASE_APP_NAME = CHARM_METADATA["name"]
 DATABASE_ENDPOINT = "mysql-root"
 APPLICATION_APP_NAME = "mysql-test-app"
 APPLICATION_ENDPOINT = "mysql"
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
 @pytest.mark.abort_on_fail
@@ -54,13 +58,13 @@ def test_relation_creation_eager(juju: Juju):
         f"{DATABASE_APP_NAME}:{DATABASE_ENDPOINT}",
     )
 
-    logger.info("Waiting for application app to be waiting...")
+    logging.info("Waiting for application app to be waiting...")
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_waiting, APPLICATION_APP_NAME),
         error=jubilant_backports.any_blocked,
         timeout=15 * MINUTE_SECS,
     )
-    logger.info("Waiting for database app to be active...")
+    logging.info("Waiting for database app to be active...")
     juju.wait(
         ready=wait_for_apps_status(jubilant_backports.all_active, DATABASE_APP_NAME),
         error=jubilant_backports.any_blocked,

--- a/tests/integration/integration/roles/test_database_dba_role.py
+++ b/tests/integration/integration/roles/test_database_dba_role.py
@@ -19,10 +19,10 @@ from ...helpers_ha import (
     wait_for_apps_status,
 )
 
-logger = logging.getLogger(__name__)
-
 DATABASE_APP_NAME = CHARM_METADATA["name"]
 INTEGRATOR_APP_NAME = "data-integrator"
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
 @pytest.mark.abort_on_fail
@@ -91,7 +91,7 @@ def test_charmed_dba_role(juju: Juju):
     data_integrator_2_unit_name = get_app_units(juju, f"{INTEGRATOR_APP_NAME}2")[0]
     results = juju.run(data_integrator_2_unit_name, "get-credentials").results
 
-    logger.info("Checking that the database-level DBA role cannot create new databases")
+    logging.info("Checking that the database-level DBA role cannot create new databases")
     with pytest.raises(ProgrammingError):
         execute_queries_on_unit(
             primary_unit_address,
@@ -101,7 +101,7 @@ def test_charmed_dba_role(juju: Juju):
             commit=True,
         )
 
-    logger.info("Checking that the database-level DBA role can see all databases")
+    logging.info("Checking that the database-level DBA role can see all databases")
     execute_queries_on_unit(
         primary_unit_address,
         results["mysql"]["username"],
@@ -110,7 +110,7 @@ def test_charmed_dba_role(juju: Juju):
         commit=True,
     )
 
-    logger.info("Checking that the database-level DBA role can create a new table")
+    logging.info("Checking that the database-level DBA role can create a new table")
     execute_queries_on_unit(
         primary_unit_address,
         results["mysql"]["username"],
@@ -121,7 +121,7 @@ def test_charmed_dba_role(juju: Juju):
         commit=True,
     )
 
-    logger.info("Checking that the database-level DBA role can write into an existing table")
+    logging.info("Checking that the database-level DBA role can write into an existing table")
     execute_queries_on_unit(
         primary_unit_address,
         results["mysql"]["username"],
@@ -132,7 +132,7 @@ def test_charmed_dba_role(juju: Juju):
         commit=True,
     )
 
-    logger.info("Checking that the database-level DBA role can read from an existing table")
+    logging.info("Checking that the database-level DBA role can read from an existing table")
     rows = execute_queries_on_unit(
         primary_unit_address,
         results["mysql"]["username"],

--- a/tests/integration/integration/roles/test_instance_dba_role.py
+++ b/tests/integration/integration/roles/test_instance_dba_role.py
@@ -2,6 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 
 import jubilant_backports
 import pytest
@@ -20,6 +21,8 @@ from ...helpers_ha import (
 
 DATABASE_APP_NAME = CHARM_METADATA["name"]
 INTEGRATOR_APP_NAME = "data-integrator"
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/integration/roles/test_instance_roles.py
+++ b/tests/integration/integration/roles/test_instance_roles.py
@@ -20,10 +20,10 @@ from ...helpers_ha import (
     wait_for_apps_status,
 )
 
-logger = logging.getLogger(__name__)
-
 DATABASE_APP_NAME = CHARM_METADATA["name"]
 INTEGRATOR_APP_NAME = "data-integrator"
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
 @pytest.mark.abort_on_fail
@@ -93,7 +93,7 @@ def test_charmed_read_role(juju: Juju):
     data_integrator_unit_name = get_app_units(juju, f"{INTEGRATOR_APP_NAME}1")[0]
     results = juju.run(data_integrator_unit_name, "get-credentials").results
 
-    logger.info("Checking that the charmed_read role can read from an existing table")
+    logging.info("Checking that the charmed_read role can read from an existing table")
     rows = execute_queries_on_unit(
         primary_unit_address,
         results["mysql"]["username"],
@@ -108,7 +108,7 @@ def test_charmed_read_role(juju: Juju):
         "test_data_2",
     ]), "Unexpected data in charmed_read_db with charmed_read role"
 
-    logger.info("Checking that the charmed_read role cannot write into an existing table")
+    logging.info("Checking that the charmed_read role cannot write into an existing table")
     with pytest.raises(ProgrammingError):
         execute_queries_on_unit(
             primary_unit_address,
@@ -120,7 +120,7 @@ def test_charmed_read_role(juju: Juju):
             commit=True,
         )
 
-    logger.info("Checking that the charmed_read role cannot create a new table")
+    logging.info("Checking that the charmed_read role cannot create a new table")
     with pytest.raises(ProgrammingError):
         execute_queries_on_unit(
             primary_unit_address,
@@ -170,7 +170,7 @@ def test_charmed_dml_role(juju: Juju):
     data_integrator_1_unit_name = get_app_units(juju, f"{INTEGRATOR_APP_NAME}1")[0]
     results = juju.run(data_integrator_1_unit_name, "get-credentials").results
 
-    logger.info("Checking that when no role is specified the created user can do everything")
+    logging.info("Checking that when no role is specified the created user can do everything")
     rows = execute_queries_on_unit(
         primary_unit_address,
         results["mysql"]["username"],
@@ -190,7 +190,7 @@ def test_charmed_dml_role(juju: Juju):
     data_integrator_2_unit_name = get_app_units(juju, f"{INTEGRATOR_APP_NAME}2")[0]
     results = juju.run(data_integrator_2_unit_name, "get-credentials").results
 
-    logger.info("Checking that the charmed_dml role can read from an existing table")
+    logging.info("Checking that the charmed_dml role can read from an existing table")
     rows = execute_queries_on_unit(
         primary_unit_address,
         results["mysql"]["username"],
@@ -205,7 +205,7 @@ def test_charmed_dml_role(juju: Juju):
         "test_data_2",
     ]), "Unexpected data in charmed_dml_db with charmed_dml role"
 
-    logger.info("Checking that the charmed_dml role can write into an existing table")
+    logging.info("Checking that the charmed_dml role can write into an existing table")
     execute_queries_on_unit(
         primary_unit_address,
         results["mysql"]["username"],
@@ -216,7 +216,7 @@ def test_charmed_dml_role(juju: Juju):
         commit=True,
     )
 
-    logger.info("Checking that the charmed_dml role cannot create a new table")
+    logging.info("Checking that the charmed_dml role cannot create a new table")
     with pytest.raises(ProgrammingError):
         execute_queries_on_unit(
             primary_unit_address,


### PR DESCRIPTION
This PR reduces Jubilant produced logging to the `WARNING` level in relations / roles integration tests.

Fixes PR https://github.com/canonical/mysql-k8s-operator/pull/683.
