### PR TITLE
[MISC] Cleanup duplicated spread jobs

### DIFF
--- a/tests/spread/integration/test_crash_during_setup.py/task.yaml
+++ b/tests/spread/integration/test_crash_during_setup.py/task.yaml
@@ -1,7 +1,0 @@
-summary: test_self_healing_node_drain.py
-environment:
-  TEST_MODULE: high_availability/test_self_healing_node_drain.py
-execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-artifacts:
-  - allure-results

--- a/tests/spread/integration/test_node_drain.py/task.yaml
+++ b/tests/spread/integration/test_node_drain.py/task.yaml
@@ -1,7 +1,0 @@
-summary: test_self_healing_setup_crash.py
-environment:
-  TEST_MODULE: high_availability/test_self_healing_setup_crash.py
-execute: |
-  tox run -e integration -- "tests/integration/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
-artifacts:
-  - allure-results


### PR DESCRIPTION
This PR removes duplicated spread jobs which were mistakenly re-introduced in PR https://github.com/canonical/mysql-k8s-operator/pull/672:

- `test_crash_during_setup.py`, duplicated with [test_self_healing_setup_crash.py](https://github.com/canonical/mysql-k8s-operator/tree/be2067e604572fd3426e593b3f07fc99d0c4aca7/tests/spread/integration/test_self_healing_setup_crash.py).
- `test_node_drain.py`, duplicated with [test_self_healing_node_drain.py](https://github.com/canonical/mysql-k8s-operator/tree/be2067e604572fd3426e593b3f07fc99d0c4aca7/tests/spread/integration/test_self_healing_node_drain.py).