### PR TITLE
[DPE-8916] Use mysql-shell-client package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1208,6 +1208,23 @@ gssapi = ["gssapi (==1.8.3)"]
 telemetry = ["opentelemetry-api (==1.18.0)", "opentelemetry-exporter-otlp-proto-http (==1.18.0)", "opentelemetry-sdk (==1.18.0)"]
 
 [[package]]
+name = "mysql-shell-client"
+version = "0.6.1"
+description = "Python client for MySQL Shell"
+optional = false
+python-versions = ">=3.10"
+groups = ["charm-libs"]
+files = [
+    {file = "mysql_shell_client-0.6.1-py3-none-any.whl", hash = "sha256:364bfddb6003aeaf4599057f29d0e2d76f4463e998adf397c7ca1918f97485b2"},
+    {file = "mysql_shell_client-0.6.1.tar.gz", hash = "sha256:4d67003aaf049c3003b931b95bd1f6ceb3fa129f252d4f7c6c41646869404dff"},
+]
+
+[package.extras]
+format = ["ruff (>=0.9,<1.0)"]
+lint = ["codespell (>=2.3,<3.0)", "ruff (>=0.9,<1.0)"]
+test = ["coverage (>=7.6,<8.0)", "pytest (>=8.3,<9.0)"]
+
+[[package]]
 name = "oauthlib"
 version = "3.2.2"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -2465,4 +2482,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = "~=3.10"
-content-hash = "a914a89c31c4705d529b3c0c8f201b2d13c0946e6788cd03a9961e11262fe50b"
+content-hash = "967e4e13222da4f822b94d30e187d85b91a2b4ea105d1c902cb9967612b27577"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@
 [project]
 name = "mysql-k8s-operator"  # Charm is not meant to be packaged
 dependencies = [
-  "ops~=2.15",
-  "lightkube~=0.15.0",
-  "tenacity~=8.2",
-  "boto3~=1.28",
-  "jinja2~=3.1",
-  "pyyaml~=6.0",
+    "boto3~=1.28",
+    "jinja2~=3.1",
+    "lightkube~=0.15.0",
+    "ops~=2.15",
+    "pyyaml~=6.0",
+    "tenacity~=8.2",
 ]
 requires-python = "~=3.10"
 
