### PR TITLE
[DPE-8924] fix scale up from zero when metrics-endpoint is related

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -608,6 +608,11 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if not self._mysql.is_data_dir_initialised():
             logger.debug("Skip reconcile mysqld exporter: mysql not initialised")
             return
+
+        if self.is_new_unit:
+            # scaling up from zero, treatment done on pebble-ready
+            return
+
         self.current_event = event
         self._reconcile_pebble_layer(container)
 


### PR DESCRIPTION
## Issue

When related to a `metrics-endpoint` (e.g. prometheus-k8s), scale up from zero fails. See #689

When scaling up from zero, metrics-relation join hook can run before pebble-ready.
The hook will reconcile the pebble layer, to start the exporter service. When ran before pebble ready, `mysqld` service will
start with default configuration, as charm config is written on pebble-ready.
With default config, admin port (33062) is not enabled, and further reconcile does not restart mysqld, making the charm unable to connect to mysqld

## Solution

Skip reconcile pebble layer if scaling up from zero on metrics-relation join event

Fix #689