@@ -23,6 +23,8 @@ charm-libs = [
     # data_platform_libs/v0/data_models.py requires pydantic ^1.10
     # tempo_coordinator_k8s/v0/charm_tracing.py requires pydantic
     "pydantic~=1.10",
+    # mysql/v0/*.py"
+    "mysql_shell_client~=0.6",
     # tls_certificates_interface/v1/tls_certificates.py
     # tls_certificates lib uses a feature only available in cryptography >=42.0.5
     "cryptography>=42.0.5",

--- a/src/mysql_k8s_executor.py
+++ b/src/mysql_k8s_executor.py
@@ -1,0 +1,196 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helper class to manage the MySQL Shell executor."""
+
+import json
+import re
+from typing import Generator
+
+import ops
+from mysql_shell.executors import BaseExecutor
+from mysql_shell.executors.errors import ExecutionError
+from mysql_shell.models import ConnectionDetails
+from ops.model import Container
+
+
+class ContainerExecutor(BaseExecutor):
+    """Container executor for the MySQL Shell."""
+
+    def __init__(self, conn_details: ConnectionDetails, shell_path: str):
+        """Initialize the executor."""
+        super().__init__(conn_details, shell_path)
+        self._container = None
+
+    def _common_args(self) -> list[str]:
+        """Return the list of common arguments."""
+        return [
+            self._shell_path,
+            "--json=raw",
+            "--save-passwords=never",
+            "--passwords-from-stdin",
+        ]
+
+    def _connection_args(self) -> list[str]:
+        """Return the list of connection arguments."""
+        if self._conn_details.socket:
+            return [
+                f"--socket={self._conn_details.socket}",
+                f"--user={self._conn_details.username}",
+            ]
+        else:
+            return [
+                f"--host={self._conn_details.host}",
+                f"--port={self._conn_details.port}",
+                f"--user={self._conn_details.username}",
+            ]
+
+    def _parse_error(self, output: str) -> dict:
+        """Parse the execution error."""
+        error = next(self._iter_output(output, "error"), None)
+        if not error:
+            error = {}
+
+        return error
+
+    def _parse_output_py(self, output: str) -> str:
+        """Parse the Python execution output."""
+        result = next(self._iter_output(output, "info"), None)
+        if not result:
+            result = "{}"
+
+        return result
+
+    def _parse_output_sql(self, output: str) -> list:
+        """Parse the SQL execution output."""
+        result = next(self._iter_output(output, "rows"), None)
+        if not result:
+            result = []
+
+        return result
+
+    @staticmethod
+    def _iter_output(output: str, key: str) -> Generator:
+        """Iterates over the log lines in reversed order."""
+        logs = output.split("\n")
+
+        # MySQL Shell always prints prompts and warnings first
+        for log in reversed(logs):
+            if not log:
+                continue
+
+            log = json.loads(log)
+            val = log.get(key)
+            if not isinstance(val, str) or val.strip():
+                yield val
+
+    @staticmethod
+    def _strip_password(error: ops.pebble.Error):
+        """Strip passwords from SQL scripts."""
+        if not hasattr(error, "command"):
+            return error
+
+        password_pattern = re.compile("(?<=IDENTIFIED BY ')[^']+(?=')")
+        password_replace = "*****"  # noqa: S105
+
+        for index, value in enumerate(error.command):
+            if "IDENTIFIED BY" in value:
+                error.command[index] = re.sub(password_pattern, password_replace, value)
+
+        return error
+
+    def set_container(self, container: Container) -> None:
+        """Set the executor container."""
+        self._container = container
+
+    def check_connection(self) -> None:
+        """Check the connection."""
+        command = [
+            *self._common_args(),
+            *self._connection_args(),
+        ]
+
+        try:
+            process = self._container.exec(
+                command,
+                stdin=self._conn_details.password,
+            )
+            process.wait_output()
+        except ops.pebble.ExecError as exc:
+            err = self._parse_error(exc.stdout)
+            raise ExecutionError(err) from exc
+        except ops.pebble.TimeoutError as exc:
+            raise ExecutionError() from exc
+
+    def execute_py(self, script: str, *, timeout: int | None = None) -> str:
+        """Execute a Python script.
+
+        Arguments:
+            script: Python script to execute
+            timeout: Optional timeout seconds
+
+        Returns:
+            String with the output of the MySQL Shell command.
+            The output cannot be parsed to JSON, as the output depends on the script
+        """
+        # Prepend every Python command with useWizards=False, to disable interactive mode.
+        # Cannot be set on command line as it conflicts with --passwords-from-stdin.
+        script = "shell.options.set('useWizards', False)\n" + script
+
+        command = [
+            *self._common_args(),
+            *self._connection_args(),
+            "--py",
+            "--execute",
+            script,
+        ]
+
+        try:
+            process = self._container.exec(
+                command,
+                timeout=timeout,
+                stdin=self._conn_details.password,
+            )
+            stdout, _ = process.wait_output()
+        except ops.pebble.ExecError as exc:
+            err = self._parse_error(exc.stdout)
+            raise ExecutionError(err) from exc
+        except ops.pebble.TimeoutError as exc:
+            raise ExecutionError() from exc
+        else:
+            return self._parse_output_py(stdout)
+
+    def execute_sql(self, script: str, *, timeout: int | None = None) -> list[dict]:
+        """Execute a SQL script.
+
+        Arguments:
+            script: SQL script to execute
+            timeout: Optional timeout seconds
+
+        Returns:
+            List of dictionaries, one per returned row
+        """
+        command = [
+            *self._common_args(),
+            *self._connection_args(),
+            "--sql",
+            "--execute",
+            script,
+        ]
+
+        try:
+            process = self._container.exec(
+                command,
+                timeout=timeout,
+                stdin=self._conn_details.password,
+            )
+            stdout, _ = process.wait_output()
+        except ops.pebble.ExecError as exc:
+            err = self._parse_error(exc.stdout)
+            exc = self._strip_password(exc)
+            raise ExecutionError(err) from exc
+        except ops.pebble.TimeoutError as exc:
+            exc = self._strip_password(exc)
+            raise ExecutionError() from exc
+        else:
+            return self._parse_output_sql(stdout)

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -156,7 +156,7 @@ class MySQLRelation(Object):
             self.charm.unit.status = BlockedStatus("Failed to retrieve cluster primary address")
             return
 
-        if host != primary_address.split(":")[0]:
+        if host != primary_address:
             # Trigger a peer relation changed event in order to refresh the relation data
             update_status_count = int(self.charm.app_peer_data.get("update_status_count", "0"))
             self.charm.app_peer_data["update_status_count"] = str(update_status_count + 1)
@@ -193,7 +193,7 @@ class MySQLRelation(Object):
             logger.error("Unable to query the cluster primary address")
             self.charm.unit.status = BlockedStatus("Failed to retrieve cluster primary address")
             return
-        updates["host"] = primary_address.split(":")[0]
+        updates["host"] = primary_address
 
         self.model.get_relation(LEGACY_MYSQL).data[self.charm.unit].update(updates)
 
@@ -271,7 +271,7 @@ class MySQLRelation(Object):
 
         updates = {
             "database": database,
-            "host": primary_address.split(":")[0],
+            "host": primary_address,
             "password": password,
             "port": "3306",
             "root_password": self.charm.get_secret("app", ROOT_PASSWORD_KEY),

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -297,7 +297,8 @@ class MySQLProvider(Object):
             return
 
         users = self.charm._mysql.get_mysql_router_users_for_unit(
-            relation_id=event.relation.id, mysql_router_unit_name=event.departing_unit.name
+            relation_id=event.relation.id,
+            mysql_router_unit_name=event.departing_unit.name,
         )
         if not users:
             return
@@ -308,14 +309,17 @@ class MySQLProvider(Object):
             )
             return
 
-        user = users[0]
+        user_name = users[0].username
+        user_attrs = users[0].attributes
+        router_id = user_attrs["router_id"]
+
         try:
-            self.charm._mysql.delete_user(user.username)
-            logger.info(f"Deleted router user {user.username}")
+            self.charm._mysql.delete_user(user_name)
+            logger.info(f"Deleted router user {user_name}")
         except MySQLDeleteUserError:
-            logger.error(f"Failed to delete user {user.username}")
+            logger.error(f"Failed to delete user {user_name}")
         try:
-            self.charm._mysql.remove_router_from_cluster_metadata(user.router_id)
-            logger.info(f"Removed router from metadata {user.router_id}")
+            self.charm._mysql.remove_router_from_cluster_metadata(router_id)
+            logger.info(f"Removed router from metadata {router_id}")
         except MySQLRemoveRouterFromMetadataError:
-            logger.error(f"Failed to remove router from metadata with ID {user.router_id}")
+            logger.error(f"Failed to remove router from metadata with ID {router_id}")

--- a/src/relations/mysql_root.py
+++ b/src/relations/mysql_root.py
@@ -126,7 +126,7 @@ class MySQLRootRelation(Object):
                 )
                 return
 
-            relation_databag[self.charm.unit]["host"] = primary_address.split(":")[0]
+            relation_databag[self.charm.unit]["host"] = primary_address
 
     def _on_config_changed(self, _) -> None:
         """Handle the change of the username/database config."""
@@ -228,7 +228,7 @@ class MySQLRootRelation(Object):
 
         updates = {
             "database": database,
-            "host": primary_address.split(":")[0],
+            "host": primary_address,
             "password": password,
             "port": "3306",
             "root_password": root_password,

--- a/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -118,8 +118,8 @@ def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
         juju.wait(
             ready=lambda status: all((
                 wait_for_unit_status(app_name, unit_to_promote, "active")(status),
-                wait_for_unit_message(app_name, units_to_kill[0], "offline")(status),
-                wait_for_unit_message(app_name, units_to_kill[1], "offline")(status),
+                wait_for_unit_message(app_name, units_to_kill[0], "OFFLINE")(status),
+                wait_for_unit_message(app_name, units_to_kill[1], "OFFLINE")(status),
             )),
             timeout=15 * MINUTE_SECS,
             delay=15,

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -12,22 +12,22 @@ from constants import DB_RELATION_NAME
 APP_NAME = "mysql-k8s"
 
 SAMPLE_CLUSTER_STATUS = {
-    "defaultreplicaset": {
+    "defaultReplicaSet": {
         "topology": {
             "mysql-k8s/0": {
                 "address": "2.2.2.2:3306",
-                "mode": "r/w",
-                "status": "online",
+                "mode": "R/W",
+                "status": "ONLINE",
             },
             "mysql-k8s/1": {
                 "address": "2.2.2.1:3306",
-                "mode": "r/o",
+                "mode": "R/O",
                 "status": "gone_away",
             },
             "mysql-k8s/2": {
                 "address": "2.2.2.3:3306",
-                "mode": "r/0",
-                "status": "online",
+                "mode": "R/O",
+                "status": "ONLINE",
             },
         }
     }


### PR DESCRIPTION
This PR removes a whole _horizontal slice_ of the charm code, to rely on [mysql-shell-client](https://github.com/canonical/mysql-shell-client) package.

Exceptions to this extraction are those that will be removed in MySQL 8.4:
- The creation of an instance database (see [code](https://github.com/canonical/mysql-k8s-operator/blob/29101a6f392c9c28ec1b8977b7a89d8a383ea4ad/src/mysql_k8s_helpers.py#L504-L509)).
- The creation of an instance user (see [code](https://github.com/canonical/mysql-k8s-operator/blob/29101a6f392c9c28ec1b8977b7a89d8a383ea4ad/src/mysql_k8s_helpers.py#L536-L539)).
- The escalation of instance user privileges (see [code](https://github.com/canonical/mysql-k8s-operator/blob/29101a6f392c9c28ec1b8977b7a89d8a383ea4ad/src/mysql_k8s_helpers.py#L576-L579)).
- The deletion of instance users searched by label (see [code](https://github.com/canonical/mysql-k8s-operator/blob/29101a6f392c9c28ec1b8977b7a89d8a383ea4ad/src/mysql_k8s_helpers.py#L602-L624)).

---

### Highlights:
- All hard-coded MySQL instance roles have been replaced by constants (when not comparing to existing data-bags).
- All hard-coded MySQL instance states have been replaced by constants (when not comparing to existing data-bags).

### Review strategy

Given the amount of changes proposed on this PR, I recommend reviewing commit by commit.